### PR TITLE
Tweak bsc partial path.

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -3,12 +3,9 @@ import * as path from "path";
 // See https://microsoft.github.io/language-server-protocol/specification Abstract Message
 // version is fixed to 2.0
 export let jsonrpcVersion = "2.0";
-export let bscPartialPath = path.join(
-	"node_modules",
-	"bs-platform",
-	process.platform,
-	"bsc.exe"
-);
+// can't use the native bsc, different package managers and project layouts (e.g. yarn workspace)
+// might put the platform specific binaries in an unknown location
+export let bscPartialPath = path.join("node_modules", ".bin", "bsc");
 // can't use the native bsb since we might need the watcher -w flag, which is only in the js wrapper
 // export let bsbPartialPath = path.join('node_modules', 'bs-platform', process.platform, 'bsb.exe');
 export let bsbPartialPath = path.join("node_modules", ".bin", "bsb");


### PR DESCRIPTION
The platform specific bsc might be in an unknown location. An example of this scheme is a variant of monorepos setup through yarn workspaces. The only guarantee we have is the `bsc` binary exposed at the root of the [project](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bin)