### PR TITLE
Add autocomplete of JSX props without test letter.

### DIFF
--- a/analysis/src/PartialParser.ml
+++ b/analysis/src/PartialParser.ml
@@ -175,6 +175,11 @@ let findCompletable text offset =
         Some (Clabel (funPath, labelPrefix))
       | '@' -> Some (Cdecorator (suffix i))
       | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' -> loop (i - 1)
+      | ' ' when i = offset - 1 -> (
+        match findJsxContext text (offset - 1) with
+        | None -> None
+        | Some componentName ->
+          Some (Cjsx (Str.split (Str.regexp_string ".") componentName, "")))
       | _ -> if i = offset - 1 then None else Some (mkPath (suffix i))
   in
   if offset > String.length text || offset = 0 then None else loop (offset - 1)

--- a/analysis/src/PartialParser.ml
+++ b/analysis/src/PartialParser.ml
@@ -176,6 +176,7 @@ let findCompletable text offset =
       | '@' -> Some (Cdecorator (suffix i))
       | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' -> loop (i - 1)
       | ' ' when i = offset - 1 -> (
+        (* autocomplete with no id: check if inside JSX *)
         match findJsxContext text (offset - 1) with
         | None -> None
         | Some componentName ->

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -11,5 +11,4 @@ let d = <M first="abc" />
 
 //^com <M second="abc" f
 
-let e = <M   first="abc" />
-//         ^com
+//^com let e = <M 

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -10,3 +10,6 @@ let d = <M first="abc" />
 
 
 //^com <M second="abc" f
+
+let e = <M   first="abc" />
+//         ^com

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -25,3 +25,6 @@ Complete tests/src/Jsx.res 10:2
     "documentation": null
   }]
 
+Complete tests/src/Jsx.res 13:11
+[]
+

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -2,7 +2,31 @@ Definition tests/src/Jsx.res 5:9
 {"uri": "Jsx.res", "range": {"start": {"line": 2, "character": 6}, "end": {"line": 2, "character": 10}}}
 
 Complete tests/src/Jsx.res 7:2
-[]
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }, {
+    "label": "first",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }, {
+    "label": "fun",
+    "kind": 4,
+    "tags": [],
+    "detail": "option<string>",
+    "documentation": null
+  }, {
+    "label": "second",
+    "kind": 4,
+    "tags": [],
+    "detail": "option<string>",
+    "documentation": null
+  }]
 
 Complete tests/src/Jsx.res 10:2
 [{
@@ -25,6 +49,30 @@ Complete tests/src/Jsx.res 10:2
     "documentation": null
   }]
 
-Complete tests/src/Jsx.res 13:11
-[]
+Complete tests/src/Jsx.res 12:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }, {
+    "label": "first",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }, {
+    "label": "fun",
+    "kind": 4,
+    "tags": [],
+    "detail": "option<string>",
+    "documentation": null
+  }, {
+    "label": "second",
+    "kind": 4,
+    "tags": [],
+    "detail": "option<string>",
+    "documentation": null
+  }]
 


### PR DESCRIPTION
The autocomplete command does not support this yet, as the example shows.

https://github.com/rescript-lang/rescript-vscode/issues/147