### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         node-version: 14.4.0
 
-    - run: npm ci
+    - run: npm install
     - run: npm run compile
 
     # These 2 runs (or just the second?) are for when you have opam dependencies. We don't.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         node-version: 14.4.0
 
-    - run: npm install
+    - run: npm ci
     - run: npm run compile
 
     # These 2 runs (or just the second?) are for when you have opam dependencies. We don't.

--- a/analysis/src/BuildSystem.ml
+++ b/analysis/src/BuildSystem.ml
@@ -7,11 +7,11 @@ open Infix
 
 let getBsPlatformDir rootPath =
   let result =
-    ModuleResolution.resolveNodeModulePath ~startPath:rootPath "bs-platform"
+    ModuleResolution.resolveNodeModulePath ~startPath:rootPath "rescript"
   in
   let result =
     if result = None then
-      ModuleResolution.resolveNodeModulePath ~startPath:rootPath "rescript"
+      ModuleResolution.resolveNodeModulePath ~startPath:rootPath "bs-platform"
     else result
   in
   match result with

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -172,7 +172,8 @@ let documentSymbol ~path =
           | Module (Structure contents) -> (Module, getItems contents)
           | Module (Ident _) -> (Module, [])
         in
-        (txt, extentLoc, item) :: siblings
+        if extentLoc.loc_ghost then siblings
+        else (txt, extentLoc, item) :: siblings
       in
       let x = topLevel |> List.map fn |> List.concat in
       x

--- a/analysis/test.sh
+++ b/analysis/test.sh
@@ -15,5 +15,6 @@ if [[ $diff = "" ]]; then
   printf "${successGreen}✅ No unstaged tests difference.${reset}\n"
 else
   printf "${warningYellow}⚠️ There are unstaged differences in tests/! Did you break a test?\n${diff}\n${reset}"
+  git --no-pager diff tests/src/expected
   exit 1
 fi

--- a/analysis/test.sh
+++ b/analysis/test.sh
@@ -2,7 +2,7 @@ function exp {
   echo "$(dirname $1)/expected/$(basename $1).txt"
 }
 
