### PR TITLE
Add type, external, let word coloring && unit as constant

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -444,10 +444,6 @@
         {
           "match": "(?<=let rec )[a-z][a-z_A-Z_0-9_]*",
           "name": "entity.name.function"
-        },
-        {
-          "match": "(?<=let )[_][a-z][a-z_A-Z_0-9_]*",
-          "name": "comment"
         }
       ]
     },

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -434,15 +434,15 @@
     "variable-declaration": {
       "patterns": [
         {
-          "match": "(?<=external )[a-z][a-z_A-Z_0-9_]*",
+          "match": "(?<=external )[a-z_][0-9a-zA-Z_]*",
           "name": "entity.name.function"
         },
         {
-          "match": "(?<=let )[a-z][a-z_A-Z_0-9_]*",
+          "match": "(?<=let )[a-z_][0-9a-zA-Z_]*",
           "name": "entity.name.function"
         },
         {
-          "match": "(?<=let rec )[a-z][a-z_A-Z_0-9_]*",
+          "match": "(?<=let rec )[a-z_][0-9a-zA-Z_]*",
           "name": "entity.name.function"
         }
       ]
@@ -450,15 +450,15 @@
     "type-declaration": {
       "patterns": [
         {
-          "match": "(?<=type )\\b[a-z][a-z_A-Z_0-9_]*",
+          "match": "(?<=type )[a-z_][0-9a-zA-Z_]*",
           "name": "entity.name.function"
         },
         {
-          "match": "(?<=and )\\b[a-z][a-z_A-Z_0-9_]*",
+          "match": "(?<=and )[a-z_][0-9a-zA-Z_]*",
           "name": "entity.name.function"
         },
         {
-          "match": "(?<=type rec )[a-z][a-z_A-Z_0-9_]*",
+          "match": "(?<=type rec )[a-z_][0-9a-zA-Z_]*",
           "name": "entity.name.function"
         }
       ]

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -431,7 +431,7 @@
         }
       ]
     },
-    "variable-declaration": {
+    "variableDeclaration": {
       "patterns": [
         {
           "match": "(?<=external )[a-z_][0-9a-zA-Z_]*",
@@ -447,7 +447,7 @@
         }
       ]
     },
-    "type-declaration": {
+    "typeDeclaration": {
       "patterns": [
         {
           "match": "(?<=type )[a-z_][0-9a-zA-Z_]*",
@@ -460,6 +460,14 @@
         {
           "match": "(?<=type rec )[a-z_][0-9a-zA-Z_]*",
           "name": "entity.name.function"
+        }
+      ]
+    },
+    "recordProperty": {
+      "patterns": [
+        {
+          "name": "variable.object.property",
+          "match": "([a-z_][0-9a-zA-Z_]*(?=:))"
         }
       ]
     }
@@ -526,10 +534,10 @@
       "include": "#punctuations"
     },
     {
-      "include": "#type-declaration"
+      "include": "#typeDeclaration"
     },
     {
-      "include": "#variable-declaration"
+      "include": "#variableDeclaration"
     }
   ]
 }

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -21,6 +21,10 @@
       "name": "constant.language",
       "match": "\\b(true|false)\\b"
     },
+    "RE_UNIT": {
+      "name": "constant.language",
+      "match": "\\(\\)"
+    },
     "commentLine": {
       "match": "//.*",
       "name": "comment.line"
@@ -98,6 +102,9 @@
       "patterns": [
         {
           "include": "#RE_LITERAL"
+        },
+        {
+          "include": "#RE_UNIT"
         }
       ]
     },
@@ -430,6 +437,46 @@
           ]
         }
       ]
