### PR TITLE
Fix JSON unicode string

### DIFF
--- a/analysis/.depend
+++ b/analysis/.depend
@@ -36,7 +36,7 @@ src/Process_406.cmx : src/SharedTypes.cmx src/Shared.cmx \
     src/ProcessExtra.cmx src/ProcessCmt.cmx src/PrintType.cmx \
     src/Process_406.cmi
 src/Process_406.cmi : src/Uri2.cmx src/SharedTypes.cmx
-src/Protocol.cmx :
+src/Protocol.cmx : src/vendor/Json.cmx
 src/Query.cmx : src/SharedTypes.cmx src/Log.cmx src/Infix.cmx
 src/References.cmx : src/Utils.cmx src/Uri2.cmx src/SharedTypes.cmx \
     src/Query.cmx src/Log.cmx src/Infix.cmx

--- a/analysis/src/Protocol.ml
+++ b/analysis/src/Protocol.ml
@@ -42,7 +42,7 @@ let stringifyRange r =
 
 let stringifyMarkupContent (m: markupContent) =
   Printf.sprintf {|{"kind": "%s", "value": "%s"}|}
-  m.kind (String.escaped m.value)
+  m.kind (Json.escape m.value)
 
 let stringifyCompletionItem c =
   Printf.sprintf {|{
@@ -52,19 +52,19 @@ let stringifyCompletionItem c =
     "detail": "%s",
     "documentation": %s
   }|}
-  (String.escaped c.label)
+  (Json.escape c.label)
   c.kind
   (c.tags |> List.map string_of_int |> array)
-  (String.escaped c.detail)
+  (Json.escape c.detail)
   (stringifyMarkupContent c.documentation)
 
 let stringifyHover h =
   Printf.sprintf {|{"contents": "%s"}|}
-  (String.escaped h.contents)
+  (Json.escape h.contents)
 
 let stringifyLocation h =
   Printf.sprintf {|{"uri": "%s", "range": %s}|}
-  (String.escaped h.uri)
+  (Json.escape h.uri)
   (stringifyRange h.range)
 
 let null = "null"

--- a/analysis/tests/src/expected/Complete.res.txt
+++ b/analysis/tests/src/expected/Complete.res.txt
@@ -382,7 +382,7 @@ Complete tests/src/Complete.res 23:2
     "kind": 12,
     "tags": [],
     "detail": "t => t",
-    "documentation": {"kind": "markdown", "value": "`toUpperCase str` converts `str` to upper case using the locale-insensitive case mappings in the Unicode Character Database. Notice that the conversion can expand the number of letters in the result; for example the German `\195\159` capitalizes to two `S`es in a row.\n\n```ml\ntoUpperCase \"abc\" = \"ABC\";;\ntoUpperCase {js|Stra\195\159e|js} = {js|STRASSE|js};;\ntoLowerCase {js|\207\128\207\130|js} = {js|\206\160\206\163|js};;\n```\n\n\n\njs_string2.ml:601"}
+    "documentation": {"kind": "markdown", "value": "`toUpperCase str` converts `str` to upper case using the locale-insensitive case mappings in the Unicode Character Database. Notice that the conversion can expand the number of letters in the result; for example the German `ß` capitalizes to two `S`es in a row.\n\n```ml\ntoUpperCase \"abc\" = \"ABC\";;\ntoUpperCase {js|Straße|js} = {js|STRASSE|js};;\ntoLowerCase {js|πς|js} = {js|ΠΣ|js};;\n```\n\n\n\njs_string2.ml:601"}
   }]
 
 Complete tests/src/Complete.res 27:2


### PR DESCRIPTION
String.escaped doesn't support unicode... so we're gonna use Json.escape instead.

Fixes #114
