### PR TITLE
renaming config to rescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		],
 		"configuration": {
 			"type": "object",
-			"title": "Example configuration",
+			"title": "ReScript",
 			"properties": {
 				"languageServerExample.maxNumberOfProblems": {
 					"scope": "resource",


### PR DESCRIPTION
Tiny fix. making the settings in vscode be "ReScript" instead of "Example configuration"