### PR TITLE
Revert "Temporarily disable interface creation"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rename: use renameProvider to give a warning when it's not a symbol that can be renamed.
 - Add support for Go to Type Definition.
 - Restore documentSymbolProvider.
+- Restore creation of interface files (fully supported from compiler 9.1.3 onwards)
 
 ## 1.1.2
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
 			}
 		],
 		"commands": [
+			{
+				"command": "rescript-vscode.create_interface",
+				"title": "ReScript: Create an interface file for this implementation file."
+			}
 		],
 		"snippets": [
 			{


### PR DESCRIPTION
This reverts commit ffdd918830e07766b8d2fdf796096d5d4f0907f8.

This check is already in place:
<img width="466" alt="Screenshot 2021-06-19 at 07 09 05" src="https://user-images.githubusercontent.com/7965335/122631639-53ef5900-d0cd-11eb-912c-592320b5376e.png">
