### PR TITLE
Update grammar with better JSX syntax highlighting

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "ReScript",
+  "fileTypes": [
+    "res",
+    "resi"
+  ],
   "scopeName": "source.rescript",
   "repository": {
     "RE_IDENT": {
@@ -20,15 +24,6 @@
     "RE_LITERAL": {
       "name": "constant.language",
       "match": "\\b(true|false)\\b"
-    },
-    "commentLine": {
-      "match": "//.*",
-      "name": "comment.line"
-    },
-    "commentBlock": {
-      "name": "comment.block",
-      "begin": "/\\*",
-      "end": "\\*/"
     },
     "punctuations": {
       "patterns": [
@@ -299,32 +294,6 @@
         }
       ]
     },
-    "jsx": {
-      "patterns": [
-        {
-          "match": "<>|</>|/>"
-        },
-        {
-          "match": "</([A-Z_][0-9a-zA-Z_]*)",
-          "captures": {
-            "1": {
-              "name": "entity.name.namespace"
-            }
-          }
-        },
-        {
-          "match": "</([A-Z_][0-9a-zA-Z_]*)"
-        },
-        {
-          "match": "<([A-Z_][0-9a-zA-Z_]*)",
-          "captures": {
-            "1": {
-              "name": "entity.name.namespace"
-            }
-          }
-        }
-      ]
-    },
     "openOrIncludeModule": {
       "patterns": [
         {
@@ -412,6 +381,968 @@
           ]
         }
       ]
+    },
+    "jsx": {
+      "patterns": [
+        {
+          "include": "#jsx-head"
+        },
+        {
+          "include": "#jsx-tail"
+        }
+      ]
+    },
+    "jsx-attributes": {
+      "patterns": [
+        {
+          "begin": "\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*(=)",
+          "end": "(?<![=])(?=[/>[:lower:]])",
+          "comment": "meta.separator",
+          "beginCaptures": {
+            "1": {
+              "name": "markup.inserted constant.language support.property-value entity.name.filename"
+            },
+            "2": {
+              "name": "keyword.control.less"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#value-expression-atomic-with-paths"
+            }
+          ]
+        },
+        {
+          "match": "(\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*+)",
+          "captures": {
+            "1": {
+              "comment": "meta.separator"
+            },
+            "2": {
+              "name": "markup.inserted constant.language support.property-value entity.name.filename"
+            }
+          }
+        }
+      ]
+    },
+    "jsx-body": {
+      "begin": "((>))",
+      "end": "(?=</)",
+      "beginCaptures": {
+        "1": {
+          "comment": "meta.separator"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "comment": "FIXME: seems necessary in order to properly tokenize `[[:word:]]</` boundary",
+          "match": "[[:lower:]][[:word:]]*"
+        },
+        {
+          "include": "#value-expression"
+        }
+      ]
+    },
+    "jsx-head": {
+      "begin": "((<))(?=[_[:alpha:]])",
+      "end": "((/>))|(?=</)",
+      "applyEndPatternLast": true,
+      "beginCaptures": {
+        "1": {
+          "comment": "meta.separator"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.begin.js"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "comment": "meta.separator"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "\\G",
+          "end": "(?=[[:space:]/>])[[:space:]]*+",
+          "comment": "meta.separator",
+          "patterns": [
+            {
+              "include": "#module-path-simple"
+            },
+            {
+              "match": "\\b[[:lower:]][[:word:]]*\\b",
+              "name": "entity.name.tag.inline.any.html"
+            }
+          ]
+        },
+        {
+          "include": "#jsx-attributes"
+        },
+        {
+          "include": "#jsx-body"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "jsx-tail": {
+      "begin": "\\G(/>)|(</)",
+      "end": "(>)",
+      "applyEndPatternLast": true,
+      "comment": "meta.separator",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.end.js"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.begin.js"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#module-path-simple"
+        },
+        {
+          "match": "\\b[[:lower:]][[:word:]]*\\b",
+          "name": "entity.name.tag.inline.any.html"
+        }
+      ]
+    },
+    "module-path-simple": {
+      "patterns": [
+        {
+          "include": "#module-name-simple"
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "comment": "NOTE: end early to avoid too much reparsing",
+          "begin": "([\\.])",
+          "end": "(?<=[[:word:]\\)])|(?=[^\\.[:upper:]/])",
+          "beginCaptures": {
+            "1": {
+              "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "(?<=[\\.])",
+              "end": "(?<=[[:word:]\\)])|(?=[^\\.[:upper:]/])",
+              "patterns": [
+                {
+                  "include": "#comment"
+                },
+                {
+                  "include": "#module-name-simple"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "module-name-simple": {
+      "match": "\\b[[:upper:]][[:word:]]*\\b",
+      "name": "support.class entity.name.class"
+    },
+    "comment": {
+      "patterns": [
+        {
+          "include": "#comment-line"
+        },
+        {
+          "include": "#comment-block-doc"
+        },
+        {
+          "include": "#comment-block"
+        }
+      ]
+    },
+    "comment-line": {
+      "begin": "(^[ \\t]+)?(//)",
+      "end": "$",
+      "name": "comment.line.double-slash",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.leading"
+        },
+        "2": {
+          "name": "punctuation.definition.comment"
+        }
+      }
+    },
+    "comment-block": {
+      "begin": "/\\*",
+      "end": "\\*/",
+      "name": "comment.block",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.begin"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.end"
+        }
+      }
+    },
+    "comment-block-doc": {
+      "begin": "/\\*\\*(?!/)",
+      "end": "\\*/",
+      "name": "comment.block.documentation",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.begin"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.end"
+        }
+      }
+    },
+    "value-expression": {
+      "patterns": [
+        {
+          "include": "#attribute"
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#extension-node"
+        },
+        {
+          "include": "#jsx"
+        },
+        {
+          "include": "#operator"
+        },
+        {
+          "include": "#value-expression-builtin"
+        },
+        {
+          "include": "#value-expression-if-then-else"
+        },
+        {
+          "include": "#value-expression-atomic"
+        },
+        {
+          "include": "#module-path-simple-prefix"
+        },
+        {
+          "match": "[:?]",
+          "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+        },
+        {
+          "include": "#record-path"
+        }
+      ]
+    },
+    "value-expression-atomic-with-paths": {
+      "patterns": [
+        {
+          "include": "#value-expression-atomic"
+        },
+        {
+          "include": "#module-path-simple-prefix"
+        },
+        {
+          "include": "#record-path-suffix"
+        }
+      ]
+    },
+    "value-expression-atomic": {
+      "patterns": [
+        {
+          "include": "#value-expression-literal"
+        },
+        {
+          "include": "#value-expression-literal-list-or-array"
+        },
+        {
+          "include": "#value-expression-for"
+        },
+        {
+          "include": "#value-expression-fun"
+        },
+        {
+          "include": "#value-expression-block-or-record-or-object"
+        },
+        {
+          "include": "#value-expression-label"
+        },
+        {
+          "include": "#value-expression-parens"
+        },
+        {
+          "include": "#value-expression-switch"
+        },
+        {
+          "include": "#value-expression-try"
+        },
+        {
+          "include": "#value-expression-while"
+        }
+      ]
+    },
+    "module-path-simple-prefix": {
+      "begin": "(?=\\b[[:upper:]])",
+      "end": "([\\.])|(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "endCaptures": {
+        "1": {
+          "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#module-path-simple"
+        }
+      ]
+    },
+    "value-expression-literal": {
+      "patterns": [
+        {
+          "include": "#value-expression-literal-boolean"
+        },
+        {
+          "include": "#value-expression-literal-character"
+        },
+        {
+          "include": "#value-expression-constructor"
+        },
+        {
+          "include": "#value-expression-constructor-polymorphic"
+        },
+        {
+          "include": "#value-expression-lazy"
+        },
+        {
+          "include": "#value-expression-literal-numeric"
+        },
+        {
+          "include": "#value-expression-literal-string"
+        },
+        {
+          "include": "#value-expression-literal-unit"
+        }
+      ]
+    },
+    "value-expression-literal-boolean": {
+      "match": "\\b(false|true)\\b",
+      "name": "entity.other.attribute-name.css constant.language constant.numeric"
+    },
+    "value-expression-literal-character": {
+      "match": "(')([[:space:]]|[[:graph:]]|\\\\[\\\\\"'ntbr]|\\\\[[:digit:]][[:digit:]][[:digit:]]|\\\\x[[:xdigit:]][[:xdigit:]]|\\\\o[0-3][0-7][0-7])(')",
+      "name": "constant.character"
+    },
+    "value-expression-literal-list-or-array": {
+      "begin": "(\\[\\|?)(?![@%])",
+      "end": "(\\|?\\])",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.language.list"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "constant.language.list"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value-expression-literal-list-or-array-separator"
+        },
+        {
+          "include": "#value-expression"
+        },
+        {
+          "include": "#value-expression-literal-list-or-array"
+        }
+      ]
+    },
+    "value-expression-literal-list-or-array-separator": {
+      "match": "(,)|(\\.\\.\\.)",
+      "captures": {
+        "1": {
+          "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+        },
+        "2": {
+          "name": "keyword.control"
+        }
+      }
+    },
+    "value-expression-literal-numeric": {
+      "patterns": [
+        {
+          "match": "([-])?([[:digit:]][_[:digit:]]*)(?:(\\.)([_[:digit:]]*))?(?:([eE])([\\-\\+])?([[:digit:]][_[:digit:]]*))?(?![bBoOxX])",
+          "captures": {
+            "1": {
+              "name": "keyword.control.less"
+            },
+            "2": {
+              "name": "constant.numeric"
+            },
+            "3": {
+              "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+            },
+            "4": {
+              "name": "constant.numeric"
+            },
+            "5": {
+              "name": "keyword.control.less"
+            },
+            "6": {
+              "name": "keyword.control.less"
+            },
+            "7": {
+              "name": "constant.numeric"
+            }
+          }
+        },
+        {
+          "match": "([-])?(0[xX])([[:xdigit:]][_[:xdigit:]]*)(?:(\\.)([_[:xdigit:]]*))?(?:([pP])([\\-\\+])?([[:digit:]][_[:digit:]]*))?",
+          "captures": {
+            "1": {
+              "name": "keyword.control.less"
+            },
+            "2": {
+              "name": "keyword.control.less"
+            },
+            "3": {
+              "name": "constant.numeric"
+            },
+            "4": {
+              "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+            },
+            "5": {
+              "name": "constant.numeric"
+            },
+            "6": {
+              "name": "keyword.control.less"
+            },
+            "7": {
+              "name": "keyword.control.less"
+            },
+            "8": {
+              "name": "constant.numeric"
+            }
+          }
+        },
+        {
+          "match": "([-])?(0[oO])([0-7][_0-7]*)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.less"
+            },
+            "2": {
+              "name": "keyword.control.less"
+            },
+            "3": {
+              "name": "constant.numeric"
+            }
+          }
+        },
+        {
+          "match": "([-])?(0[bB])([0-1][_0-1]*)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.less"
+            },
+            "2": {
+              "name": "keyword.control.less"
+            },
+            "3": {
+              "name": "constant.numeric"
+            }
+          }
+        }
+      ]
+    },
+    "value-expression-literal-string": {
+      "patterns": [
+        {
+          "begin": "(?<![[:alpha:]])js_expr(?!=[[:word:]])",
+          "end": "(?<=\")|(\\|)([_[:lower:]]*)?(})|(?=[^[:space:]\"{])",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.flow message.error"
+            },
+            "2": {
+              "name": "entity.other.attribute-name.css constant.language constant.numeric"
+            },
+            "3": {
+              "name": "keyword.control.flow message.error"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "({)([_[:lower:]]*)?(\\|)",
+              "end": "(?=\\|\\2})",
+              "comment": "meta.separator",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.control.flow message.error"
+                },
+                "2": {
+                  "name": "entity.other.attribute-name.css constant.language constant.numeric"
+                },
+                "3": {
+                  "name": "keyword.control.flow message.error"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "source.js"
+                }
+              ]
+            },
+            {
+              "begin": "\"",
+              "end": "\"",
+              "comment": "meta.separator",
+              "patterns": [
+                {
+                  "include": "source.js"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "({)([_[:lower:]]*)?(\\|)",
+          "end": "(\\|)(\\2)(})",
+          "name": "string.double string.regexp",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.flow message.error"
+            },
+            "2": {
+              "name": "entity.other.attribute-name.css constant.language constant.numeric"
+            },
+            "3": {
+              "name": "keyword.control.flow message.error"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.flow message.error"
+            },
+            "2": {
+              "name": "entity.other.attribute-name.css constant.language constant.numeric"
+            },
+            "3": {
+              "name": "keyword.control.flow message.error"
+            }
+          }
+        },
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.double string.regexp",
+          "patterns": [
+            {
+              "include": "#value-expression-literal-string-escape"
+            }
+          ]
+        }
+      ]
+    },
+    "value-expression-literal-string-escape": {
+      "patterns": [
+        {
+          "comment": "FIXME: make escapes into separate rule",
+          "match": "\\\\[\\\\\"'ntbr ]|\\\\[[:digit:]][[:digit:]][[:digit:]]|\\\\x[[:xdigit:]][[:xdigit:]]|\\\\o[0-3][0-7][0-7]",
+          "name": "constant.character"
+        },
+        {
+          "match": "(@)([ \\[\\],.]|\\\\n)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.less"
+            },
+            "2": {
+              "name": "entity.other.attribute-name.css constant.language constant.numeric"
+            }
+          }
+        },
+        {
+          "comment": "FIXME: don't highlight in external strings",
+          "match": "(%)([ads])?",
+          "captures": {
+            "1": {
+              "name": "entity.other.attribute-name.css constant.language constant.numeric"
+            },
+            "2": {
+              "name": "variable.other.readwrite.instance string.other.link variable.language"
+            }
+          }
+        }
+      ]
+    },
+    "value-expression-literal-unit": {
+      "match": "\\(\\)",
+      "name": "constant.language.unit"
+    },
+    "value-expression-object-look": {
+      "comment": "FIXME: is there a better way than listing all the keywords?",
+      "begin": "(?:\\G|^)[[:space:]]*(?=method)",
+      "end": "(?=})",
+      "patterns": [
+        {
+          "include": "#object-item"
+        }
+      ]
+    },
+    "value-expression-parens": {
+      "begin": "(?=\\()",
+      "end": "(\\))|(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "endCaptures": {},
+      "patterns": [
+        {
+          "include": "#condition-lhs"
+        },
+        {
+          "include": "#value-expression-parens-lhs"
+        },
+        {
+          "include": "#type-annotation-rhs"
+        }
+      ]
+    },
+    "value-expression-parens-lhs": {
+      "begin": "(\\()|(,)",
+      "end": "(?=[?,:\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "2": {
+          "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "\\b(module)\\b",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other message.error"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#module-path-simple"
+            }
+          ]
+        },
+        {
+          "include": "#value-expression"
+        }
+      ]
+    },
+    "value-expression-record-field": {
+      "patterns": [
+        {
+          "begin": "(\\.\\.\\.)",
+          "end": "(,)|(?=})",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#module-path-simple-prefix"
+            },
+            {
+              "begin": "(?=[\\.])",
+              "end": "(?=[:,])",
+              "patterns": [
+                {
+                  "match": "\\b[[:lower:]][[:word:]]*\\b",
+                  "name": "markup.inserted constant.language support.property-value entity.name.filename"
+                }
+              ]
+            },
+            {
+              "begin": "(:)",
+              "end": "(?=[,}])",
+              "beginCaptures": {
+                "1": {
+                  "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#value-expression"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "\\b[[:upper:]][[:word:]]*\\b",
+          "end": "(,)|(?=})",
+          "beginCaptures": {
+            "1": {
+              "name": "support.class entity.name.class"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#module-path-simple-prefix"
+            },
+            {
+              "begin": "(:)",
+              "end": "(?=[,}])",
+              "beginCaptures": {
+                "1": {
+                  "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#value-expression"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "\\b([[:lower:]][[:word:]]*)\\b",
+          "end": "(,)|(?=})",
+          "beginCaptures": {
+            "1": {
+              "name": "markup.inserted constant.language support.property-value entity.name.filename"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "(:)",
+              "end": "(?=[,}])",
+              "beginCaptures": {
+                "1": {
+                  "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#value-expression"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "value-expression-record-item": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#module-path-simple-prefix"
+        },
+        {
+          "include": "#value-expression-record-field"
+        }
+      ]
+    },
+    "value-expression-switch": {
+      "begin": "\\b(switch)\\b",
+      "end": "(?<=})",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.switch"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value-expression-switch-head"
+        },
+        {
+          "include": "#value-expression-switch-body"
+        }
+      ]
+    },
+    "value-expression-switch-body": {
+      "begin": "{",
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#value-expression-switch-pattern-match-rule"
+        }
+      ]
+    },
+    "value-expression-switch-head": {
+      "begin": "(?<=switch)",
+      "end": "(?<!switch)(?={)|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "begin": "\\G[[:space:]]*+{",
+          "end": "}[[:space:]]*+",
+          "patterns": [
+            {
+              "include": "#value-expression-block-item"
+            }
+          ]
+        },
+        {
+          "include": "#value-expression-atomic-with-paths"
+        }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule": {
+      "patterns": [
+        {
+          "include": "#value-expression-switch-pattern-match-rule-lhs"
+        },
+        {
+          "include": "#value-expression-switch-pattern-match-rule-rhs"
+        }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule-lhs": {
+      "begin": "(?=\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))",
+      "end": "(?==>|[;\\)}])",
+      "patterns": [
+        {
+          "include": "#pattern-guard"
+        },
+        {
+          "include": "#pattern"
+        }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule-rhs": {
+      "begin": "(=>)",
+      "end": "(?=}|\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.less"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value-expression-block-item"
+        }
+      ]
+    },
+    "value-expression-try": {
+      "begin": "\\b(try)\\b",
+      "end": "(?<=})|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.trycatch"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value-expression-try-head"
+        },
+        {
+          "include": "#value-expression-switch-body"
+        }
+      ]
+    },
+    "value-expression-try-head": {
+      "begin": "(?<=try)",
+      "end": "(?<!try)(?={)|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "begin": "\\G[[:space:]]*+{",
+          "end": "}[[:space:]]*+",
+          "patterns": [
+            {
+              "include": "#value-expression-block-item"
+            }
+          ]
+        },
+        {
+          "include": "#value-expression-atomic-with-paths"
+        }
+      ]
+    },
+    "value-expression-while": {
+      "begin": "\\b(while)\\b",
+      "end": "(?<=})|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.loop"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value-expression-while-head"
+        },
+        {
+          "include": "#value-expression-block"
+        }
+      ]
+    },
+    "value-expression-while-head": {
+      "begin": "(?<=while)[[:space:]]*+",
+      "end": "(?={)|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#value-expression-atomic-with-paths"
+        }
+      ]
+    },
+    "value-expression-record-look": {
+      "begin": "(?=\\.\\.\\.|([[:upper:]][[:word:]]*\\.)*([[:lower:]][[:word:]]*)[[:space:]]*[,:}])",
+      "end": "(?=})",
+      "patterns": [
+        {
+          "include": "#value-expression-record-item"
+        }
+      ]
     }
   },
   "patterns": [
@@ -422,10 +1353,7 @@
       "include": "#constant"
     },
     {
-      "include": "#commentLine"
-    },
-    {
-      "include": "#commentBlock"
+      "include": "#comment"
     },
     {
       "include": "#character"


### PR DESCRIPTION
I have extracted code from the [language-reason](https://github.com/reasonml-editor/language-reason/blob/56efe7d1b9ffa0ab662ecd3dc45b8e5ca80f3825/grammars/reason.json) grammar to get better support for JSX in ReScript. It's not identical to the old syntax highlighting and it's got some issues (see below), but it's better than nothing.

## Before change

![Screenshot 2020-09-04 at 16 24 00](https://user-images.githubusercontent.com/1478102/92249897-110c1e00-eecb-11ea-81e6-0ec929577ef2.png)

## After change

| New syntax (.res) | Old syntax for comparison (.re) |
| ----------------- | ------------------------------- |
| ![Screenshot 2020-09-04 at 16 20 01](https://user-images.githubusercontent.com/1478102/92249739-cf7b7300-eeca-11ea-9ced-f05aac200c99.png) | ![Screenshot 2020-09-04 at 16 20 09](https://user-images.githubusercontent.com/1478102/92249745-d1453680-eeca-11ea-8719-9317dd729021.png)
 |

## Issues I've noticed

Highlighting of the new template string syntax isn't working correctly.

![Screenshot 2020-09-04 at 16 28 43](https://user-images.githubusercontent.com/1478102/92250427-c17a2200-eecb-11ea-8fee-e1a6fe936060.png)