### PR TITLE
JSX Autocomplete: handle more cases of atomic expression  to the rhs of `=` without braces (variant, polymorphic variant, function call, etc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## master
+- ppx autocomplete: handle variant and polymorphic variant without braces.
+
 ## 1.1.1
 
 This update contains _lots_ of autocomplete, hover and jump-to-definition improvements. We'll list only a few below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master
-- ppx autocomplete: handle values to the rhs of `=` without braces (variant, polymorphic variant, function call, list literal).
+- ppx autocomplete: handle values to the rhs of `=` without braces (variant, polymorphic variant, function call, list literal, nested component).
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master
-- ppx autocomplete: handle values to the rhs of `=` without braces (variant, polymorphic variant, function call, list literal, nested component).
+- ppx autocomplete: handle more atomic expressions to the rhs of `=` without braces (variant, polymorphic variant, function call, list literal, nested component, characters, templates).
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master
-- ppx autocomplete: handle variant and polymorphic variant without braces.
+- ppx autocomplete: handle values to the rhs of `=` without braces (variant, polymorphic variant, function call, list literal).
 
 ## 1.1.1
 

--- a/analysis/src/PartialParser.ml
+++ b/analysis/src/PartialParser.ml
@@ -69,7 +69,7 @@ let skipOptVariant text i =
    Find JSX context ctx for component M to autocomplete id (already parsed) as a prop.
    ctx ::= <M args id
    arg ::= id | id = [?] val
-   val ::= id | "abc" | 42 | optVariant {...} | optVariant (...) | [...]
+   val ::= id | "abc" | 42 | optVariant {...} | optVariant (...) | <...> | [...]
    optVariant ::= a | A | #a |  #A |  _nothing_
  *)
 let findJsxContext text offset =
@@ -83,6 +83,9 @@ let findJsxContext text offset =
       | ')' ->
         let i1 = findBackSkippingCommentsAndStrings text '(' ')' (i - 1) 0 in
         if i1 > 0 then beforeParen identsSeen i1 else None
+      | '>' ->
+        let i1 = findBackSkippingCommentsAndStrings text '<' '>' (i - 1) 0 in
+        if i1 > 0 then beforeValue identsSeen i1 else None
       | ']' ->
         let i1 = findBackSkippingCommentsAndStrings text '[' ']' (i - 1) 0 in
         if i1 > 0 then beforeValue identsSeen i1 else None

--- a/analysis/src/PartialParser.ml
+++ b/analysis/src/PartialParser.ml
@@ -68,8 +68,8 @@ let skipOptVariant text i =
 (* Figure out whether id should be autocompleted as component prop.
    Find JSX context ctx for component M to autocomplete id (already parsed) as a prop.
    ctx ::= <M args id
-   arg ::= id | id = [?] val
-   val ::= id | "abc" | 42 | optVariant {...} | optVariant (...) | <...> | [...]
+   arg ::= id | id = [?] atomicExpr
+   atomicExpr ::= id | "abc" | 'a' | 42 | `...` | optVariant {...} | optVariant (...) | <...> | [...]
    optVariant ::= a | A | #a |  #A |  _nothing_
  *)
 let findJsxContext text offset =
@@ -91,6 +91,12 @@ let findJsxContext text offset =
         if i1 > 0 then beforeValue identsSeen i1 else None
       | '"' ->
         let i1 = findBack text '"' (i - 1) in
+        if i1 > 0 then beforeValue identsSeen i1 else None
+      | '\'' ->
+        let i1 = findBack text '\'' (i - 1) in
+        if i1 > 0 then beforeValue identsSeen i1 else None
+      | '`' ->
+        let i1 = findBack text '`' (i - 1) in
         if i1 > 0 then beforeValue identsSeen i1 else None
       | _ ->
         let i1 = startOfLident text i in

--- a/analysis/src/PartialParser.ml
+++ b/analysis/src/PartialParser.ml
@@ -69,8 +69,8 @@ let skipOptVariant text i =
    Find JSX context ctx for component M to autocomplete id (already parsed) as a prop.
    ctx ::= <M args id
    arg ::= id | id = [?] val
