### PR TITLE
Hover different on ocaml files.

### DIFF
--- a/analysis/tests/src/Hover.res
+++ b/analysis/tests/src/Hover.res
@@ -30,7 +30,7 @@ module HoverInsideModuleWithComponent = {
   let make = () => React.null
 }
 
-@ocaml.doc("Doc comment for functionWithTypeAnnotation")
+@ocaml.doc("Doc comment **for** functionWithTypeAnnotation")
 let functionWithTypeAnnotation : unit => int = () => 1
 //  ^hov
 
@@ -44,3 +44,6 @@ let make2 = (~name:string) => React.string(name)
 
 let num = 34
 //        ^hov
+
+let withAnnot = OcamlFile.functionWithTypeAnnotation
+//                           ^hov

--- a/analysis/tests/src/OcamlFile.ml
+++ b/analysis/tests/src/OcamlFile.ml
@@ -1,0 +1,3 @@
+let functionWithTypeAnnotation () = 1
+[@@ocaml.doc "Doc comment **for** functionWithTypeAnnotation"]
+

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -17,7 +17,7 @@ Hover tests/src/Hover.res 26:6
 {"contents": "```rescript\nint\n```"}
 
 Hover tests/src/Hover.res 33:4
-{"contents": "```rescript\nunit => int\n```\n\nDoc comment for functionWithTypeAnnotation"}
+{"contents": "```rescript\nunit => int\n```\n\nDoc comment **for** functionWithTypeAnnotation"}
 
 Hover tests/src/Hover.res 37:13
 {"contents": "```rescript\nstring\n```"}
@@ -27,4 +27,7 @@ Hover tests/src/Hover.res 41:13
 
 Hover tests/src/Hover.res 44:10
 {"contents": "```rescript\nint\n```"}
+
+Hover tests/src/Hover.res 47:29
+{"contents": "```rescript\nunit => int\n```\n\nDoc comment **for** functionWithTypeAnnotation"}
 


### PR DESCRIPTION
The hover command gives identical results for hover on doc comments in .res and .ml files.
Hovever vscode shows markdown only for those from .res files.