### PR TITLE
Fix open and include syntax highlighting

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -343,7 +343,7 @@
           }
         },
         {
-          "match": "\\b(open|include)\\s*",
+          "match": "\\b(open|include)\\s+",
           "name": "keyword"
         }
       ]


### PR DESCRIPTION
**Before Fix**
<img width="476" alt="Before Syntax Highlight Fix" src="https://user-images.githubusercontent.com/31521089/99853461-e7ce6600-2b7a-11eb-8ac9-231b91489dcb.png">

**After Fix**
<img width="475" alt="After Syntax Highlight Fix" src="https://user-images.githubusercontent.com/31521089/99853484-f3ba2800-2b7a-11eb-943b-c09083b4900c.png">
