### PR TITLE
Revert "Test using normal filename concat without trying to normalize `./foo`."

### DIFF
--- a/analysis/.depend
+++ b/analysis/.depend
@@ -1,4 +1,5 @@
-src/BuildSystem.cmx : src/ModuleResolution.cmx src/Log.cmx src/Files.cmx
+src/BuildSystem.cmx : src/ModuleResolution.cmx src/Log.cmx src/Infix.cmx \
+    src/Files.cmx
 src/Cli.cmx : src/Commands.cmx
 src/Commands.cmx : src/Utils.cmx src/Uri2.cmx src/SharedTypes.cmx \
     src/Shared.cmx src/References.cmx src/Protocol.cmx src/ProcessCmt.cmx \

--- a/analysis/.depend
+++ b/analysis/.depend
@@ -10,9 +10,9 @@ src/FindFiles.cmx : src/Utils.cmx src/SharedTypes.cmx \
     src/Files.cmx src/BuildSystem.cmx
 src/Hover.cmx : src/Utils.cmx src/SharedTypes.cmx src/Shared.cmx \
     src/References.cmx src/ProcessCmt.cmx
-src/Infix.cmx : src/Log.cmx
+src/Infix.cmx : src/Log.cmx src/Files.cmx
 src/Log.cmx :
-src/ModuleResolution.cmx : src/Files.cmx
+src/ModuleResolution.cmx : src/Infix.cmx src/Files.cmx
 src/NewCompletions.cmx : src/Utils.cmx src/Uri2.cmx src/SharedTypes.cmx \
     src/Shared.cmx src/Protocol.cmx src/ProcessCmt.cmx src/PartialParser.cmx \
     src/Log.cmx src/Infix.cmx src/Hover.cmx
@@ -33,7 +33,7 @@ src/References.cmx : src/Utils.cmx src/Uri2.cmx src/SharedTypes.cmx \
 src/Shared.cmx : src/PrintType.cmx src/Files.cmx
 src/SharedTypes.cmx : src/Utils.cmx src/Uri2.cmx src/Shared.cmx \
     src/Infix.cmx
-src/Uri2.cmx :
+src/Uri2.cmx : src/Files.cmx
 src/Utils.cmx : src/Protocol.cmx
 src/vendor/Json.cmx :
 src/vendor/res_outcome_printer/res_comment.cmx : \

--- a/analysis/src/BuildSystem.ml
+++ b/analysis/src/BuildSystem.ml
@@ -1,5 +1,7 @@
 let namespacedName namespace name =
-  match namespace with None -> name | Some namespace -> name ^ "-" ^ namespace
+  match namespace with
+  | None -> name
+  | Some namespace -> name ^ "-" ^ namespace
 
 open Infix
 
@@ -19,11 +21,9 @@ let getBsPlatformDir rootPath =
     Log.log message;
     Error message
 
-let getCompiledBase root =
-  Files.ifExists (Filename.concat (Filename.concat root "lib") "bs")
+let getCompiledBase root = Files.ifExists (root /+ "lib" /+ "bs")
 
 let getStdlib base =
   match getBsPlatformDir base with
   | Error e -> Error e
-  | Ok bsPlatformDir ->
-    Ok (Filename.concat (Filename.concat bsPlatformDir "lib") "ocaml")
+  | Ok bsPlatformDir -> Ok (bsPlatformDir /+ "lib" /+ "ocaml")

--- a/analysis/src/BuildSystem.ml
+++ b/analysis/src/BuildSystem.ml
@@ -1,6 +1,8 @@
 let namespacedName namespace name =
   match namespace with None -> name | Some namespace -> name ^ "-" ^ namespace
 
+open Infix
+
 let getBsPlatformDir rootPath =
   let result =
     ModuleResolution.resolveNodeModulePath ~startPath:rootPath "rescript"

