### PR TITLE
Command to open compiled file

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,40 +1,12 @@
-import * as fs from "fs";
-import { window, DiagnosticCollection } from "vscode";
-import { LanguageClient, RequestType } from "vscode-languageclient/node";
+import { DiagnosticCollection } from "vscode";
+
 import {
   DiagnosticsResultCodeActionsMap,
   runDeadCodeAnalysisWithReanalyze,
 } from "./commands/dead_code_analysis";
 
-interface CreateInterfaceRequestParams {
-  uri: string;
-}
-
-let createInterfaceRequest = new RequestType<
-  CreateInterfaceRequestParams,
-  string,
-  void
->("rescript-vscode.create_interface");
-
-export const createInterface = (client: LanguageClient) => {
-  if (!client) {
-    return window.showInformationMessage("Language server not running");
-  }
-
-  const editor = window.activeTextEditor;
-
-  if (!editor) {
-    return window.showInformationMessage("No active editor");
-  }
-
-  if (fs.existsSync(editor.document.uri.fsPath + "i")) {
-    return window.showInformationMessage("Interface file already exists");
-  }
-
-  client.sendRequest(createInterfaceRequest, {
-    uri: editor.document.uri.toString(),
-  });
-};
+export { createInterface } from "./commands/create_interface";
+export { openCompiled } from "./commands/open_compiled";
 
 export const deadCodeAnalysisWithReanalyze = (
   targetDir: string | null,

--- a/client/src/commands/create_interface.ts
+++ b/client/src/commands/create_interface.ts
@@ -1,0 +1,33 @@
+import * as fs from "fs";
+import { LanguageClient, RequestType } from "vscode-languageclient/node";
+import { window } from "vscode";
+
+interface CreateInterfaceRequestParams {
+  uri: string;
+}
+
+let createInterfaceRequest = new RequestType<
+  CreateInterfaceRequestParams,
+  string,
+  void
+>("rescript-vscode.create_interface");
+
+export const createInterface = (client: LanguageClient) => {
+  if (!client) {
+    return window.showInformationMessage("Language server not running");
+  }
+
+  const editor = window.activeTextEditor;
+
+  if (!editor) {
+    return window.showInformationMessage("No active editor");
+  }
+
+  if (fs.existsSync(editor.document.uri.fsPath + "i")) {
+    return window.showInformationMessage("Interface file already exists");
+  }
+
+  client.sendRequest(createInterfaceRequest, {
+    uri: editor.document.uri.toString(),
+  });
+};

--- a/client/src/commands/open_compiled.ts
+++ b/client/src/commands/open_compiled.ts
@@ -1,0 +1,45 @@
+import * as fs from "fs";
+import { window, Uri, ViewColumn } from "vscode";
+import { LanguageClient, RequestType } from "vscode-languageclient/node";
+
+interface OpenCompiledFileRequestParams {
+  uri: string;
+}
+
+interface OpenCompiledFileResponseParams {
+  uri: string;
+}
+
+let openCompiledFileRequest = new RequestType<
+  OpenCompiledFileRequestParams,
+  OpenCompiledFileResponseParams,
+  void
+>("rescript-vscode.open_compiled");
+
+export const openCompiled = (client: LanguageClient) => {
+  if (!client) {
+    return window.showInformationMessage("Language server not running");
+  }
+
+  const editor = window.activeTextEditor;
+
+  if (!editor) {
+    return window.showInformationMessage("No active editor");
+  }
+
+  if (!fs.existsSync(editor.document.uri.fsPath)) {
+    return window.showInformationMessage("Compiled file does not exist");
+  }
+
+  client
+    .sendRequest(openCompiledFileRequest, {
+      uri: editor.document.uri.toString(),
+    })
+    .then((response) => {
+      const document = Uri.file(response.uri);
+
+      return window.showTextDocument(document, {
+        viewColumn: ViewColumn.Beside,
+      });
+    });
+};

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -146,6 +146,10 @@ export function activate(context: ExtensionContext) {
     customCommands.createInterface(client);
   });
 