-for file in tests/src/*.res[i]; do
+for file in tests/src/*.res*; do
   ./rescript-editor-analysis.exe test $file &> $(exp $file)
 done
 

--- a/analysis/test.sh
+++ b/analysis/test.sh
@@ -2,7 +2,7 @@ function exp {
   echo "$(dirname $1)/expected/$(basename $1).txt"
 }
 
-for file in tests/src/*.res*; do
+for file in tests/src/*.{res,resi}; do
   ./rescript-editor-analysis.exe test $file &> $(exp $file)
 done
 

--- a/analysis/tests/src/expected/Auto.res.txt
+++ b/analysis/tests/src/expected/Auto.res.txt
@@ -1,3 +1,3 @@
 Hover tests/src/Auto.res 2:13
-{"contents": "```rescript\n(Belt.List.t<'a>, 'a => 'b) => Belt.List.t<'b>\n```\n\n\n    [map xs f]\n\n    return the list obtained by applying [f] to each element of [xs]\n\n   @example {[\n     map [1;2] (fun x-> x + 1) = [3;4]\n   ]}\n"}
+{"contents": "```rescript\n(Belt.List.t<'a>, 'a => 'b) => Belt.List.t<'b>\n```\n\n\n  `map xs f`\n\n  **return** the list obtained by applying `f` to each element of `xs`\n\n  ```\n  map [1;2] (fun x-> x + 1) = [3;4]\n  ```\n"}
 

--- a/analysis/tests/src/expected/Complete.res.txt
+++ b/analysis/tests/src/expected/Complete.res.txt
@@ -4,19 +4,19 @@ Complete tests/src/Complete.res 0:2
     "kind": 12,
     "tags": [],
     "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": " [mapReverse xs f]\n\n    Equivalent to [reverse (map xs f)]\n\n    @example {[\n      mapReverse [3;4;5] (fun x -> x * x) = [25;16;9];;\n    ]}\n"}
+    "documentation": {"kind": "markdown", "value": "\n  `mapReverse xs f`\n\n  Equivalent to `reverse (map xs f)`\n\n  ```\n  mapReverse [3;4;5] (fun x -> x * x) = [25;16;9];;\n  ```\n"}
   }, {
     "label": "makeBy",
     "kind": 12,
     "tags": [],
     "detail": "(int, int => 'a) => t<'a>",
-    "documentation": {"kind": "markdown", "value": " [makeBy n f] \n\n    - return a list of length [n] with element [i] initialized with [f i]\n    - return the empty list if [n] is negative\n\n    @example {[\n      makeBy 5 (fun i -> i) = [0;1;2;3;4];;\n      makeBy 5 (fun i -> i * i) = [0;1;4;9;16];;\n    ]}\n"}
+    "documentation": {"kind": "markdown", "value": "\n  `makeBy n f`\n\n  **return** a list of length `n` with element `i` initialized with `f i`\n\n  **return** the empty list if `n` is negative\n\n  ```\n  makeBy 5 (fun i -> i) = [0;1;2;3;4];;\n  makeBy 5 (fun i -> i * i) = [0;1;4;9;16];;\n  ```\n"}
   }, {
     "label": "make",
     "kind": 12,
     "tags": [],
     "detail": "(int, 'a) => t<'a>",
-    "documentation": {"kind": "markdown", "value": "  [make n v] \n\n     - return a list of length [n] with each element filled with value [v]  \n     - return the empty list if [n] is negative\n\n     @example {[\n       make 3 1 =  [1;1;1]\n     ]}\n"}
+    "documentation": {"kind": "markdown", "value": "\n  `make n v`\n\n  **return** a list of length `n` with each element filled with value `v`\n\n  **return** the empty list if `n` is negative\n\n  ```\n  make 3 1 =  [1;1;1]\n  ```\n"}
   }, {
     "label": "mapReverse2U",
     "kind": 12,
@@ -28,7 +28,7 @@ Complete tests/src/Complete.res 0:2
     "kind": 12,
     "tags": [],
     "detail": "(t<'a>, 'a => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": "\n    [map xs f]\n\n    return the list obtained by applying [f] to each element of [xs]\n\n   @example {[\n     map [1;2] (fun x-> x + 1) = [3;4]\n   ]}\n"}
+    "documentation": {"kind": "markdown", "value": "\n  `map xs f`\n\n  **return** the list obtained by applying `f` to each element of `xs`\n\n  ```\n  map [1;2] (fun x-> x + 1) = [3;4]\n  ```\n"}
   }, {
     "label": "mapWithIndexU",
     "kind": 12,
@@ -52,13 +52,13 @@ Complete tests/src/Complete.res 0:2
     "kind": 12,
     "tags": [],
     "detail": "(t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>",
-    "documentation": {"kind": "markdown", "value": " [mapReverse2 xs ys f]\n\n    equivalent to [reverse (zipBy xs ys f)]    \n\n    @example {[\n      mapReverse2 [1;2;3] [1;2] (+) = [4;2]\n    ]}\n"}
+    "documentation": {"kind": "markdown", "value": "\n  `mapReverse2 xs ys f`\n\n  equivalent to `reverse (zipBy xs ys f)`\n\n  ```\n  mapReverse2 [1;2;3] [1;2] (+) = [4;2]\n  ```\n"}
   }, {
     "label": "mapWithIndex",
     "kind": 12,
     "tags": [],
     "detail": "(t<'a>, (int, 'a) => 'b) => t<'b>",
-    "documentation": {"kind": "markdown", "value": " [mapWithIndex xs f] applies [f] to each element of [xs]. Function [f] takes two arguments:\n    the index starting from 0 and the element from [xs].\n\n    @example {[\n      mapWithIndex [1;2;3] (fun i x -> i + x) =\n      [0 + 1; 1 + 2; 2 + 3 ]\n    ]}\n"}
+    "documentation": {"kind": "markdown", "value": "\n  `mapWithIndex xs f` applies `f` to each element of `xs`. Function `f` takes two arguments:\n  the index starting from 0 and the element from `xs`.\n\n  ```\n  mapWithIndex [1;2;3] (fun i x -> i + x) =\n    [0 + 1; 1 + 2; 2 + 3 ]\n  ```\n"}
   }, {
     "label": "mapReverseU",
     "kind": 12,
@@ -382,7 +382,7 @@ Complete tests/src/Complete.res 23:2
     "kind": 12,
     "tags": [],
     "detail": "t => t",
-    "documentation": {"kind": "markdown", "value": "\n  [toUpperCase str] converts [str] to upper case using the locale-insensitive case mappings in the Unicode Character Database. Notice that the conversion can expand the number of letters in the result; for example the German [ß] capitalizes to two [S]es in a row.\n\n@example {[\n  toUpperCase \"abc\" = \"ABC\";;\n  toUpperCase {js|Straße|js} = {js|STRASSE|js};;\n  toLowerCase {js|πς|js} = {js|ΠΣ|js};;\n]}\n"}
+    "documentation": {"kind": "markdown", "value": "\n  `toUpperCase str` converts `str` to upper case using the locale-insensitive case mappings in the Unicode Character Database. Notice that the conversion can expand the number of letters in the result; for example the German `ß` capitalizes to two `S`es in a row.\n\n  ```\n  toUpperCase \"abc\" = \"ABC\";;\n  toUpperCase {js|Straße|js} = {js|STRASSE|js};;\n  toLowerCase {js|πς|js} = {js|ΠΣ|js};;\n  ```\n"}
   }]
 
 Complete tests/src/Complete.res 27:2
@@ -391,13 +391,13 @@ Complete tests/src/Complete.res 27:2
     "kind": 12,
     "tags": [],
     "detail": "(option<'a>, option<'b>, (. 'a, 'b) => bool) => bool",
-    "documentation": {"kind": "markdown", "value": "\n   Uncurried version of [eq]\n"}
+    "documentation": {"kind": "markdown", "value": "\n   Uncurried version of `eq`\n"}
   }, {
     "label": "Belt.Option.eq",
     "kind": 12,
     "tags": [],
     "detail": "(option<'a>, option<'b>, ('a, 'b) => bool) => bool",
-    "documentation": {"kind": "markdown", "value": "\n   [eq optValue1 optvalue2 predicate]\n\n   Evaluates two optional values for equality with respect to a predicate function.\n\n   If both [optValue1] and [optValue2] are [None], returns [true].\n\n   If one of the arguments is [Some value] and the other is [None], returns [false]\n\n   If arguments are [Some value1] and [Some value2], returns the result of [predicate value1 value2];\n   the [predicate] function must return a [bool]\n\n   @example {[\n     let clockEqual = (fun a b -> a mod 12 = b mod 12);;\n     eq (Some 3) (Some 15) clockEqual = true;;\n     eq (Some 3) None clockEqual = false;;\n     eq None (Some 3) clockEqual = false;;\n     eq None None clockEqual = true;;\n   ]}\n"}
+    "documentation": {"kind": "markdown", "value": "\n   `eq optValue1 optvalue2 predicate`\n\n   Evaluates two optional values for equality with respect to a predicate function.\n\n   If both `optValue1` and `optValue2` are `None`, returns `true`.\n\n   If one of the arguments is `Some value` and the other is `None`, returns `false`\n\n   If arguments are `Some value1` and `Some value2`, returns the result of `predicate value1 value2`;\n   the `predicate` function must return a `bool`\n\n   ```\n   let clockEqual = (fun a b -> a mod 12 = b mod 12);;\n   eq (Some 3) (Some 15) clockEqual = true;;\n   eq (Some 3) None clockEqual = false;;\n   eq None (Some 3) clockEqual = false;;\n   eq None None clockEqual = true;;\n   ```\n"}
   }]
 
 Complete tests/src/Complete.res 36:2
@@ -421,7 +421,7 @@ Complete tests/src/Complete.res 38:2
     "kind": 12,
     "tags": [],
     "detail": "(t<'a>, key) => 'a",
-    "documentation": {"kind": "markdown", "value": " [unsafeGet dict key] return the value if the [key] exists, \n    otherwise an {b undefined} value is returned. Must be used only \n    when the existence of a key is certain. (i.e. when having called [keys]\n    function previously. \n\n    @example {[\n      Array.iter (fun key -> Js.log (Js_dict.unsafeGet dic key)) (Js_dict.keys dict) \n    ]} \n"}
+    "documentation": {"kind": "markdown", "value": "\n  `unsafeGet dict key` return the value if the `key` exists,\n  otherwise an **undefined** value is returned. Must be used only\n  when the existence of a key is certain. (i.e. when having called `keys`\n  function previously.\n\n  ```\n  Array.iter (fun key -> Js.log (Js_dict.unsafeGet dic key)) (Js_dict.keys dict)\n  ```\n"}
   }, {
     "label": "unsafeDeleteKey",
     "kind": 12,

--- a/analysis/tests/src/expected/Complete.res.txt
+++ b/analysis/tests/src/expected/Complete.res.txt
@@ -527,6 +527,16 @@ DocumentSymbol tests/src/Complete.res
         "location": {"uri": "Complete.res", "range": {"start": {"line": 42, "character": 9}, "end": {"line": 46, "character": 3}}}
 },
 {
+        "name": "makeProps",
+        "kind": 12,
+        "location": {"uri": "Complete.res", "range": {"start": {"line": 0, "character": -1}, "end": {"line": 0, "character": -1}}}
+},
+{
+        "name": "make",
+        "kind": 12,
+        "location": {"uri": "Complete.res", "range": {"start": {"line": 0, "character": -1}, "end": {"line": 0, "character": -1}}}
+},
+{
         "name": "make",
         "kind": 12,
         "location": {"uri": "Complete.res", "range": {"start": {"line": 44, "character": 4}, "end": {"line": 45, "character": 57}}}

--- a/analysis/tests/src/expected/Complete.res.txt
+++ b/analysis/tests/src/expected/Complete.res.txt
@@ -527,16 +527,6 @@ DocumentSymbol tests/src/Complete.res
         "location": {"uri": "Complete.res", "range": {"start": {"line": 42, "character": 9}, "end": {"line": 46, "character": 3}}}
 },
 {
-        "name": "makeProps",
-        "kind": 12,
-        "location": {"uri": "Complete.res", "range": {"start": {"line": 0, "character": -1}, "end": {"line": 0, "character": -1}}}
-},
-{
-        "name": "make",
-        "kind": 12,
-        "location": {"uri": "Complete.res", "range": {"start": {"line": 0, "character": -1}, "end": {"line": 0, "character": -1}}}
-},
-{
         "name": "make",
         "kind": 12,
         "location": {"uri": "Complete.res", "range": {"start": {"line": 44, "character": 4}, "end": {"line": 45, "character": 57}}}

--- a/analysis/tests/src/expected/Definition.res.txt
+++ b/analysis/tests/src/expected/Definition.res.txt
@@ -8,5 +8,5 @@ Hover tests/src/Definition.res 14:14
 {"contents": "```rescript\n('a => 'b, list<'a>) => list<'b>\n```\n\n [List.map f [a1; ...; an]] applies function [f] to [a1, ..., an],\n   and builds the list [[f a1; ...; f an]]\n   with the results returned by [f].  Not tail-recursive. "}
 
 Hover tests/src/Definition.res 18:14
-{"contents": "```rescript\n(Belt.List.t<'a>, 'a => 'b) => Belt.List.t<'b>\n```\n\n\n    [map xs f]\n\n    return the list obtained by applying [f] to each element of [xs]\n\n   @example {[\n     map [1;2] (fun x-> x + 1) = [3;4]\n   ]}\n"}
+{"contents": "```rescript\n(Belt.List.t<'a>, 'a => 'b) => Belt.List.t<'b>\n```\n\n\n  `map xs f`\n\n  **return** the list obtained by applying `f` to each element of `xs`\n\n  ```\n  map [1;2] (fun x-> x + 1) = [3;4]\n  ```\n"}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "rescript-vscode",
 			"version": "1.0.8",
 			"hasInstallScript": true,
 			"license": "MIT",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -56,7 +56,6 @@
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",


### PR DESCRIPTION
For some reason, locally, bs-platform is resolved before rescript, and on CI there's no bs-platform. So on CI we have the newest doc blocks from rescript, while locally we have the old ones.

This makes the analysis get rescript first. As for why ci doesn't install bs-platform: maybe node/npm version difference.