+    },
+    "variable-declaration": {
+      "patterns": [
+        {
+          "match": "(?<=external )[a-z][a-z_A-Z_0-9_]*",
+          "name": "entity.name.function"
+        },
+        {
+          "match": "(?<=let )[a-z][a-z_A-Z_0-9_]*",
+          "name": "entity.name.function"
+        },
+
+        {
+          "match": "(?<=let rec )[a-z][a-z_A-Z_0-9_]*",
+          "name": "entity.name.function"
+        },
+
+        {
+          "match": "(?<=let )[_][a-z][a-z_A-Z_0-9_]*",
+          "name": "comment"
+        }
+      ]
+    },
+    "type-declaration": {
+      "patterns": [
+        {
+          "match": "(?<=type )\\b[a-z][a-z_A-Z_0-9_]*",
+          "name": "entity.name.function"
+        },
+
+        {
+          "match": "(?<=and )\\b[a-z][a-z_A-Z_0-9_]*",
+          "name": "entity.name.function"
+        },
+
+        {
+          "match": "(?<=type rec )[a-z][a-z_A-Z_0-9_]*",
+          "name": "entity.name.function"
+        }
+      ]
     }
   },
   "patterns": [
@@ -470,6 +517,10 @@
       "include": "#jsx"
     },
     {
+      "include": "#jsx-attributes"
+    },
+
+    {
       "include": "#operator"
     },
     {
@@ -492,6 +543,9 @@
     },
     {
       "include": "#punctuations"
-    }
+    },
+
+    { "include": "#type-declaration" },
+    { "include": "#variable-declaration" }
   ]
 }

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -51,31 +51,27 @@
         },
         {
           "match": "\\,",
-          "name": "punctuation.separator"
+          "name": "constant.character punctuation.separator"
         },
         {
           "match": "\\?|:",
-          "name": "punctuation.separator"
-        },
-        {
-          "match": "\\|(?!\\|)",
-          "name": "punctuation.separator"
+          "name": "constant.character punctuation.separator"
         },
         {
           "match": "\\{",
-          "name": "punctuation.section.braces.begin"
+          "name": "constant.character punctuation.section.braces.begin"
         },
         {
           "match": "\\}",
-          "name": "punctuation.section.braces.end"
+          "name": "constant.character punctuation.section.braces.end"
         },
         {
           "match": "\\(",
-          "name": "punctuation.section.parens.begin"
+          "name": "constant.character punctuation.section.parens.begin"
         },
         {
           "match": "\\)",
-          "name": "punctuation.section.parens.end"
+          "name": "constant.character punctuation.section.parens.end"
         }
       ]
     },
@@ -234,11 +230,11 @@
       "patterns": [
         {
           "match": "\\[",
-          "name": "punctuation.section.brackets.begin"
+          "name": "constant.character punctuation.section.brackets.begin"
         },
         {
           "match": "\\]",
-          "name": "punctuation.section.brackets.end"
+          "name": "constant.character punctuation.section.brackets.end"
         }
       ]
     },
@@ -251,13 +247,13 @@
               "name": "keyword"
             },
             "2": {
-              "name": "punctuation.section.braces.begin"
+              "name": "constant.character punctuation.section.braces.begin"
             }
           }
         },
         {
           "match": "\\}",
-          "name": "punctuation.section.braces.end"
+          "name": "constant.character punctuation.section.braces.end"
         }
       ]
     },
@@ -267,13 +263,13 @@
           "match": "\\b[a-z_][0-9a-zA-Z_]*(\\[)",
           "captures": {
             "1": {
-              "name": "punctuation.section.brackets.begin"
+              "name": "constant.character punctuation.section.brackets.begin"
             }
           }
         },
         {
           "match": "\\]",
-          "name": "punctuation.section.brackets.end"
+          "name": "constant.character punctuation.section.brackets.end"
         }
       ]
     },

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -21,10 +21,6 @@
       "name": "constant.language",
       "match": "\\b(true|false)\\b"
     },