-   val ::= id | "abc" | 42 | {...} | optVariant (...) | [...]
-   optVariant ::= A | #a |  _nothing_
+   val ::= id | "abc" | 42 | optVariant {...} | optVariant (...) | [...]
+   optVariant ::= a | A | #a |  #A |  _nothing_
  *)
 let findJsxContext text offset =
   let rec loop identsSeen i =
@@ -79,7 +79,7 @@ let findJsxContext text offset =
       match text.[i] with
       | '}' ->
         let i1 = findBackSkippingCommentsAndStrings text '{' '}' (i - 1) 0 in
-        if i1 > 0 then beforeValue identsSeen i1 else None
+        if i1 > 0 then beforeParen identsSeen i1 else None
       | ')' ->
         let i1 = findBackSkippingCommentsAndStrings text '(' ')' (i - 1) 0 in
         if i1 > 0 then beforeParen identsSeen i1 else None

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -16,3 +16,6 @@ let _ = <M first="abc" />
 let make = (~first) => React.string(first)
 
 let y = 44
+
+//^com <M prop={A(3)} k
+//^com <M prop=A(3) k

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -25,3 +25,4 @@ let y = 44
 
 //^com <M prop=list{1,2,3} k
 
+//^com <M prop=<N /> k

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -21,5 +21,7 @@ let y = 44
 
 //^com <M prop=A(3) k
 
+//^com <M prop=foo(1+2) k
 
-//^com <M prop = #A (3) k
+//^com <M prop=list{1,2,3} k
+

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -18,4 +18,8 @@ let make = (~first) => React.string(first)
 let y = 44
 
 //^com <M prop={A(3)} k
+
 //^com <M prop=A(3) k
+
+
+//^com <M prop = #A (3) k

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -26,3 +26,17 @@ let y = 44
 //^com <M prop=list{1,2,3} k
 
 //^com <M prop=<N /> k
+
+//^com <M prop=1.5 k
+
+//^com <M prop=0X33 k
+
+//^com <M prop=12e+3 k
+
+//^com <M prop='z' k
+
+//^com <M prop=`before${foo}` k
+
+//<M prop=module(@foo Three: X_int) k
+
+//<M prop=%bs.raw("1") k

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -71,6 +71,7 @@ Complete tests/src/Jsx.res 11:2
   }]
 
 Complete tests/src/Jsx.res 18:2
+skipOptIdent
 [{
     "label": "key",
     "kind": 4,
@@ -89,7 +90,17 @@ skipOptIdent
     "documentation": null
   }]
 
-Complete tests/src/Jsx.res 23:2
+Complete tests/src/Jsx.res 22:2
+skipOptIdent
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Jsx.res 24:2
 skipOptIdent
 [{
     "label": "key",

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -79,6 +79,23 @@ Complete tests/src/Jsx.res 18:2
     "documentation": null
   }]
 
-Complete tests/src/Jsx.res 19:2
-[]
+Complete tests/src/Jsx.res 20:2
+skipOptIdent
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Jsx.res 23:2
+skipOptIdent
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
 

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -70,3 +70,15 @@ Complete tests/src/Jsx.res 11:2
     "documentation": null
   }]
 
+Complete tests/src/Jsx.res 18:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Jsx.res 19:2
+[]
+

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -119,3 +119,48 @@ Complete tests/src/Jsx.res 26:2
     "documentation": null
   }]
 
+Complete tests/src/Jsx.res 28:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Jsx.res 30:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Jsx.res 32:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Jsx.res 34:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Jsx.res 36:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -111,5 +111,11 @@ skipOptIdent
   }]
 
 Complete tests/src/Jsx.res 26:2
-[]
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
 

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -110,3 +110,6 @@ skipOptIdent
     "documentation": null
   }]
 
+Complete tests/src/Jsx.res 26:2
+[]
+


### PR DESCRIPTION
See https://github.com/rescript-lang/rescript-vscode/issues/213