### PR TITLE
Add support for detailed info (jump-to-def, hover) on a signature.

### DIFF
--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -47,9 +47,9 @@ let hover ~path ~line ~col =
   let result =
     match ProcessCmt.getFullFromCmt ~uri with
     | None -> Protocol.null
-    | Some ({file; extra} as full) -> (
+    | Some ({file} as full) -> (
       let pos = Utils.protocolLineColToCmtLoc ~line ~col in
-      match References.locItemForPos ~extra pos with
+      match References.locItemForPos ~full pos with
       | None -> Protocol.null
       | Some locItem -> (
         let isModule =
@@ -83,10 +83,10 @@ let definition ~path ~line ~col =
   let result =
     match ProcessCmt.getFullFromCmt ~uri with
     | None -> Protocol.null
-    | Some ({file; extra} as full) -> (
+    | Some ({file} as full) -> (
       let pos = Utils.protocolLineColToCmtLoc ~line ~col in
 
-      match References.locItemForPos ~extra pos with
+      match References.locItemForPos ~full pos with
       | None -> Protocol.null
       | Some locItem -> (
         let isModule =
@@ -118,9 +118,9 @@ let references ~path ~line ~col =
   let result =
     match ProcessCmt.getFullFromCmt ~uri with
     | None -> Protocol.null
-    | Some ({extra} as full) -> (
+    | Some full -> (
       let pos = Utils.protocolLineColToCmtLoc ~line ~col in
-      match References.locItemForPos ~extra pos with
+      match References.locItemForPos ~full pos with
       | None -> Protocol.null
       | Some locItem ->
         let allReferences = References.allReferencesForLocItem ~full locItem in

--- a/analysis/src/References.ml
+++ b/analysis/src/References.ml
@@ -17,9 +17,12 @@ let checkPos (line, char)
 let locItemsForPos ~extra pos =
   extra.locItems |> List.filter (fun {loc; locType = _} -> checkPos pos loc)
 
-let locItemForPos ~extra pos =
-  let locItems = locItemsForPos ~extra pos in
+let locItemForPos ~full pos =
+  let locItems = locItemsForPos ~extra:full.extra pos in
   match locItems with
+  | _ :: _ :: _ :: l :: _ when full.file.uri |> Uri2.isInterface ->
+    (* heuristic for makeProps in interface files *)
+    Some l
   | [({locType = Typed (_, LocalReference _)} as li1); li3]
     when li1.loc = li3.loc ->
     (* JSX and compiler combined:

--- a/analysis/tests/src/expected/A.res.txt
+++ b/analysis/tests/src/expected/A.res.txt
@@ -1,3 +1,0 @@
-Hover tests/src/A.res 4:7
-{"contents": "```rescript\nmodule JsLogger = {\n  let log: string => unit\n}\n```"}
-

--- a/analysis/tests/src/expected/Jsx.resi.txt
+++ b/analysis/tests/src/expected/Jsx.resi.txt
@@ -1,5 +1,5 @@
 Hover tests/src/Jsx.resi 1:4
-{"contents": "```rescript\n(~first: string, ~?key: string, unit) => {\"first\": string}\n```"}
+{"contents": "```rescript\nReact.componentLike<{\"first\": string}, React.element>\n```\n\n```rescript\ntype componentLike<'props, 'return> = 'props => 'return\n```"}
 
 Hover tests/src/Jsx.resi 4:4
 {"contents": "```rescript\nint\n```"}

--- a/analysis/tests/src/expected/Jsx.resi.txt
+++ b/analysis/tests/src/expected/Jsx.resi.txt
@@ -1,5 +1,5 @@
 Hover tests/src/Jsx.resi 1:4
-{"contents": "```rescript\nReact.componentLike<{\"first\": string}, React.element>\n```\n\n```rescript\ntype componentLike<'props, 'return> = 'props => 'return\n```"}
+{"contents": "```rescript\n(~first: string, ~?key: string, unit) => {\"first\": string}\n```"}
 
 Hover tests/src/Jsx.resi 4:4
 {"contents": "```rescript\nint\n```"}


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/204