### PR TITLE
Fix #5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "rescript-vscode",
-	"version": "0.0.3",
+	"version": "0.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1763,6 +1763,11 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
 			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
 			"dev": true
+		},
+		"vscode-uri": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
 		},
 		"which": {
 			"version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "The official VSCode plugin for ReScript.",
 	"author": "chenglou",
 	"license": "MIT",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/rescript-lang/rescript-vscode"
@@ -98,6 +98,7 @@
 	},
 	"dependencies": {
 		"@types/tmp": "^0.2.0",
-		"tmp": "^0.2.1"
+		"tmp": "^0.2.1",
+		"vscode-uri": "^2.1.2"
 	}
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,6 +11,7 @@ import * as childProcess from 'child_process';
 import { DidOpenTextDocumentNotification, DidChangeTextDocumentNotification, DidCloseTextDocumentNotification } from 'vscode-languageserver-protocol';
 import * as tmp from 'tmp';
 import { Range } from 'vscode-languageserver-textdocument';
+import { uriToFsPath, URI } from 'vscode-uri';
 
 // See https://microsoft.github.io/language-server-protocol/specification Abstract Message
 // version is fixed to 2.0
@@ -203,8 +204,7 @@ let startWatchingBsbOutputFile = (root: p.DocumentUri, process: NodeJS.Process) 
 		let openFiles = Object.keys(stupidFileContentCache);
 		let bsbLogDirs: Set<p.DocumentUri> = new Set();
 		openFiles.forEach(openFile => {
-			// TODO: remove this hack
-			let filePath = openFile.replace('file://', '');
+			let filePath = uriToFsPath(URI.parse(openFile), true);
 			let bsbLogDir = findDirOfFileNearFile(bsbLogPartialPath, filePath)
 			if (bsbLogDir != null) {
 				bsbLogDirs.add(bsbLogDir);
@@ -355,8 +355,7 @@ process.on('message', (a: (m.RequestMessage | m.NotificationMessage)) => {
 			}
 		} else if (aa.method === p.DocumentFormattingRequest.method) {
 			let params = (aa.params as p.DocumentFormattingParams)
-			// TODO: remove this hack
-			let filePath = params.textDocument.uri.replace('file://', '')
+			let filePath = uriToFsPath(URI.parse(params.textDocument.uri), true);
 			let extension = path.extname(params.textDocument.uri);
 			if (extension !== resExt && extension !== resiExt) {
 				let response: m.ResponseMessage = {


### PR DESCRIPTION
I initially tried `uriToFilePath` from `vscode-languageserver` but I found out it's deprecated in favor of `uriToFsPath` from `vscode-uri`, which I had to add in `package.json`.

Tested on Windows 10 and MacOS. I wasn't able to run `scripts/e2e.sh` though.