+  commands.registerCommand("rescript-vscode.open_compiled", () => {
+    customCommands.openCompiled(client);
+  });
+
   // Starts the dead code analysis mode.
   commands.registerCommand("rescript-vscode.start_dead_code_analysis", () => {
     // Save the directory this first ran from, and re-use that when continuously

--- a/package.json
+++ b/package.json
@@ -40,10 +40,25 @@
 				"title": "ReScript: Create an interface file for this implementation file."
 			},
 			{
+				"command": "rescript-vscode.open_compiled",
+				"category": "ReScript",
+				"title": "Open the compiled JS file for this implementation file.",
+				"icon": "$(output)"
+			},
+			{
 				"command": "rescript-vscode.start_dead_code_analysis",
 				"title": "ReScript: Start dead code analysis."
 			}
 		],
+		"menus": {
+			"editor/title": [
+				{
+					"command": "rescript-vscode.open_compiled",
+					"when": "editorLangId == rescript",
+					"group": "navigation"
+				}
+			]
+		},
 		"snippets": [
 			{
 				"language": "rescript",

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -45,3 +45,7 @@ export let resExt = ".res";
 export let resiExt = ".resi";
 export let cmiExt = ".cmi";
 export let startBuildAction = "Start Build";
+
+// bsconfig defaults according configuration schema (https://rescript-lang.org/docs/manual/latest/build-configuration-schema)
+export let bsconfigModuleDefault = "commonjs";
+export let bsconfigSuffixDefault = ".js";

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -634,10 +634,18 @@ function openCompiledFile(msg: p.RequestMessage): m.Message {
 
   let compiledFilePath = utils.getCompiledFilePath(filePath, projDir);
 
-  if (compiledFilePath.kind === "error" || !fs.existsSync(compiledFilePath.result)) {
+  if (
+    compiledFilePath.kind === "error" ||
+    !fs.existsSync(compiledFilePath.result)
+  ) {
+    let message =
+      compiledFilePath.kind === "success"
+        ? `No compiled file found. Expected it at: ${compiledFilePath.result}`
+        : `No compiled file found. Please compile your project first.`;
+
     let params: p.ShowMessageParams = {
       type: p.MessageType.Error,
-      message: `No compiled file found. Please compile your project first.`,
+      message,
     };
 
     let response: m.NotificationMessage = {

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -252,6 +252,18 @@ export let createInterfaceFileUsingValidBscExePath = (
   }
 };
 
+let getCompiledFolderName = (moduleFormat: string): string => {
+  switch (moduleFormat) {
+    case "es6":
+      return "es6";
+    case "es6-global":
+      return "es6_global";
+    case "commonjs":
+    default:
+      return "js";
+  }
+};
+
 export let getCompiledFilePath = (
   filePath: string,
   projDir: string
@@ -272,13 +284,17 @@ export let getCompiledFilePath = (
   let module = c.bsconfigModuleDefault;
   let suffix = c.bsconfigSuffixDefault;
 
-  if (pkgSpecs && pkgSpecs.module) {
-    moduleFormatObj = pkgSpecs;
-  } else if (pkgSpecs && pkgSpecs[0]) {
-    if (typeof pkgSpecs[0] === "string") {
-      module = pkgSpecs[0];
-    } else {
-      moduleFormatObj = pkgSpecs[0];
+  if (pkgSpecs) {
+    if (pkgSpecs.module) {
+      moduleFormatObj = pkgSpecs;
+    } else if (typeof pkgSpecs === "string") {
+      module = pkgSpecs;
+    } else if (pkgSpecs[0]) {
+      if (typeof pkgSpecs[0] === "string") {
+        module = pkgSpecs[0];
+      } else {
+        moduleFormatObj = pkgSpecs[0];
+      }
     }
   }
 
@@ -287,7 +303,7 @@ export let getCompiledFilePath = (
   }
 
   if (!moduleFormatObj["in-source"]) {
-    pathFragment = "lib/" + module.replace("-", "_");
+    pathFragment = "lib/" + getCompiledFolderName(module);
   }
 
   if (moduleFormatObj.suffix) {


### PR DESCRIPTION
This implements #107 

Press CMD+Shift+P and select `ReScript: Open the compiled JS file for this implementation file.`
It should open the corresponding `.bs.js`, `.js`, `.mjs` in the correct directory (whether in-source or not).

Unfortunately, this requires to parse `bsconfig.json`. I did not know how to account for an array with more than one element of package-specs, so for now it just takes the first one, but I guess it is better to use an object anyway, as [suggested by the docs](https://rescript-lang.org/docs/manual/latest/build-configuration#package-specs).