### PR TITLE
Autocomplete for function calls: only suggest labeled args that were …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 - ppx autocomplete: handle more atomic expressions to the rhs of `=` without braces (variant, polymorphic variant, function call, list literal, nested component, characters, templates).
+- Autocomplete for function calls: only suggest labeled args that were not yet assigned.
 
 ## 1.1.1
 

--- a/analysis/src/NewCompletions.ml
+++ b/analysis/src/NewCompletions.ml
@@ -610,7 +610,7 @@ let processCompletable ~findItems ~package ~rawOpens
            in
            dec2)
     |> List.map mkDecorator
-  | Clabel (funPath, prefix) ->
+  | Clabel (funPath, prefix, identsSeen) ->
     let labels =
       match funPath |> findItems ~exact:true with
       | {SharedTypes.item = Value typ} :: _ ->
@@ -631,7 +631,8 @@ let processCompletable ~findItems ~package ~rawOpens
         ~docstring:[]
     in
     labels
-    |> List.filter (fun (name, _t) -> Utils.startsWith name prefix)
+    |> List.filter (fun (name, _t) ->
+           Utils.startsWith name prefix && not (List.mem name identsSeen))
     |> List.map mkLabel
 
 let computeCompletions ~full ~maybeText ~pos =

--- a/analysis/tests/src/Completion.res
+++ b/analysis/tests/src/Completion.res
@@ -18,7 +18,7 @@ module Lib = {
   let next = (~number=0, ~year) => number + year
 }
 
-//^com let x = foo(~
+//^com let x = Lib.foo(~
 
 //^com [1,2,3]->m
 
@@ -58,3 +58,9 @@ let zzz = 11
 //^com @reac
 
 //^com @react.
+
+//^com let x = Lib.foo(~name, ~
+
+//^com let x = Lib.foo(~age, ~
+
+//^com let x = Lib.foo(~age={3+4}, ~

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -556,3 +556,30 @@ Complete tests/src/Completion.res 58:2
     "documentation": null
   }]
 
+Complete tests/src/Completion.res 60:2
+[{
+    "label": "age",
+    "kind": 4,
+    "tags": [],
+    "detail": "int",
+    "documentation": null
+  }]
+
+Complete tests/src/Completion.res 62:2
+[{
+    "label": "name",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Completion.res 64:2
+[{
+    "label": "name",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+


### PR DESCRIPTION
…not yet assigned.

Fixes https://github.com/rescript-lang/rescript-vscode/issues/187