### PR TITLE
Tweak bsc path algorithm.

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -4,11 +4,14 @@ import * as path from "path";
 // version is fixed to 2.0
 export let jsonrpcVersion = "2.0";
 export let bscPartialPath = path.join(
-	"node_modules",
-	"bs-platform",
-	process.platform,
-	"bsc.exe"
+  "node_modules",
+  "bs-platform",
+  process.platform,
+  "bsc.exe"
 );
+
+export let bscNodePartialPath = path.join("node_modules", ".bin", "bsc");
+
 // can't use the native bsb since we might need the watcher -w flag, which is only in the js wrapper
 // export let bsbPartialPath = path.join('node_modules', 'bs-platform', process.platform, 'bsb.exe');
 export let bsbPartialPath = path.join("node_modules", ".bin", "bsb");

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -425,11 +425,21 @@ process.on("message", (msg: m.Message) => {
           process.send!(fakeSuccessResponse);
           process.send!(response);
         } else {
+          let bscExists = false;
           let bscPath = path.join(projectRootPath, c.bscPartialPath);
-          if (!fs.existsSync(bscPath)) {
+          bscExists = fs.existsSync(bscPath);
+          if (!bscExists) {
+            // In certain cases the native bsc binaries might be put in an unknown location
+            // on the file system. Example: yarn workspaces.
+            // The only other guarantee we have is that the node bsc should be available in the
+            // project root + ./node_modules/.bin cf. package.json
+            bscPath = path.join(projectRootPath, c.bscNodePartialPath);
+            bscExists = fs.existsSync(bscPath);
+          }
+          if (!bscExists) {
             let params: p.ShowMessageParams = {
               type: p.MessageType.Error,
-              message: `Cannot find a nearby ${c.bscPartialPath}. It's needed for formatting.`,
+              message: `Cannot find a nearby ${c.bscNodePartialPath}. It's needed for formatting.`,
             };
             let response: m.NotificationMessage = {
               jsonrpc: c.jsonrpcVersion,


### PR DESCRIPTION
In certain cases the native bsc binaries might be put in an unknown location on the file system. Example: yarn workspaces. The only other guarantee we have is that the node bsc should be available in the `project root + ./node_modules/.bin` cf. package.json. See [npm package.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bin) or [yarn package.json](https://classic.yarnpkg.com/en/docs/package-json#bin) and [yarn run](https://classic.yarnpkg.com/en/docs/cli/run#toc-yarn-run-script)