### PR TITLE
Fix: Windows Executable Path

### DIFF
--- a/server/src/RescriptEditorSupport.ts
+++ b/server/src/RescriptEditorSupport.ts
@@ -36,11 +36,8 @@ export function runDumpCommand(
     let command =
       `"${executable.binaryPath}"` +
       " dump " +
-      executable.filePath +
-      ":" +
-      msg.params.position.line +
-      ":" +
-      msg.params.position.character;
+      `"${executable.filePath}:${msg.params.position.line}:${msg.params.position.character}"`;
+      
     exec(command, { cwd: executable.cwd }, function (_error, stdout, _stderr) {
       let result = JSON.parse(stdout);
       if (result && result[0]) {
@@ -64,14 +61,10 @@ export function runCompletionCommand(
     let tmpname = utils.createFileInTempDir();
     fs.writeFileSync(tmpname, code, { encoding: "utf-8" });
 
-    let command = 
+    let command =
       `"${executable.binaryPath}"` +
       " complete " +
-      executable.filePath +
-      ":" +
-      msg.params.position.line +
-      ":" +
-      msg.params.position.character +
+      `"${executable.filePath}:${msg.params.position.line}:${msg.params.position.character}"` +
       " " +
       tmpname;
 

--- a/server/src/RescriptEditorSupport.ts
+++ b/server/src/RescriptEditorSupport.ts
@@ -34,7 +34,7 @@ export function runDumpCommand(
     onResult(null);
   } else {
     let command =
-      `"executable.binaryPath"` +
+      `"${executable.binaryPath}"` +
       " dump " +
       executable.filePath +
       ":" +
@@ -64,8 +64,8 @@ export function runCompletionCommand(
     let tmpname = utils.createFileInTempDir();
     fs.writeFileSync(tmpname, code, { encoding: "utf-8" });
 
-    let command =
-      `"executable.binaryPath"` +
+    let command = 
+      `"${executable.binaryPath}"` +
       " complete " +
       executable.filePath +
       ":" +

--- a/server/src/RescriptEditorSupport.ts
+++ b/server/src/RescriptEditorSupport.ts
@@ -34,7 +34,7 @@ export function runDumpCommand(
     onResult(null);
   } else {
     let command =
-      executable.binaryPath +
+      `"executable.binaryPath"` +
       " dump " +
       executable.filePath +
       ":" +
@@ -65,7 +65,7 @@ export function runCompletionCommand(
     fs.writeFileSync(tmpname, code, { encoding: "utf-8" });
 
     let command =
-      executable.binaryPath +
+      `"executable.binaryPath"` +
       " complete " +
       executable.filePath +
       ":" +


### PR DESCRIPTION
From the Issue #78 
I gone through the Source Code for hours and fixed it by a workaround.
On Line [37](https://github.com/rescript-lang/rescript-vscode/blob/master/server/src/RescriptEditorSupport.ts#L37) and [68](https://github.com/rescript-lang/rescript-vscode/blob/master/server/src/RescriptEditorSupport.ts#L68), we are concatenating the strings. 
But it my scenario, my username in my system was `SHRI HARI` (space), so the command fails 😶

![image](https://user-images.githubusercontent.com/57325503/107070793-c5f38f80-6809-11eb-9f9c-9a0120bd5090.png)


So I fixed by enclosing the path with quotes  => ``"executable.binaryPath"``

