### PR TITLE
fix watcher race condition

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -108,7 +108,7 @@ let deleteProjectDiagnostics = (projectRootPath: string) => {
 let compilerLogsWatcher = chokidar
   .watch([], {
     awaitWriteFinish: {
-      stabilityThreshold: 500,
+      stabilityThreshold: 1,
     },
   })
   .on("all", (_e, changedPath) => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -105,9 +105,15 @@ let deleteProjectDiagnostics = (projectRootPath: string) => {
   }
 };
 
-let compilerLogsWatcher = chokidar.watch([]).on("all", (_e, changedPath) => {
-  sendUpdatedDiagnostics();
-});
+let compilerLogsWatcher = chokidar
+  .watch([], {
+    awaitWriteFinish: {
+      stabilityThreshold: 500,
+    },
+  })
+  .on("all", (_e, changedPath) => {
+    sendUpdatedDiagnostics();
+  });
 let stopWatchingCompilerLog = () => {
   // TODO: cleanup of compilerLogs?
   compilerLogsWatcher.close();


### PR DESCRIPTION
see issue #55
on some sytems the `.compiler.log` was not readable after
_chokidar_ called _sendUpdateDiagnostics_. Setting
_awaitWriteFinish_ as an option fixes the issue