-    "RE_UNIT": {
-      "name": "constant.language",
-      "match": "\\(\\)"
-    },
     "commentLine": {
       "match": "//.*",
       "name": "comment.line"
@@ -102,9 +98,6 @@
       "patterns": [
         {
           "include": "#RE_LITERAL"
-        },
-        {
-          "include": "#RE_UNIT"
         }
       ]
     },

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -224,7 +224,7 @@
               "name": "punctuation.definition.keyword"
             },
             "3": {
-              "name": "variable.function variable.other"
+              "name": "variable.function variable.other variable.other.enummember constant.other.symbol"
             }
           }
         }

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -538,6 +538,9 @@
     },
     {
       "include": "#variableDeclaration"
+    },
+    {
+      "include": "#recordProperty"
     }
   ]
 }

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -448,12 +448,10 @@
           "match": "(?<=let )[a-z][a-z_A-Z_0-9_]*",
           "name": "entity.name.function"
         },
-
         {
           "match": "(?<=let rec )[a-z][a-z_A-Z_0-9_]*",
           "name": "entity.name.function"
         },
-
         {
           "match": "(?<=let )[_][a-z][a-z_A-Z_0-9_]*",
           "name": "comment"
@@ -466,12 +464,10 @@
           "match": "(?<=type )\\b[a-z][a-z_A-Z_0-9_]*",
           "name": "entity.name.function"
         },
-
         {
           "match": "(?<=and )\\b[a-z][a-z_A-Z_0-9_]*",
           "name": "entity.name.function"
         },
-
         {
           "match": "(?<=type rec )[a-z][a-z_A-Z_0-9_]*",
           "name": "entity.name.function"
@@ -517,10 +513,6 @@
       "include": "#jsx"
     },
     {
-      "include": "#jsx-attributes"
-    },
-
-    {
       "include": "#operator"
     },
     {
@@ -544,8 +536,11 @@
     {
       "include": "#punctuations"
     },
-
-    { "include": "#type-declaration" },
-    { "include": "#variable-declaration" }
+    {
+      "include": "#type-declaration"
+    },
+    {
+      "include": "#variable-declaration"
+    }
   ]
 }


### PR DESCRIPTION
Hi, 

First things first. I want  to thank you all for your work on this amazing project and this extension. 

And now the rest.

### Description
One thing that i want to point straight away, I rarely wrote any regexp so sorry in advance if those changes are just garbage 😅 
But I look through on files in my project and I think i didn't break any working grammar.

Presented code is mostly from rescript/reason docs, I think i don't miss any possible scenario for using let, external, and type.

### What changed

When working with .re files and with vscode-ocaml-platform I have (imo) beatiful syntax highlighting:
![reason](https://user-images.githubusercontent.com/19210348/108774273-bd1bf100-755f-11eb-9444-4c0728b3836a.png)

and rescript file look like this:

![one-pro-before](https://user-images.githubusercontent.com/19210348/108774994-c48fca00-7560-11eb-8bb4-ba3f852dc864.png)

This pr is mostly about 2 changes:
1. Coloring word after `let, type, external`but also `type rec, let rec` keyword as `entity.name.function` (the same way vscode-ocaml-platform does it).
The word I am matching is `[a-z][a-z_A-Z_0-9_]*` - this (i hope) match every valid name for type and let name declaration.

NOTE: one small change that I thought would be nice to have is match variable started with `_ `as comment (line 22 on screens) it looks very cool in my current One Dark Pro theme. (the same way as ocaml-platform) 

2. Coloring unit - `()` - (again inspired by vscode-ocaml-platform)

In my actual theme **One Dark Pro**

Before
![one-pro-before](https://user-images.githubusercontent.com/19210348/108774994-c48fca00-7560-11eb-8bb4-ba3f852dc864.png)

After
![one-pro-after](https://user-images.githubusercontent.com/19210348/108775233-1b959f00-7561-11eb-9f2e-567db146eafe.png)

**Dark+**

Before:
![dark-plus-before](https://user-images.githubusercontent.com/19210348/108775290-2d774200-7561-11eb-8bdd-3fb0d3acaf1d.png)

After:
![dark-plus-after](https://user-images.githubusercontent.com/19210348/108775334-3cf68b00-7561-11eb-986a-28906760e529.png)



