### PR TITLE
Add support for Reason syntax

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -84,6 +84,7 @@ export function activate(context: ExtensionContext) {
 		// Register the server for plain text documents
 		documentSelector: [
 			{ scheme: 'file', language: 'rescript' },
+			{ scheme: 'file', language: 'reason' }
 		],
 		synchronize: {
 			// Notify the server about file changes to '.clientrc files contained in the workspace

--- a/grammars/reason.tmLanguage.json
+++ b/grammars/reason.tmLanguage.json
@@ -1,0 +1,2264 @@
+{
+  "name": "Reason",
+  "scopeName": "source.reason",
+  "fileTypes": [
+    "re",
+    "rei"
+  ],
+  "patterns": [
+    { "include": "#structure-expression-block-item" },
+    { "include": "#value-expression" }
+  ],
+  "repository": {
+    "attribute": {
+      "begin": "(?=\\[(@{1,3})[[:space:]]*[[:alpha:]])",
+      "end": "\\]",
+      "patterns": [
+        {
+          "begin": "\\[(@{1,3})",
+          "end": "(?=[^_\\.'[:word:]])",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.less" }
+          },
+          "patterns": [
+            { "include": "#attribute-identifier" }
+          ]
+        },
+        { "include": "#attribute-payload" }
+      ]
+    },
+    "attribute-identifier": {
+      "patterns": [
+        {
+          "match": "\\b([[:alpha:]][[:word:]]*)\\b[[:space:]]*(?:(\\.))",
+          "captures": {
+            "1": { "name": "support.class entity.name.class" },
+            "2": { "name": "keyword.control.less" }
+          }
+        },
+        {
+          "match": "\\b([[:alpha:]][[:word:]]*)\\b",
+          "name": "entity.other.attribute-name.css constant.language constant.numeric"
+        }
+      ]
+    },
+    "attribute-payload": {
+      "patterns": [
+        {
+          "begin": "(:)",
+          "end": "(?=\\])",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#structure-expression" },
+            { "include": "#module-item-type" },
+            { "include": "#type-expression" }
+          ]
+        },
+        {
+          "begin": "([\\?])",
+          "end": "(?=\\])",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.less" }
+          },
+          "patterns": [
+            { "include": "#pattern-guard" },
+            { "include": "#pattern" }
+          ]
+        },
+        { "include": "#structure-expression-block-item" },
+        { "include": "#value-expression" }
+      ]
+    },
+    "class-item-inherit": {
+      "begin": "\\b(inherit)\\b",
+      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "class-item-method": {
+      "begin": "\\b(method)\\b",
+      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "storage.type" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-value-bind-name-params-type-body" }
+      ]
+    },
+    "comment": {
+      "name": "comment",
+      "patterns": [
+        { "include": "#comment-line" },
+        { "include": "#comment-block-doc" },
+        {	"include": "#comment-block"	}
+      ]
+    },
+    "comment-line": {
+      "name": "comment.line",
+      "begin": "(^[ \\t]+)?((//))",
+      "end": "(?=^)"
+    },
+    "comment-block": {
+      "begin": "/\\*",
+      "end": "\\*/",
+      "name": "comment.block",
+      "patterns": [
+        { "include": "#comment-block-doc" },
+        { "include": "#comment-block" }
+      ]
+    },
+    "comment-block-doc": {
+      "begin": "/\\*\\*(?!/)",
+      "end": "\\*/",
+      "name": "comment.block.documentation",
+      "patterns": [
+        { "include": "#comment-block-doc" },
+        { "include": "#comment-block" }
+      ]
+    },
+    "condition-lhs": {
+      "begin": "(?<![#\\-:!?.@*/&%^+<=>|~$\\\\])([\\?])(?![#\\-:!?.@*/&%^+<=>|~$\\\\])",
+      "end": "(?=[\\)])",
+      "beginCaptures": {
+        "1": { "name": "keyword.control message.error variable.interpolation" }
+      },
+      "patterns": [
+        {
+          "match": "(?:\\b|[[:space:]]+)([?])(?:\\b|[[:space:]]+)",
+          "name": "keyword.control message.error variable.interpolation"
+        },
+        { "include": "#value-expression" }
+      ]
+    },
+    "extension-node": {
+      "begin": "(?=\\[(%{1,3})[[:space:]]*[[:alpha:]])",
+      "end": "\\]",
+      "patterns": [
+        {
+          "begin": "\\[(%{1,3})",
+          "end": "(?=[^_\\.'[:word:]])",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.less" }
+          },
+          "patterns": [
+            { "include": "#attribute-identifier" }
+          ]
+        },
+        { "include": "#attribute-payload" }
+      ]
+    },
+    "jsx": {
+      "patterns": [
+        { "include": "#jsx-head" },
+        { "include": "#jsx-tail" }
+      ]
+    },
+    "jsx-attributes": {
+      "patterns": [
+        {
+          "begin": "\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*(=)",
+          "end": "(?<![=])(?=[/>[:lower:]])",
+          "comment": "meta.separator",
+          "beginCaptures": {
+            "1": { "name": "markup.inserted constant.language support.property-value entity.name.filename" },
+            "2": { "name": "keyword.control.less" }
+          },
+          "patterns": [
+            { "include": "#value-expression-atomic-with-paths" }
+          ]
+        },
+        {
+          "match": "(\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*+)",
+          "captures": {
+            "1": { "comment": "meta.separator" },
+            "2": { "name": "markup.inserted constant.language support.property-value entity.name.filename" }
+          }
+        }
+      ]
+    },
+    "jsx-body": {
+      "begin": "((>))",
+      "end": "(?=</)",
+      "beginCaptures": {
+        "1": { "comment": "meta.separator" },
+        "2": { "name": "punctuation.definition.tag.end.js" }
+      },
+      "patterns": [
+        {
+          "comment": "FIXME: seems necessary in order to properly tokenize `[[:word:]]</` boundary",
+          "match": "[[:lower:]][[:word:]]*"
+        },
+        { "include": "#value-expression" }
+      ]
+    },
+    "jsx-head": {
+      "begin": "((<))(?=[_[:alpha:]])",
+      "end": "((/>))|(?=</)",
+      "applyEndPatternLast": true,
+      "beginCaptures": {
+        "1": { "comment": "meta.separator" },
+        "2": { "name": "punctuation.definition.tag.begin.js" }
+      },
+      "endCaptures": {
+        "1": { "comment": "meta.separator" },
+        "2": { "name": "punctuation.definition.tag.end.js" }
+      },
+      "patterns": [
+        {
+          "begin": "\\G",
+          "end": "(?=[[:space:]/>])[[:space:]]*+",
+          "comment": "meta.separator",
+          "patterns": [
+            { "include": "#module-path-simple" },
+            {
+              "match": "\\b[[:lower:]][[:word:]]*\\b",
+              "name": "entity.name.tag.inline.any.html"
+            }
+          ]
+        },
+        { "include": "#jsx-attributes" },
+        { "include": "#jsx-body" },
+        { "include": "#comment" }
+      ]
+    },
+    "jsx-tail": {
+      "begin": "\\G(/>)|(</)",
+      "end": "(>)",
+      "applyEndPatternLast": true,
+      "comment": "meta.separator",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.tag.end.js" },
+        "2": { "name": "punctuation.definition.tag.begin.js" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.tag.end.js" }
+      },
+      "patterns": [
+        { "include": "#module-path-simple" },
+        {
+          "match": "\\b[[:lower:]][[:word:]]*\\b",
+          "name": "entity.name.tag.inline.any.html"
+        }
+      ]
+    },
+    "module-name-extended": {
+      "patterns": [
+        { "include": "#module-name-simple" },
+        {
+          "begin": "([\\(])",
+          "end": "([\\)])",
+          "captures": {
+            "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+          },
+          "patterns": [
+            { "include": "#module-path-extended" }
+          ]
+        }
+      ]
+    },
+    "module-name-simple": {
+      "match": "\\b[[:upper:]][[:word:]]*\\b",
+      "name": "support.class entity.name.class"
+    },
+    "module-path-extended": {
+      "patterns": [
+        { "include": "#module-name-extended" },
+        { "include": "#comment" },
+        {
+          "comment": "NOTE: end early to avoid too much reparsing",
+          "begin": "([\\.])",
+          "end": "(?<=[[:word:]\\)])|(?=[^\\.[:upper:]/])",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.less" }
+          },
+          "patterns": [
+            {
+              "begin": "(?<=[\\.])",
+              "end": "(?<=[[:word:]\\)])|(?=[^\\.[:upper:]/])",
+              "patterns": [
+                { "include": "#comment" },
+                { "include": "#module-name-extended" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "module-path-extended-prefix": {
+      "begin": "(?=\\b[[:upper:]])",
+      "end": "([\\.])|(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-path-extended" }
+      ]
+    },
+    "module-path-simple": {
+      "patterns": [
+        { "include": "#module-name-simple" },
+        { "include": "#comment" },
+        {
+          "comment": "NOTE: end early to avoid too much reparsing",
+          "begin": "([\\.])",
+          "end": "(?<=[[:word:]\\)])|(?=[^\\.[:upper:]/])",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            {
+              "begin": "(?<=[\\.])",
+              "end": "(?<=[[:word:]\\)])|(?=[^\\.[:upper:]/])",
+              "patterns": [
+                { "include": "#comment" },
+                { "include": "#module-name-simple" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "module-path-simple-prefix": {
+      "begin": "(?=\\b[[:upper:]])",
+      "end": "([\\.])|(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-path-simple" }
+      ]
+    },
+    "module-item-class-type": {
+      "comment": "FIXME: proper parsing",
+      "begin": "\\b(class)\\b",
+      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        {
+          "begin": "(?:\\G|^)[[:space:]]*\\b(type)\\b",
+          "end": "(?==)",
+          "beginCaptures": {
+            "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+          },
+          "patterns": [
+            { "include": "#module-item-type-bind-name-tyvars" }
+          ]
+        },
+        {
+          "begin": "(=)",
+          "end": "(?=;)",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.less" }
+          },
+          "patterns": [
+            { "include": "#attribute" },
+            { "include": "#comment" },
+            { "include": "#class-item-inherit" },
+            { "include": "#class-item-method" }
+          ]
+        }
+      ]
+    },
+    "module-item-exception": {
+      "begin": "\\b(exception)\\b",
+      "end": "(;)|(?=}|\\b(class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-type-bind-body-item" }
+      ]
+    },
+    "module-item-external": {
+      "begin": "\\b(external)\\b",
+      "end": "(;)|(?=}|\\b(class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "storage.type" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-value-bind-name-or-pattern" },
+        { "include": "#module-item-let-value-bind-type" },
+        {
+          "begin": "(=)",
+          "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.less" }
+          },
+          "patterns": [
+            { "include": "#attribute" },
+            {
+              "begin": "\"",
+              "end": "\"",
+              "name": "string.double string.regexp",
+              "patterns": [
+                { "include": "#value-literal-string-escape" },
+                {
+                  "match": "(?:(%)(.*?)|(caml.*?))(?=\"|(?:[^\\\\\\n]$))",
+                  "captures": {
+                    "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" },
+                    "2": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+                    "3": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"}
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "module-item-include": {
+      "begin": "\\b(include)\\b",
+      "end": "(;)|(?=}|\\b(class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|type|val)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.include" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#signature-expression" }
+      ]
+    },
+    "module-item-let": {
+      "begin": "\\b(let)((%)([[:word:]\\.]+))?\\b",
+      "end": "(;)|(?=}|\\b(class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "storage.type" },
+        "3": { "name": "keyword.control.less" },
+        "4": { "name": "entity.name.class" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module" },
+        { "include": "#module-item-let-value" }
+      ]
+    },
+    "module-item-let-module": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(module)\\b",
+      "end": "(?=[;}]|\\b(class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.control storage.type message.error" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-item-let-module-and" },
+        { "include": "#module-item-let-module-rec" },
+        { "include": "#module-item-let-module-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-module-and": {
+      "begin": "\\b(and)\\b",
+      "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "storage.type" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-module-bind-body": {
+      "begin": "(=>?)",
+      "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.less" }
+      },
+      "patterns": [
+        { "include": "#structure-expression" }
+      ]
+    },
+    "module-item-let-module-bind-name-params": {
+      "begin": "\\b([[:upper:]][[:word:]]*)\\b",
+      "end": "(?=[;:}=]|\\b(class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "support.class entity.name.class" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-item-let-module-param" }
+      ]
+    },
+    "module-item-let-module-bind-name-params-type-body": {
+      "begin": "(?:\\G|^)",
+      "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-item-let-module-bind-name-params" },
+        { "include": "#module-item-let-module-bind-type" },
+        { "include": "#module-item-let-module-bind-body" }
+      ]
+    },
+    "module-item-let-module-bind-type": {
+      "begin": "(:)",
+      "end": "(?=[;}=]|\\b(and|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val)\\b)",
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#signature-expression" }
+      ]
+    },
+    "module-item-let-module-param": {
+      "begin": "(?=\\()",
+      "end": "\\)",
+      "patterns": [
+        {
+          "begin": "\\(",
+          "end": "(?=[:])",
+          "patterns": [
+            { "include": "#comment" },
+            { "include": "#module-name-simple" }
+          ]
+        },
+        {
+          "begin": "(:)",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#signature-expression" }
+          ]
+        }
+      ]
+    },
+    "module-item-let-module-rec": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(rec)\\b",
+      "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control storage.modifier.rec" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-value": {
+      "patterns": [
+        { "include": "#module-item-let-value-and" },
+        { "include": "#module-item-let-value-rec" },
+        { "include": "#module-item-let-value-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-value-and": {
+      "begin": "\\b(and)\\b",
+      "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "storage.type" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-value-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-let-value-bind-body": {
+      "begin": "(=>?)",
+      "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.less" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "module-item-let-value-bind-name-or-pattern": {
+      "end": "(?<=[^[:space:]])|(?=[[:space:]]|[;:}=]|\\b(and|as|class|constraint|exception|external|for|include|inherit|let|method|module|nonrec|open|private|rec|switch|try|type|val|while|with)\\b)",
+      "patterns": [
+        { "include": "#comment" },
+        {
+          "match": "\\b(?:([_][[:word:]]+)|([[:lower:]][[:word:]]*))\\b",
+          "captures": {
+            "1": { "name": "comment" },
+            "2": { "name": "entity.name.function" }
+          }
+        },
+        { "include": "#module-item-let-value-bind-parens-params" },
+        { "include": "#pattern" }
+      ]
+    },
+    "module-item-let-value-bind-name-params-type-body": {
+      "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#module-item-let-value-bind-name-or-pattern" },
+        { "include": "#module-item-let-value-bind-params-type" },
+        { "include": "#module-item-let-value-bind-type" },
+        { "include": "#module-item-let-value-bind-body" }
+      ]
+    },
+    "module-item-let-value-bind-params-type": {
+      "begin": "(?=[^[:space:]:=])",
+      "end": "(?=[;}=]|\\b(class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-item-let-value-param" },
+        {
+          "begin": "(?<![:])(:)[[:space:]]*(?![[:space:]]*[:\\)])",
+          "end": "(?=[;}=]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#type-expression-atomic" }
+          ]
+        }
+      ]
+    },
+    "module-item-let-value-bind-parens-params": {
+      "begin": "\\((?![\\)])",
+      "end": "\\)",
+      "patterns": [
+        { "include": "#operator" },
+        { "include": "#pattern-parens-lhs" },
+        { "include": "#type-annotation-rhs" },
+        { "include": "#pattern" }
+      ]
+    },
+    "module-item-let-value-bind-pattern": {
+      "begin": "(?<=[^[:word:]]and|^and|[^[:word:]]external|^external|[^[:word:]]let|^let|[^[:word:]]method|^method|[^[:word:]]rec|^rec)",
+      "end": "(?=[;:}=]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-item-let-value-bind-parens-params" },
+        { "include": "#pattern" }
+      ]
+    },
+    "module-item-let-value-bind-type": {
+      "comment": "FIXME: lookahead",
+      "begin": "(?<![:])(:)(?![[:space:]]*[:\\)])",
+      "end": "(?==[^>]|[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        {
+          "begin": "\\b(type)\\b",
+          "end": "([\\.])",
+          "beginCaptures": {
+            "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+          },
+          "endCaptures": {
+            "1": { "name": "entity.name.function" }
+          },
+          "patterns": [
+            { "include": "#pattern-variable" }
+          ]
+        },
+        { "include": "#type-expression" }
+      ]
+    },
+    "module-item-let-value-param": {
+      "patterns": [
+        { "include": "#module-item-let-value-param-label" },
+        { "include": "#module-item-let-value-param-type" },
+        { "include": "#module-item-let-value-param-module" },
+        { "include": "#pattern" }
+      ]
+    },
+    "module-item-let-value-param-label": {
+      "patterns": [
+        {
+          "begin": "(\\b[[:lower:]][[:word:]]*\\b)?[[:space:]]*(::)",
+          "end": "(?<=[[:space:]])",
+          "beginCaptures": {
+            "1": { "name": "markup.inserted constant.language support.property-value entity.name.filename" },
+            "2": { "name": "keyword.control" }
+          },
+          "patterns": [
+            { "include": "#pattern" },
+            {
+              "begin": "(=)",
+              "end": "(\\?)|(?<=[^[:space:]=][[:space:]])(?=[[:space:]]*+[^\\.])",
+              "beginCaptures": {
+                "1": { "name": "markup.inserted keyword.control.less message.error" }
+              },
+              "endCaptures": {
+                "1": { "name": "storage.type" }
+              },
+              "patterns": [
+                { "include": "#value-expression-atomic-with-paths" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "module-item-let-value-param-module": {
+      "comment": "FIXME: merge with pattern-parens",
+      "begin": "\\([[:space:]]*(?=\\b(module)\\b)",
+      "end": "\\)",
+      "patterns": [
+        {
+          "begin": "\\b(module)\\b",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": { "name": "keyword.other message.error" }
+          },
+          "patterns": [
+            {
+              "match": "\\b[[:upper:]][[:word:]]*\\b",
+              "name": "support.class entity.name.class"
+            }
+          ]
+        }
+      ]
+    },
+    "module-item-let-value-param-type": {
+      "comment": "FIXME: merge with pattern-parens",
+      "begin": "\\((?=\\b(type)\\b)",
+      "end": "\\)",
+      "patterns": [
+        {
+          "begin": "\\b(type)\\b",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+          },
+          "patterns": [
+            { "include": "#pattern-variable" }
+          ]
+        }
+      ]
+    },
+    "module-item-let-value-rec": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(rec)\\b",
+      "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control storage.modifier message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-value-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-module": {
+      "comment": "NOTE: this is to support the let-module case without the let prefix",
+      "begin": "\\b(module)\\b[[:space:]]*(?!\\b(type)\\b|$)",
+      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "storage.type message.error" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-module-and" },
+        { "include": "#module-item-let-module-rec" },
+        { "include": "#module-item-let-module-bind-name-params-type-body" }
+      ]
+    },
+    "module-item-module-type": {
+      "begin": "\\b(module)\\b[[:space:]]*(?=\\b(type)\\b|$)",
+      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control message.error" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        {
+          "begin": "(?:\\G|^)[[:space:]]*\\b(type)\\b",
+          "end": "(?==)",
+          "beginCaptures": {
+            "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            {
+              "match": "([[:upper:]][[:word:]]*)",
+              "captures": {
+                "1": { "name": "support.class entity.name.class" }
+              }
+            }
+          ]
+        },
+        {
+          "begin": "(=)",
+          "end": "(?=;)",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.less" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            { "include": "#signature-expression" }
+          ]
+        }
+      ]
+    },
+    "module-item-open": {
+      "begin": "\\b(open)\\b",
+      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.open" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-path-simple" }
+      ]
+    },
+    "module-item-type": {
+      "comment": "FIXME: the semi-colon is optional so we can re-use this for hover, which does not print the trailing ;",
+      "begin": "\\b(type)\\b",
+      "end": "(;)|(?=[\\)}]|\\b(class|exception|external|include|inherit|let|method|nonrec|open|private|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-type-and" },
+        { "include": "#module-item-type-constraint" },
+        { "include": "#module-item-type-bind" }
+      ]
+    },
+    "module-item-type-and": {
+      "comment": "FIXME: the optional `type` is for module constraints",
+      "begin": "\\b(and)\\b([[:space:]]*type)?",
+      "end": "(?=[;\\)}]|\\b(class|exception|external|include|inherit|let|method|nonrec|open|private|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" },
+        "2": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+      },
+      "patterns": [
+        { "include": "#module-item-type-bind-name-tyvars-body" }
+      ]
+    },
+    "module-item-type-bind": {
+      "comment": "FIXME: only allow module paths before type variables",
+      "patterns": [
+        { "include": "#module-item-type-bind-nonrec" },
+        { "include": "#module-item-type-bind-name-tyvars-body" }
+      ]
+    },
+    "module-item-type-bind-body": {
+      "comment": "FIXME: parsing",
+      "begin": "(\\+?=)",
+      "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.less" }
+      },
+      "patterns": [
+        { "include": "#module-item-type-bind-body-item" }
+      ]
+    },
+    "module-item-type-bind-body-item": {
+      "patterns": [
+        {
+          "match": "(=)(?!>)|\\b(private)\\b",
+          "captures": {
+            "1": { "name": "keyword.control.less" },
+            "2": { "name": "variable.other.class.js variable.interpolation storage.modifier message.error" }
+          }
+        },
+        {
+          "comment": "FIXME: specialized version of variant rule that also scans for (",
+          "match": "\\b([[:upper:]][[:word:]]*)\\b(?![[:space:]]*[\\.\\(])",
+          "captures": {
+            "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+          }
+        },
+        {
+          "begin": "(\\.\\.)",
+          "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.less" }
+          }
+        },
+        {
+          "begin": "(\\|)(?![#\\-:!?.@*/&%^+<=>|~$\\\\])[[:space:]]*",
+          "end": "(?=[;\\)}]|\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\])|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#value-expression-constructor" },
+            {
+              "match": "([:])|\\b(of)\\b",
+              "captures": {
+                "1": { "name": "keyword.control.less" },
+                "2": { "name": "keyword.other" }
+              }
+            },
+            { "include": "#type-expression" }
+          ]
+        },
+        {
+          "comment": "FIXME: remove this once the pretty printer no longer outputs 'of'",
+          "match": "(:)|(\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))|\\b(of)\\b",
+          "captures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+            "2": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+            "3": { "name": "keyword.other" }
+          }
+        },
+        { "include": "#type-expression" }
+      ]
+    },
+    "module-item-type-bind-name-tyvars": {
+      "begin": "(?<=\\G|^|\\.)[[:space:]]*\\b([[:lower:]][[:word:]]*)\\b",
+      "end": "(?=\\+?=|[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "entity.name.function" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#attribute" },
+        {
+          "match": "_",
+          "name": "comment"
+        },
+        {
+          "comment": "FIXME: add separate type-variable rule",
+          "match": "([+\\-])?(?:(_)|(')([[:lower:]][[:word:]]*)\\b)(?!\\.[[:upper:]])",
+          "captures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+            "2": { "name": "comment" },
+            "3": { "name": "comment" },
+            "4": { "name": "variable.parameter string.other.link variable.language" }
+          }
+        }
+      ]
+    },
+    "module-item-type-bind-name-tyvars-body": {
+      "begin": "(?=(\\G|^)[[:space:]]*\\b[[:alpha:]])",
+      "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#module-path-simple-prefix" },
+        { "include": "#module-item-type-bind-name-tyvars" },
+        { "include": "#module-item-type-bind-body" }
+      ]
+    },
+    "module-item-type-bind-nonrec": {
+      "begin": "(?:\\G|^)[[:space:]]*\\b(nonrec)\\b",
+      "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control storage.modifier message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-type-bind-name-tyvars-body" }
+      ]
+    },
+    "module-item-type-constraint": {
+      "comment": "FIXME: proper parsing",
+      "begin": "\\b(constraint)\\b",
+      "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation storage.modifier message.error" }
+      },
+      "patterns": [
+        {
+          "comment": "FIXME: add separate type-variable rule",
+          "match": "([+\\-])?(')([_[:lower:]][[:word:]]*)\\b(?!\\.[[:upper:]])",
+          "captures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+            "2": { "name": "comment" },
+            "3": { "name": "variable.parameter string.other.link variable.language" }
+          }
+        },
+        {
+          "match": "=",
+          "name": "keyword.control.less"
+        },
+        { "include": "#type-expression" }
+      ]
+    },
+    "object-item": {
+      "begin": "\\G|(;)",
+      "end": "(?=[;}]|\\b(class|constraint|exception|external|include|let|module|nonrec|open|private|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#class-item-method" }
+      ]
+    },
+    "operator": {
+      "patterns": [
+        { "include": "#operator-infix" },
+        { "include": "#operator-prefix" }
+      ]
+    },
+    "operator-infix": {
+      "patterns": [
+        {
+          "match": ";",
+          "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+        },
+        { "include": "#operator-infix-assign" },
+        { "include": "#operator-infix-builtin" },
+        { "include": "#operator-infix-custom" },
+        { "comment": "#operator-infix-custom-hash" }
+      ]
+    },
+    "operator-infix-assign": {
+      "match": "(?<![#\\-:!?.@*/&%^+<=>|~$\\\\])(=)(?![#\\-:!?.@*/&%^+<=>|~$\\\\])",
+      "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control.less message.error"
+    },
+    "operator-infix-builtin": {
+      "match": ":=",
+      "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control.less message.error"
+    },
+    "operator-infix-custom": {
+      "match": "(?:(?<![#\\-:!?.@*/&%^+<=>|~$\\\\])((<>))(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))|([#\\-@*/&%^+<=>$\\\\][#\\-:!?.@*/&%^+<=>|~$\\\\]*|[|][#\\-:!?.@*/&%^+<=>|~$\\\\]+)",
+      "captures": {
+        "1": { "comment": "meta.separator" },
+        "2": { "name": "punctuation.definition.tag.begin.js" },
+        "3": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      }
+    },
+    "operator-infix-custom-hash": {
+      "match": "#[\\-:!?.@*/&%^+<=>|~$]+",
+      "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+    },
+    "operator-prefix": {
+      "patterns": [
+        { "include": "#operator-prefix-bang" },
+        { "include": "#operator-prefix-label-token" }
+      ]
+    },
+    "operator-prefix-bang": {
+      "match": "![\\-:!?.@*/&%^+<=>|~$]*",
+      "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+    },
+    "operator-prefix-label-token": {
+      "match": "[?~][\\-:!?.@*/&%^+<=>|~$]+",
+      "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+    },
+    "pattern": {
+      "patterns": [
+        { "include": "#attribute" },
+        { "include": "#comment" },
+        { "include": "#pattern-atomic" },
+        {
+          "match": "[[:space:]]*+(?:(\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))|\\b(as)\\b|(\\.\\.\\.?))[[:space:]]*+",
+          "captures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+            "2": { "name": "keyword.other" },
+            "3": { "name": "keyword.control" }
+          }
+        }
+      ]
+    },
+    "pattern-atomic": {
+      "patterns": [
+        {
+          "match": "\\b(exception)\\b",
+          "name": "keyword.other"
+        },
+        { "include": "#value-expression-literal" },
+        { "include": "#module-path-simple-prefix" },
+        { "include": "#pattern-list-or-array" },
+        { "include": "#pattern-record" },
+        { "include": "#pattern-variable" },
+        { "include": "#pattern-parens" }
+      ]
+    },
+    "pattern-guard": {
+      "begin": "\\b(when)\\b",
+      "end": "(?==>)",
+      "beginCaptures": {
+        "1": { "name": "keyword.other" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "pattern-list-or-array": {
+      "begin": "(\\[\\|?)(?![@%])",
+      "end": "(\\|?\\])",
+      "beginCaptures": {
+        "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+      },
+      "endCaptures": {
+        "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+      },
+      "patterns": [
+        { "include": "#value-expression-literal-list-or-array-separator" },
+        { "include": "#pattern" }
+      ]
+    },
+    "pattern-parens": {
+      "begin": "(?=\\()",
+      "end": "\\)|(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#pattern-parens-lhs" },
+        { "include": "#type-annotation-rhs" }
+      ]
+    },
+    "pattern-parens-lhs": {
+      "begin": "\\(|(,)",
+      "end": "(?=(?:[,:\\)]))|(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#pattern" }
+      ]
+    },
+    "record-path": {
+      "begin": "\\b[[:lower:]][[:word:]]*\\b",
+      "end": "(?=[^[:space:]\\.])(?!/\\*)",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#record-path-suffix" }
+      ]
+    },
+    "record-path-suffix": {
+      "begin": "(\\.)",
+      "end": "(\\))|\\b([[:upper:]][[:word:]]*)\\b|\\b([[:lower:]][[:word:]]*)\\b|(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "endCaptures": {
+        "1": { "name": "keyword.control" },
+        "2": { "name": "support.class entity.name.class" },
+        "3": { "name": "markup.inserted constant.language support.property-value entity.name.filename" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        {
+          "begin": "([\\(])",
+          "end": "(?=[\\)])",
+          "beginCaptures": {
+            "1": { "name": "keyword.control" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            {
+              "match": "\\b([[:lower:]][[:word:]]*)\\b(?=[^\\)]*([\\.]))",
+              "captures": {
+                "1": { "name": "markup.inserted constant.language support.property-value entity.name.filename" },
+                "2": { "name": "keyword.other" }
+              }
+            },
+            {
+              "match": "([\\.])",
+              "name": "keyword.control.less"
+            },
+            {
+              "match": "\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*",
+              "captures": {
+                "1": { "name": "variable.parameter string.other.link variable.language" }
+              }
+            },
+            { "include": "#value-expression" }
+          ]
+        }
+      ]
+    },
+    "pattern-record": {
+      "begin": "{",
+      "end": "}",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#pattern-record-item" }
+      ]
+    },
+    "pattern-record-field": {
+      "begin": "\\b([_][[:word:]]*)\\b|\\b([[:lower:]][[:word:]]*)\\b",
+      "end": "(,)|(?=})",
+      "beginCaptures": {
+        "1": { "name": "comment" },
+        "2": { "name": "markup.inserted constant.language support.property-value entity.name.filename" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        {
+          "begin": "\\G(:)",
+          "end": "(?=[,}])",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#pattern" }
+          ]
+        }
+      ]
+    },
+    "pattern-record-item": {
+      "patterns": [
+        { "include": "#module-path-simple-prefix" },
+        { "include": "#pattern-record-field" }
+      ]
+    },
+    "pattern-variable": {
+      "patterns": [
+        {
+          "match": "\\b(_(?:[[:lower:]][[:word:]]*)?)\\b(?!\\.[[:upper:]])",
+          "captures": {
+            "1": { "name": "comment" }
+          }
+        },
+        {
+          "match": "\\b([[:lower:]][[:word:]]*)\\b(?!\\.[[:upper:]])",
+          "captures": {
+            "1": { "name": "variable.language string.other.link" }
+          }
+        }
+      ]
+    },
+    "signature-expression": {
+      "patterns": [
+        {
+          "comment": "FIXME: scan for :upper: to disambiguate type/signature in hover",
+          "begin": "(?=\\([[:space:]]*[[:upper:]][[:word:]]*[[:space:]]*:)",
+          "end": "(?=[;])",
+          "patterns": [
+            {
+              "begin": "(?=\\()",
+              "end": "(?=[;]|=>)",
+              "patterns": [
+                { "include": "#module-item-let-module-param" }
+              ]
+            },
+            {
+              "begin": "(=>)",
+              "end": "(?=[;\\(])",
+              "beginCaptures": {
+                "1": { "name": "markup.inserted keyword.control.less" }
+              },
+              "patterns": [
+                { "include": "#structure-expression" }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "\\b(module)\\b[[:space:]]*\\b(type)\\b([[:space:]]*\\b(of)\\b)?",
+          "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "markup.inserted keyword.other variable.other.readwrite.instance" },
+            "2": { "name": "entity.other.attribute-name.css constant.language constant.numeric" },
+            "3": { "name": "markup.inserted keyword.other variable.other.readwrite.instance" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            { "include": "#module-path-simple" },
+            {
+              "match": "\\b([[:upper:]][[:word:]]*)\\b",
+              "name": "support.class entity.name.class"
+            }
+          ]
+        },
+        { "include": "#signature-expression-constraints" },
+        { "include": "#structure-expression" }
+      ]
+    },
+    "signature-expression-constraints": {
+      "begin": "(?=\\b(with))",
+      "end": "(?=[;\\)}]|\\b(class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|val)\\b)",
+      "patterns": [
+        {
+          "begin": "\\b(and|with)\\b",
+          "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation storage.modifier message.error" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            {
+              "comment": "FIXME: special version of #module-item-type with non-consuming `;`. Atom seems to need this to work.",
+              "begin": "\\b(type)\\b",
+              "end": "(?=[;\\)}]|\\b(class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|val|with)\\b)",
+              "beginCaptures": {
+                "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+              },
+              "patterns": [
+                { "include": "#module-item-type-and" },
+                { "include": "#module-item-type-constraint" },
+                { "include": "#module-item-type-bind" }
+              ]
+            },
+            {
+              "begin": "(?=\\b(module)\\b)",
+              "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|val|with)\\b)",
+              "patterns": [
+                {
+                  "begin": "\\b(module)\\b",
+                  "end": "(?=:?=|[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|type|val|with)\\b)",
+                  "beginCaptures": {
+                    "1": { "name": "markup.inserted keyword.control storage.type variable.other.readwrite.instance" }
+                  },
+                  "patterns": [
+                    { "include": "#comment" },
+                    { "include": "#module-path-simple" },
+                    {
+                      "match": "[[:upper:]][[:word:]]*",
+                      "name": "support.class entity.name.class"
+                    }
+                  ]
+                },
+                {
+                  "begin": "(:=)|(=)",
+                  "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|type|val|with)\\b)",
+                  "beginCaptures": {
+                    "1": { "name": "markup.inserted keyword.control.less message.error" },
+                    "2": { "name": "markup.inserted keyword.control.less" }
+                  },
+                  "patterns": [
+                    { "include": "#structure-expression" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "structure-expression": {
+      "patterns": [
+        { "include": "#comment" },
+        {
+          "comment": "FIXME: scan for :upper: or `val` to disambiguate types from signatures for hover",
+          "begin": "\\((?=[[:space:]]*(\\b(val)\\b|[^'\\[<[:lower:]]))",
+          "end": "\\)|(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|with)\\b)",
+          "patterns": [
+            { "include": "#comment" },
+            {
+              "comment": "FIXME: might need to refactor this or include more expressions",
+              "include": "#structure-expression-block"
+            },
+            {
+              "begin": "\\b(val)\\b",
+              "end": "(?=\\))|(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+              "beginCaptures": {
+                "1": { "name": "keyword.other" }
+              },
+              "patterns": [
+                { "include": "#comment" },
+                {
+                  "match": "\\b([[:lower:]][[:word:]]*)\\b",
+                  "name": "support.class entity.name.class"
+                }
+              ]
+            },
+            { "include": "#module-path-simple" },
+            {
+              "begin": "(:)",
+              "end": "(?=[\\)])|(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val)\\b)",
+              "beginCaptures": {
+                "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+              },
+              "patterns": [
+                { "include": "#signature-expression" }
+              ]
+            }
+          ]
+        },
+        { "include": "#module-path-simple" },
+        { "include": "#structure-expression-block" }
+      ]
+    },
+    "structure-expression-block": {
+      "begin": "{",
+      "end": "}",
+      "patterns": [
+        { "include": "#structure-expression-block-item" }
+      ]
+    },
+    "structure-expression-block-item": {
+      "patterns": [
+        { "include": "#attribute" },
+        { "include": "#comment" },
+        { "include": "#module-item-exception" },
+        { "include": "#module-item-external" },
+        { "include": "#module-item-include" },
+        { "include": "#module-item-let" },
+        { "include": "#module-item-class-type" },
+        { "include": "#module-item-module-type" },
+        { "include": "#module-item-module" },
+        { "include": "#module-item-open" },
+        { "include": "#module-item-type" }
+      ]
+    },
+    "type-annotation-rhs": {
+      "begin": "(?<![#\\-:!?.@*/&%^+<=>|~$\\\\])([:])(?![#\\-:!?.@*/&%^+<=>|~$\\\\])",
+      "end": "(?=\\))|(?=[,;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#type-expression" }
+      ]
+    },
+    "type-expression": {
+      "patterns": [
+        {
+          "match": "([\\.])",
+          "name": "entity.name.function"
+        },
+        { "include": "#type-expression-atomic" },
+        { "include": "#type-expression-arrow" }
+      ]
+    },
+    "type-expression-atomic": {
+      "patterns": [
+        { "include": "#attribute" },
+        { "include": "#comment" },
+        { "include": "#module-path-extended-prefix" },
+        { "include": "#type-expression-label" },
+        {
+          "match": "\\b(as)\\b",
+          "name": "variable.other.class.js variable.interpolation storage.modifier message.error"
+        },
+        { "include": "#type-expression-constructor" },
+        { "include": "#type-expression-object" },
+        { "include": "#type-expression-parens" },
+        { "include": "#type-expression-polymorphic-variant" },
+        { "include": "#type-expression-record" },
+        { "include": "#type-expression-variable" }
+      ]
+    },
+    "type-expression-arrow": {
+      "match": "=>",
+      "name": "markup.inserted keyword.control.less"
+    },
+    "type-expression-constructor": {
+      "match": "(_)(?![[:alnum:]])|\\b([_[:lower:]][[:word:]]*)\\b(?!\\.[[:upper:]])",
+      "captures": {
+        "1": { "name": "comment" },
+        "2": { "name": "support.type string.regexp" }
+      }
+    },
+    "type-expression-label": {
+      "begin": "\\b([_[:lower:]][[:word:]]*)\\b(::)",
+      "end": "(?<==>)",
+      "beginCaptures": {
+        "1": { "name": "markup.inserted constant.language support.property-value entity.name.filename" },
+        "2": { "name": "keyword.control" }
+      },
+      "patterns": [
+        { "include": "#type-expression" },
+        {
+          "match": "(\\?)",
+          "captures": {
+            "1": { "name": "keyword.control.less" }
+          }
+        }
+      ]
+    },
+    "type-expression-object": {
+      "comment": "FIXME: separate sub-rules",
+      "begin": "(<)",
+      "end": "(>)",
+      "captures": {
+        "1": { "name": "entity.name.function" }
+      },
+      "patterns": [
+        {
+          "begin": "(\\.\\.)",
+          "end": "(?=>)",
+          "beginCaptures": {
+            "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+          }
+        },
+        {
+          "comment": "FIXME: method item",
+          "begin": "(?=[_[:lower:]])",
+          "end": "(,)|(?=>)",
+          "endCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            {
+              "comment": "FIXME: method name",
+              "begin": "(?=[_[:lower:]])",
+              "end": "(?=:)",
+              "patterns": [
+                {
+                  "match": "\\b([_[:lower:]][[:word:]]*)\\b",
+                  "captures": {
+                    "1": { "name": "markup.inserted constant.language support.property-value entity.name.filename" }
+                  }
+                }
+              ]
+            },
+            {
+              "comment": "FIXME: method type",
+              "begin": "(:)",
+              "end": "(?=[,>])",
+              "beginCaptures": {
+                "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+              },
+              "patterns": [
+                { "include": "#type-expression" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "type-expression-parens": {
+      "comment": "FIXME: proper tuple types",
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "begin": "\\b(module)\\b",
+          "end": "(?=[\\)])",
+          "beginCaptures": {
+            "1": { "name": "keyword.other message.error" }
+          },
+          "patterns": [
+            { "include": "#module-path-extended" },
+            { "include": "#signature-expression-constraints" }
+          ]
+        },
+        {
+          "match": ",",
+          "name": "keyword.control.less"
+        },
+        { "include": "#type-expression" }
+      ]
+    },
+    "type-expression-polymorphic-variant": {
+      "comment": "FIXME: proper parsing",
+      "begin": "(\\[)([<>])?",
+      "end": "(\\])",
+      "captures": {
+        "1": { "name": "entity.name.function" },
+        "2": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        {
+          "begin": "(\\|)?(?![#\\-:!?.@*/&%^+<=>|~$\\\\])[[:space:]]*",
+          "end": "(?=[;)}\\]]|\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\])|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#value-expression-constructor" },
+            {
+              "match": "([:])|\\b(of)\\b|([&])",
+              "captures": {
+                "1": { "name": "keyword.control.less" },
+                "2": { "name": "keyword.other" },
+                "3": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+              }
+            },
+            { "include": "#value-expression-constructor-polymorphic" },
+            { "include": "#type-expression" }
+          ]
+        }
+      ]
+    },
+    "type-expression-record": {
+      "begin": "{",
+      "end": "}",
+      "patterns": [
+        { "include": "#type-expression-record-item" }
+      ]
+    },
+    "type-expression-record-field-sans-modifier": {
+      "begin": "\\b([_[:lower:]][[:word:]]*)\\b",
+      "end": "(,)|(?=[,}])",
+      "beginCaptures": {
+        "1": { "name": "markup.inserted constant.language support.property-value entity.name.filename" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        {
+          "begin": "(:)",
+          "end": "(?=[,}])",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#type-expression" }
+          ]
+        }
+      ]
+    },
+    "type-expression-record-field": {
+      "patterns": [
+        {
+          "begin": "\\b(mutable)\\b",
+          "end": "(?<=[,])|(?=})",
+          "beginCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation storage.modifier message.error" }
+          },
+          "patterns": [
+            { "include": "#type-expression-record-field-sans-modifier" }
+          ]
+        },
+        { "include": "#type-expression-record-field-sans-modifier" }
+      ]
+    },
+    "type-expression-record-item": {
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-path-simple-prefix" },
+        { "include": "#type-expression-record-field" }
+      ]
+    },
+    "type-expression-variable": {
+      "match": "(')([_[:lower:]][[:word:]]*)\\b(?!\\.[[:upper:]])",
+      "captures": {
+        "1": { "name": "comment" },
+        "2": { "name": "variable.parameter string.other.link variable.language" }
+      }
+    },
+    "value-expression": {
+      "patterns": [
+        { "include": "#attribute" },
+        { "include": "#comment" },
+        { "include": "#extension-node" },
+        { "include": "#jsx" },
+        { "include": "#operator" },
+        { "include": "#value-expression-builtin" },
+        { "include": "#value-expression-if-then-else" },
+        { "include": "#value-expression-atomic" },
+        { "include": "#module-path-simple-prefix" },
+        {
+          "match": "[:?]",
+          "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error"
+        },
+        { "include": "#record-path" }
+      ]
+    },
+    "value-expression-atomic": {
+      "patterns": [
+        { "include": "#value-expression-literal" },
+        { "include": "#value-expression-literal-list-or-array" },
+        { "include": "#value-expression-for" },
+        { "include": "#value-expression-fun" },
+        { "include": "#value-expression-block-or-record-or-object" },
+        { "include": "#value-expression-label" },
+        { "include": "#value-expression-parens" },
+        { "include": "#value-expression-switch" },
+        { "include": "#value-expression-try" },
+        { "include": "#value-expression-while" }
+      ]
+    },
+    "value-expression-atomic-with-paths": {
+      "patterns": [
+        { "include": "#value-expression-atomic" },
+        { "include": "#module-path-simple-prefix" },
+        { "include": "#record-path-suffix" }
+      ]
+    },
+    "value-expression-block": {
+      "begin": "{",
+      "end": "}",
+      "patterns": [
+        { "include": "#value-expression-block-item" }
+      ]
+    },
+    "value-expression-block-item": {
+      "patterns": [
+        { "include": "#module-item-let" },
+        { "include": "#module-item-open" },
+        { "include": "#value-expression" }
+      ]
+    },
+    "value-expression-block-look": {
+      "begin": "(?![[:space:]]*($|\\.\\.\\.|([[:upper:]][[:word:]]*\\.)*([[:lower:]][[:word:]]*)[[:space:]]*(?:,|:(?![=]))))",
+      "end": "(?=})",
+      "patterns": [
+        { "include": "#value-expression-block-item" }
+      ]
+    },
+    "value-expression-block-or-record-or-object": {
+      "begin": "{",
+      "end": "}",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-path-simple-prefix" },
+        { "include": "#value-expression-object-look" },
+        { "include": "#value-expression-record-look" },
+        { "include": "#value-expression-block-look" }
+      ]
+    },
+    "value-expression-builtin": {
+      "match": "\\b(assert|decr|failwith|fprintf|ignore|incr|land|lazy|lor|lsl|lsr|lxor|mod|new|not|printf|ref)\\b|\\b(raise)\\b",
+      "captures": {
+        "1": { "name": "keyword.control message.error" },
+        "2": { "name": "keyword.control.trycatch" }
+      }
+    },
+    "value-expression-constructor": {
+      "match": "\\b([[:upper:]][[:word:]]*)\\b(?![[:space:]]*[\\.])",
+      "captures": {
+        "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+      }
+    },
+    "value-expression-constructor-polymorphic": {
+      "match": "(`)([[:alpha:]][[:word:]]*)\\b(?!\\.)",
+      "captures": {
+        "1": { "name": "constant.other.symbol keyword.control.less variable.parameter" },
+        "2": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+      }
+    },
+    "value-expression-for": {
+      "begin": "(?=\\b(for)\\b)",
+      "end": "(?<=})|(?=[;]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#value-expression-for-head" },
+        { "include": "#value-expression-block" }
+      ]
+    },
+    "value-expression-for-head": {
+      "begin": "(?=\\b(for)\\b)",
+      "end": "(?={)|(?=[;]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        {
+          "begin": "\\b(for)\\b",
+          "end": "(?=\\b(in)\\b)|(?=[;]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.loop" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            { "include": "#pattern-variable" }
+          ]
+        },
+        {
+          "begin": "\\b(in)\\b",
+          "end": "(?=\\b(to)\\b)|(?=[;]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.loop" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            { "include": "#value-expression-atomic-with-paths" }
+          ]
+        },
+        {
+          "begin": "\\b(to)\\b",
+          "end": "(?={)|(?=[;]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.loop" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            { "include": "#value-expression-atomic-with-paths" }
+          ]
+        },
+        { "include": "#value-expression-block" }
+      ]
+    },
+    "value-expression-fun": {
+      "begin": "\\b(fun)\\b",
+      "end": "(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control" }
+      },
+      "patterns": [
+        { "include": "#value-expression-fun-pattern-match-rule-lhs" },
+        { "include": "#value-expression-fun-pattern-match-rule-rhs" }
+      ]
+    },
+    "value-expression-fun-pattern-match-rule-lhs": {
+      "begin": "(?=\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))|(?<=fun)",
+      "end": "(\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))|(?==>)|(?=[;\\)}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "applyEndPatternLast": true,
+      "beginCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "endCaptures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        { "include": "#module-item-let-value-param" }
+      ]
+    },
+    "value-expression-fun-pattern-match-rule-rhs": {
+      "begin": "(=>)",
+      "end": "(?=[;\\)}]|\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\])|\\b(and)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.less" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "value-expression-if-then-else": {
+      "begin": "\\b(if)\\b",
+      "end": "(?=[;\\)\\]}])",
+      "applyEndPatternLast": true,
+      "beginCaptures": {
+        "1": { "name": "keyword.control.conditional" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        {
+          "begin": "\\b(else)\\b",
+          "end": "(?=[;\\)\\]}])",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.conditional" }
+          },
+          "patterns": [
+            { "include": "#value-expression" }
+          ]
+        },
+        { "include": "#value-expression-atomic-with-paths" }
+      ]
+    },
+    "value-expression-lazy": {
+      "comment": "FIXME",
+      "match": "\\b(lazy)\\b",
+      "captures": {
+        "1": { "name": "keyword.other" }
+      }
+    },
+    "value-expression-label": {
+      "begin": "\\b([_[:lower:]][[:word:]]*)\\b[[:space:]]*(::)(\\?)?",
+      "end": "(?![[:space:]])",
+      "beginCaptures": {
+        "1": { "name": "markup.inserted constant.language support.property-value entity.name.filename" },
+        "2": { "name": "keyword.control" },
+        "3": { "name": "storage.type" }
+      },
+      "patterns": [
+        { "include": "#value-expression" }
+      ]
+    },
+    "value-expression-literal": {
+      "patterns": [
+        { "include": "#value-expression-literal-boolean" },
+        { "include": "#value-expression-literal-character" },
+        { "include": "#value-expression-constructor" },
+        { "include": "#value-expression-constructor-polymorphic" },
+        { "include": "#value-expression-lazy" },
+        { "include": "#value-expression-literal-numeric" },
+        { "include": "#value-expression-literal-string" },
+        { "include": "#value-expression-literal-unit" }
+      ]
+    },
+    "value-expression-literal-boolean": {
+      "match": "\\b(false|true)\\b",
+      "name": "entity.other.attribute-name.css constant.language constant.numeric"
+    },
+    "value-expression-literal-character": {
+      "match": "(')([[:space:]]|[[:graph:]]|\\\\[\\\\\"'ntbr]|\\\\[[:digit:]][[:digit:]][[:digit:]]|\\\\x[[:xdigit:]][[:xdigit:]]|\\\\o[0-3][0-7][0-7])(')",
+      "name": "constant.character"
+    },
+    "value-expression-literal-list-or-array": {
+      "begin": "(\\[\\|?)(?![@%])",
+      "end": "(\\|?\\])",
+      "beginCaptures": {
+        "1": { "name": "constant.language.list" }
+      },
+      "endCaptures": {
+        "1": { "name": "constant.language.list" }
+      },
+      "patterns": [
+        { "include": "#value-expression-literal-list-or-array-separator" },
+        { "include": "#value-expression" },
+        { "include": "#value-expression-literal-list-or-array" }
+      ]
+    },
+    "value-expression-literal-list-or-array-separator": {
+      "match": "(,)|(\\.\\.\\.)",
+      "captures": {
+        "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+        "2": { "name": "keyword.control" }
+      }
+    },
+    "value-expression-literal-numeric": {
+      "patterns": [
+        {
+          "match": "([-])?([[:digit:]][_[:digit:]]*)(?:(\\.)([_[:digit:]]*))?(?:([eE])([\\-\\+])?([[:digit:]][_[:digit:]]*))?(?![bBoOxX])",
+          "captures": {
+            "1": { "name": "keyword.control.less" },
+            "2": { "name": "constant.numeric" },
+            "3": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+            "4": { "name": "constant.numeric" },
+            "5": { "name": "keyword.control.less" },
+            "6": { "name": "keyword.control.less" },
+            "7": { "name": "constant.numeric" }
+          }
+        },
+        {
+          "match": "([-])?(0[xX])([[:xdigit:]][_[:xdigit:]]*)(?:(\\.)([_[:xdigit:]]*))?(?:([pP])([\\-\\+])?([[:digit:]][_[:digit:]]*))?",
+          "captures": {
+            "1": { "name": "keyword.control.less" },
+            "2": { "name": "keyword.control.less" },
+            "3": { "name": "constant.numeric" },
+            "4": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" },
+            "5": { "name": "constant.numeric" },
+            "6": { "name": "keyword.control.less" },
+            "7": { "name": "keyword.control.less" },
+            "8": { "name": "constant.numeric" }
+          }
+        },
+        {
+          "match": "([-])?(0[oO])([0-7][_0-7]*)",
+          "captures": {
+            "1": { "name": "keyword.control.less" },
+            "2": { "name": "keyword.control.less" },
+            "3": { "name": "constant.numeric" }
+          }
+        },
+        {
+          "match": "([-])?(0[bB])([0-1][_0-1]*)",
+          "captures": {
+            "1": { "name": "keyword.control.less" },
+            "2": { "name": "keyword.control.less" },
+            "3": { "name": "constant.numeric" }
+          }
+        }
+      ]
+    },
+    "value-expression-literal-string": {
+      "patterns": [
+        {
+          "begin": "(?<![[:alpha:]])js_expr(?!=[[:word:]])",
+          "end": "(?<=\")|(\\|)([_[:lower:]]*)?(})|(?=[^[:space:]\"{])",
+          "endCaptures": {
+            "1": { "name": "keyword.control.flow message.error" },
+            "2": { "name": "entity.other.attribute-name.css constant.language constant.numeric" },
+            "3": { "name": "keyword.control.flow message.error" }
+          },
+          "patterns": [
+            {
+              "begin": "({)([_[:lower:]]*)?(\\|)",
+              "end": "(?=\\|\\2})",
+              "comment": "meta.separator",
+              "beginCaptures": {
+                "1": { "name": "keyword.control.flow message.error" },
+                "2": { "name": "entity.other.attribute-name.css constant.language constant.numeric" },
+                "3": { "name": "keyword.control.flow message.error" }
+              },
+              "patterns": [
+                { "include": "source.js" }
+              ]
+            },
+            {
+              "begin": "\"",
+              "end": "\"",
+              "comment": "meta.separator",
+              "patterns": [
+                { "include": "source.js" }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "({)([_[:lower:]]*)?(\\|)",
+          "end": "(\\|)(\\2)(})",
+          "name": "string.double string.regexp",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.flow message.error" },
+            "2": { "name": "entity.other.attribute-name.css constant.language constant.numeric" },
+            "3": { "name": "keyword.control.flow message.error" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.control.flow message.error" },
+            "2": { "name": "entity.other.attribute-name.css constant.language constant.numeric" },
+            "3": { "name": "keyword.control.flow message.error" }
+          }
+        },
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.double string.regexp",
+          "patterns": [
+            { "include": "#value-expression-literal-string-escape" }
+          ]
+        }
+      ]
+    },
+    "value-expression-literal-string-escape": {
+      "patterns": [
+        {
+          "comment": "FIXME: make escapes into separate rule",
+          "match": "\\\\[\\\\\"'ntbr ]|\\\\[[:digit:]][[:digit:]][[:digit:]]|\\\\x[[:xdigit:]][[:xdigit:]]|\\\\o[0-3][0-7][0-7]",
+          "name": "constant.character"
+        },
+        {
+          "match": "(@)([ \\[\\],.]|\\\\n)",
+          "captures": {
+            "1": { "name": "keyword.control.less" },
+            "2": { "name": "entity.other.attribute-name.css constant.language constant.numeric" }
+          }
+        },
+        {
+          "comment": "FIXME: don't highlight in external strings",
+          "match": "(%)([ads])?",
+          "captures": {
+            "1": { "name": "entity.other.attribute-name.css constant.language constant.numeric" },
+            "2": { "name": "variable.other.readwrite.instance string.other.link variable.language" }
+          }
+        }
+      ]
+    },
+    "value-expression-literal-unit": {
+      "match": "\\(\\)",
+      "name": "constant.language.unit"
+    },
+    "value-expression-object-look": {
+      "comment": "FIXME: is there a better way than listing all the keywords?",
+      "begin": "(?:\\G|^)[[:space:]]*(?=method)",
+      "end": "(?=})",
+      "patterns": [
+        { "include": "#object-item" }
+      ]
+    },
+    "value-expression-parens": {
+      "begin": "(?=\\()",
+      "end": "(\\))|(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "endCaptures": {
+      },
+      "patterns": [
+        { "include": "#condition-lhs" },
+        { "include": "#value-expression-parens-lhs" },
+        { "include": "#type-annotation-rhs" }
+      ]
+    },
+    "value-expression-parens-lhs": {
+      "begin": "(\\()|(,)",
+      "end": "(?=[?,:\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "2": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+      },
+      "patterns": [
+        {
+          "begin": "\\b(module)\\b",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": { "name": "keyword.other message.error" }
+          },
+          "patterns": [
+            { "include": "#module-path-simple" }
+          ]
+        },
+        { "include": "#value-expression" }
+      ]
+    },
+    "value-expression-record-field": {
+      "patterns": [
+        {
+          "begin": "(\\.\\.\\.)",
+          "end": "(,)|(?=})",
+          "beginCaptures": {
+            "1": { "name": "keyword.control" }
+          },
+          "endCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#comment" },
+            { "include": "#module-path-simple-prefix" },
+            {
+              "begin": "(?=[\\.])",
+              "end": "(?=[:,])",
+              "patterns": [
+                {
+                  "match": "\\b[[:lower:]][[:word:]]*\\b",
+                  "name": "markup.inserted constant.language support.property-value entity.name.filename"
+                }
+              ]
+            },
+            {
+              "begin": "(:)",
+              "end": "(?=[,}])",
+              "beginCaptures": {
+                "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+              },
+              "patterns": [
+                { "include": "#value-expression" }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "\\b[[:upper:]][[:word:]]*\\b",
+          "end": "(,)|(?=})",
+          "beginCaptures": {
+            "1": { "name": "support.class entity.name.class" }
+          },
+          "endCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            { "include": "#module-path-simple-prefix" },
+            {
+              "begin": "(:)",
+              "end": "(?=[,}])",
+              "beginCaptures": {
+                "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+              },
+              "patterns": [
+                { "include": "#value-expression" }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "\\b([[:lower:]][[:word:]]*)\\b",
+          "end": "(,)|(?=})",
+          "beginCaptures": {
+            "1": { "name": "markup.inserted constant.language support.property-value entity.name.filename" }
+          },
+          "endCaptures": {
+            "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+          },
+          "patterns": [
+            {
+              "begin": "(:)",
+              "end": "(?=[,}])",
+              "beginCaptures": {
+                "1": { "name": "variable.other.class.js variable.interpolation keyword.operator keyword.control message.error" }
+              },
+              "patterns": [
+                { "include": "#value-expression" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "value-expression-record-item": {
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#module-path-simple-prefix" },
+        { "include": "#value-expression-record-field" }
+      ]
+    },
+    "value-expression-switch": {
+      "begin": "\\b(switch)\\b",
+      "end": "(?<=})",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.switch" }
+      },
+      "patterns": [
+        { "include": "#value-expression-switch-head" },
+        { "include": "#value-expression-switch-body" }
+      ]
+    },
+    "value-expression-switch-body": {
+      "begin": "{",
+      "end": "}",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#value-expression-switch-pattern-match-rule" }
+      ]
+    },
+    "value-expression-switch-head": {
+      "begin": "(?<=switch)",
+      "end": "(?<!switch)(?={)|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#comment" },
+        {
+          "begin": "\\G[[:space:]]*+{",
+          "end": "}[[:space:]]*+",
+          "patterns": [
+            { "include": "#value-expression-block-item" }
+          ]
+        },
+        { "include": "#value-expression-atomic-with-paths" }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule": {
+      "patterns": [
+        { "include": "#value-expression-switch-pattern-match-rule-lhs" },
+        { "include": "#value-expression-switch-pattern-match-rule-rhs" }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule-lhs": {
+      "begin": "(?=\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))",
+      "end": "(?==>|[;\\)}])",
+      "patterns": [
+        { "include": "#pattern-guard" },
+        { "include": "#pattern" }
+      ]
+    },
+    "value-expression-switch-pattern-match-rule-rhs": {
+      "begin": "(=>)",
+      "end": "(?=}|\\|(?![#\\-:!?.@*/&%^+<=>|~$\\\\]))",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.less" }
+      },
+      "patterns": [
+        { "include": "#value-expression-block-item" }
+      ]
+    },
+    "value-expression-try": {
+      "begin": "\\b(try)\\b",
+      "end": "(?<=})|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.trycatch" }
+      },
+      "patterns": [
+        { "include": "#value-expression-try-head" },
+        { "include": "#value-expression-switch-body" }
+      ]
+    },
+    "value-expression-try-head": {
+      "begin": "(?<=try)",
+      "end": "(?<!try)(?={)|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control" }
+      },
+      "patterns": [
+        { "include": "#comment" },
+        {
+          "begin": "\\G[[:space:]]*+{",
+          "end": "}[[:space:]]*+",
+          "patterns": [
+            { "include": "#value-expression-block-item" }
+          ]
+        },
+        { "include": "#value-expression-atomic-with-paths" }
+      ]
+    },
+    "value-expression-while": {
+      "begin": "\\b(while)\\b",
+      "end": "(?<=})|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.loop" }
+      },
+      "patterns": [
+        { "include": "#value-expression-while-head" },
+        { "include": "#value-expression-block" }
+      ]
+    },
+    "value-expression-while-head": {
+      "begin": "(?<=while)[[:space:]]*+",
+      "end": "(?={)|(?=[;\\)]|\\b(and|as|class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|rec|type|val|with)\\b)",
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#value-expression-atomic-with-paths" }
+      ]
+    },
+    "value-expression-record-look": {
+      "begin": "(?=\\.\\.\\.|([[:upper:]][[:word:]]*\\.)*([[:lower:]][[:word:]]*)[[:space:]]*[,:}])",
+      "end": "(?=})",
+      "patterns": [
+        { "include": "#value-expression-record-item" }
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"vscode": "^1.43.0"
 	},
 	"activationEvents": [
-		"onLanguage:rescript"
+		"onLanguage:rescript",
+		"onLanguage:reason"
 	],
 	"main": "./client/out/extension",
 	"contributes": {
@@ -82,6 +83,11 @@
 				"language": "rescript",
 				"scopeName": "source.rescript",
 				"path": "./grammars/rescript.tmLanguage.json"
+			},
+			{
+				"language": "reason",
+				"scopeName": "source.reason",
+				"path": "./grammars/reason.tmLanguage.json"
 			}
 		],
 		"languages": [
@@ -95,6 +101,17 @@
 					".resi"
 				],
 				"configuration": "./rescript.configuration.json"
+			},
+			{
+				"id": "reason",
+				"aliases": [
+					"Reason"
+				],
+				"extensions": [
+					".re",
+					".rei"
+				],
+				"configuration": "./reason.configuration.json"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
 			{
 				"language": "rescript",
 				"path": "./snippets.json"
+			},
+			{
+				"language": "reason",
+				"path": "./reason_snippets.json"
 			}
 		],
 		"taskDefinitions_unused": [

--- a/reason.configuration.json
+++ b/reason.configuration.json
@@ -1,0 +1,26 @@
+{
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": [ "string" ] },
+    { "open": "/**", "close": " */", "notIn": [ "string" ] }
+  ],
+  "brackets": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ]
+  ],
+  "comments": {
+    "lineComment": "//",
+    "blockComment": [ "/*", "*/" ]
+  },
+  "surroundingPairs": [
+    [ "{", "}" ],
+    [ "[", "]" ],
+    [ "(", ")" ],
+    [ "'", "'" ],
+    [ "\"", "\"" ],
+    [ "`", "`" ]
+  ]
+}

--- a/reason_snippets.json
+++ b/reason_snippets.json
@@ -1,0 +1,63 @@
+{
+  "Module": {
+    "prefix": ["module"],
+    "body": ["module ${1:Name} = {", "\t${2:// Module contents};", "}"]
+  },
+  "Switch": {
+    "prefix": ["switch"],
+    "body": [
+      "switch (${1:value}) {",
+      "| ${2:pattern1} => ${3:expression}",
+      "${4:| ${5:pattern2} => ${6:expression}}",
+      "};"
+    ]
+  },
+  "Try": {
+    "prefix": ["try"],
+    "body": [
+      "try(${1:expression}) {",
+      "| ${2:MyException} => ${3:expression}",
+      "};"
+    ]
+  },
+  "For Loop": {
+    "prefix": ["for"],
+    "body": [
+      "for (${1:i} in ${2:startValueInclusive} to ${3:endValueInclusive}) {",
+      "\t${4:Js.log(${1:i})}",
+      "};"
+    ]
+  },
+  "Reverse For Loop": {
+    "prefix": ["for"],
+    "body": [
+      "for (${1:i} in ${2:startValueInclusive} downto ${3:endValueInclusive}) {",
+      "\t${4:Js.log(${1:i})}",
+      "};"
+    ]
+  },
+  "Global External Object": {
+    "prefix": ["@bs", "external"],
+    "body": [
+      "[@val] external ${1:setTimeout}: ${2:(unit => unit, int) => float} = \"${3:setTimeout}\";"
+    ]
+  },
+  "Global External Module": {
+    "prefix": ["@bs", "external"],
+    "body": [
+      "[@scope \"${1:Math}\"] [@val] external ${2:random}: ${3:unit => float} = \"${4:random}\";"
+    ]
+  },
+  "JS Module External": {
+    "prefix": ["@bs", "external"],
+    "body": [
+      "[@module \"${1:path}\"] external ${2:dirname}: ${3:string => string} = \"${4:dirname}\";"
+    ]
+  },
+  "JS Module Default External": {
+    "prefix": ["@bs", "external"],
+    "body": [
+      "[@module] external ${1:leftPad}: ${2:(string, int) => string} = \"${3:leftPad}\";"
+    ]
+  }
+}

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -18,4 +18,7 @@ export let bsconfigPartialPath = "bsconfig.json";
 export let compilerLogPartialPath = path.join("lib", "bs", ".compiler.log");
 export let resExt = ".res";
 export let resiExt = ".resi";
+export let reExt = ".re";
+export let reiExt = ".rei";
+export let sourceExts = [resExt, resiExt, reExt, reiExt];
 export let startBuildAction = "Start Build";


### PR DESCRIPTION
Thanks a lot for your work on this extension! Devtools and the new syntax work great, even better than my experience with reason-language-server. I've added basic Reason support based on reason-language-server. There's still some modules in our project that we haven't migrated to Reason, and it is really handy to be able to use this new and improved VSCode tooling on our legacy modules as well.