--- a/analysis/src/Files.ml
+++ b/analysis/src/Files.ml
@@ -97,3 +97,17 @@ let rec collect ?(checkDir = fun _ -> true) path test =
       |> List.concat
     else []
   | _ -> if test path then [path] else []
+
+let fileConcat a b =
+  if
+    b <> ""
+    && b.[0] = '.'
+    && String.length b >= 2
+    && b.[1] = Filename.dir_sep.[0]
+  then Filename.concat a (String.sub b 2 (String.length b - 2))
+  else Filename.concat a b
+
+let isFullPath b =
+  b.[0] = '/' || (Sys.win32 && String.length b > 1 && b.[1] = ':')
+
+let maybeConcat a b = if b <> "" && isFullPath b then b else fileConcat a b

--- a/analysis/src/Infix.ml
+++ b/analysis/src/Infix.ml
@@ -26,3 +26,5 @@ let logIfAbsent message x =
     Log.log message;
     None
   | _ -> x
+
+let ( /+ ) = Files.fileConcat

--- a/analysis/src/ModuleResolution.ml
+++ b/analysis/src/ModuleResolution.ml
@@ -1,5 +1,7 @@
+open Infix
+
 let rec resolveNodeModulePath ~startPath name =
-  let path = Filename.concat (Filename.concat startPath "node_modules") name in
+  let path = startPath /+ "node_modules" /+ name in
   if Files.exists path then Some path
   else if Filename.dirname startPath = startPath then None
   else resolveNodeModulePath ~startPath:(Filename.dirname startPath) name

--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -1,7 +1,5 @@
 open Infix
 
-let ( ++ ) = Filename.concat
-
 (* Creates the `pathsForModule` hashtbl, which maps a `moduleName` to it's `paths` (the ml/re, mli/rei, cmt, and cmti files) *)
 let makePathsForModule (localModules : (string * SharedTypes.paths) list)
     (dependencyModules : (string * SharedTypes.paths) list) =
@@ -15,7 +13,7 @@ let makePathsForModule (localModules : (string * SharedTypes.paths) list)
   pathsForModule
 
 let newBsPackage rootPath =
-  let path = rootPath ++ "bsconfig.json" in
+  let path = rootPath /+ "bsconfig.json" in
   match Files.readFile path with
   | None -> Error ("Unable to read " ^ path)
   | Some raw -> (
@@ -65,7 +63,7 @@ let newBsPackage rootPath =
              match namespace with
              | None -> []
              | Some namespace ->
-               let cmt = (compiledBase ++ namespace) ^ ".cmt" in
+               let cmt = (compiledBase /+ namespace) ^ ".cmt" in
                Log.log ("############ Namespaced as " ^ namespace ^ " at " ^ cmt);
                Hashtbl.add pathsForModule namespace (Impl (cmt, None));
                [FindFiles.nameSpaceToName namespace]
@@ -108,7 +106,7 @@ let findRoot ~uri packagesByRoot =
   let rec loop path =
     if path = "/" then None
     else if Hashtbl.mem packagesByRoot path then Some (`Root path)
-    else if Files.exists (path ++ "bsconfig.json") then Some (`Bs path)
+    else if Files.exists (path /+ "bsconfig.json") then Some (`Bs path)
     else
       let parent = Filename.dirname path in
       if parent = path then (* reached root *) None else loop parent

--- a/analysis/src/Uri2.ml
+++ b/analysis/src/Uri2.ml
@@ -29,7 +29,7 @@ end = struct
   let fromPath path = {path; uri = pathToUri path}
 
   let fromLocalPath localPath =
-    let path = Filename.concat (Unix.getcwd ()) localPath in
+    let path = Files.maybeConcat (Unix.getcwd ()) localPath in
     fromPath path
 
   let isInterface {path} = Filename.check_suffix path "i"


### PR DESCRIPTION
Reverts rescript-lang/rescript-vscode#197

This is breaking jumpt-to-definition within the same file.