### PR TITLE
Re-bump rescript version; simplify makefile

### DIFF
--- a/analysis/Makefile
+++ b/analysis/Makefile
@@ -35,10 +35,8 @@ dce: build-native
 tests/node_modules/.bin/rescript:
 	@cd tests && npm install
 
-tests/lib/.compiler.log: tests/node_modules/.bin/rescript
-	@cd tests && node_modules/.bin/rescript build -with-deps
-
-test: dce tests/lib/.compiler.log
+test: dce tests/node_modules/.bin/rescript
+	@cd tests && node_modules/.bin/rescript
 	./test.sh
 
 clean:

--- a/analysis/tests/package-lock.json
+++ b/analysis/tests/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "rescript": "^9.1.1"
+        "rescript": "9.1.2"
       },
       "devDependencies": {
         "@rescript/react": "^0.10.2"
@@ -96,12 +96,11 @@
       }
     },
     "node_modules/rescript": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-9.1.1.tgz",
-      "integrity": "sha512-c+zR5aZ5mXDpAx6oyS61t4sUPiq2VXgHigilYSMazDLp1uUGbf2JvgbSfRJFaKAjfsTKcohJyH0vtdihhdZmMA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-9.1.2.tgz",
+      "integrity": "sha512-4wHvTDv3nyYnAPJHcg1RGG8z7u3HDiBf6RN3P/dITDv859Qo35aKOzJWQtfBzbAs0EKNafLqei3TnUqiAv6BwQ==",
       "hasInstallScript": true,
       "bin": {
-        "bsb": "bsb",
         "bsc": "bsc",
         "bsrefmt": "bsrefmt",
         "bstracing": "lib/bstracing",
@@ -183,9 +182,9 @@
       }
     },
     "rescript": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-9.1.1.tgz",
-      "integrity": "sha512-c+zR5aZ5mXDpAx6oyS61t4sUPiq2VXgHigilYSMazDLp1uUGbf2JvgbSfRJFaKAjfsTKcohJyH0vtdihhdZmMA=="
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-9.1.2.tgz",
+      "integrity": "sha512-4wHvTDv3nyYnAPJHcg1RGG8z7u3HDiBf6RN3P/dITDv859Qo35aKOzJWQtfBzbAs0EKNafLqei3TnUqiAv6BwQ=="
     },
     "scheduler": {
       "version": "0.20.2",

--- a/analysis/tests/package.json
+++ b/analysis/tests/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {},
   "dependencies": {
-    "rescript": "^9.1.1"
+    "rescript": "9.1.2"
   },
   "devDependencies": {
     "@rescript/react": "^0.10.2"


### PR DESCRIPTION
This was done in a1074e150bc3918e336c32df9ec5f3f0f9d2539a but lost in a4236375a56ffb637846ad43f8f297c874e7e456

Fixes #126.

Since no-op build is cheap, I took the occasion to simplify the makefile incrementalism (which was kinda wrong before too). Gotta love perf + full build.
