### PR TITLE
Fix keyword list specified in grammer

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -15,7 +15,7 @@
     },
     "RE_KEYWORDS": {
       "name": "keyword.control",
-      "match": "\\b(and|as|assert|begin|class|constraint|done|downto|exception|external|fun|functor|inherit|lazy|let|pub|mutable|new|nonrec|object|of|or|pri|rec|then|to|val|virtual|try|catch|finally|do|else|for|if|switch|while|import|library|export|module|in|raise|private)\\b"
+      "match": "\\b(and|as|assert|constraint|downto|else|exception|external|false|for|if|in|include|lazy|let|module|mutable|of|open|rec|switch|to|true|try|type|when|while|with)\\b"
     },
     "RE_LITERAL": {
       "name": "constant.language",


### PR DESCRIPTION
Some of keywords are from OCaml that are not from Rescript docs, Hence i filter out all keyword specified in docs from keyword list specified in grammer

Here is the fixes

List of keyword that were specified in grammer json but not in docs
`nonrec, val, then, fun, virtual, do, done, catch, begin, pub, or, library, class, new, finally, inherit, export, object, pri, private, import, raise, functor`

List of keyword that were specified in rescript docs but not in grammer json
`true, include, open, when, with, false, type`

