### PR TITLE
Add support for jsx html element highlights

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -325,7 +325,23 @@
               "name": "entity.name.namespace"
             }
           }
-        }
+        },
+        {
+          "match": "<(a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|head|header|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|menu|menuitem|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|section|select|small|source|span|strong|style|sub|summary|sup|table|tbody|td|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr|circle|clipPath|defs|ellipse|g|line|linearGradient|mask|path|pattern|polygon|polyline|radialGradient|rect|stop|svg|text|tspan)(>|\\s+)",
+          "captures": {
+            "1": {
+              "name": "entity.name.tag"
+            }
+          }
+        },
+        {
+          "match": "</(a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|head|header|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|menu|menuitem|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|section|select|small|source|span|strong|style|sub|summary|sup|table|tbody|td|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr|circle|clipPath|defs|ellipse|g|line|linearGradient|mask|path|pattern|polygon|polyline|radialGradient|rect|stop|svg|text|tspan)>",
+          "captures": {
+            "1": {
+              "name": "entity.name.tag"
+            }
+          }
+        }        
       ]
     },
     "openOrIncludeModule": {


### PR DESCRIPTION
I'm not sure if this is at all how you want to solve this. But since I spent some time toying with this approach, I might as well post it as a PR.

Some notes:
- Regex matches all html tags based on the existence of opening chevron and one of explicitly listed tag names. The opening tag then expects either closing chevron or at least one whitespace character (to avoid collisions with type arguments)
- Closing tag works similarly except that it doesn't allow any content other than the tag name. 
- The tag list is just pasted from somewhere and is almost certainly not complete. I can figure out where to find a complete list if the approach is considered good otherwise.