### PR TITLE
Fix issue in JSX autocomplete when the component is declared external.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master
-
+- Fix issue in JSX autocomplete when the component is declared external.
 - Fix jump-to-definition for uncurried calls.
 - Fix issue where values for autocomplete were pulled from implementations instead of interfaces.
 

--- a/analysis/src/NewCompletions.ml
+++ b/analysis/src/NewCompletions.ml
@@ -914,6 +914,19 @@ let processCompletable ~findItems ~full ~package ~rawOpens
                 _,
                 _ ) ->
             getFields tObj
+          | Tconstr
+              ( path,
+                [
+                  {
+                    desc =
+                      ( Tconstr (* Js.t *) (_, [{desc = Tobject (tObj, _)}], _)
+                      | Tobject (tObj, _) );
+                  };
+                  _;
+                ],
+                _ )
+            when Path.name path = "React.componentLike" ->
+            getFields tObj
           | _ -> []
         in
         typ |> getLabels

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -49,6 +49,6 @@ module Ext = {
   external make: (~align: string=?) => React.element = "Typography"
 }
 
-let extMake = Ext.make
+let _extMake = Ext.make
 
 //^com <Ext al

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -42,4 +42,13 @@ let y = 44
 //^com <M prop=%bs.raw("1") k
 
 let _ = <Component />
-//         ^def
+//         ^def 
+
+module Ext = {
+  @react.component @module("@material-ui/core")
+  external make: (~align: string=?) => React.element = "Typography"
+}
+
+let extMake = Ext.make
+
+//^com <Ext al

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -182,5 +182,17 @@ Definition tests/src/Jsx.res 43:11
 {"uri": "Component.res", "range": {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 8}}}
 
 Complete tests/src/Jsx.res 52:2
-[]
+[{
+    "label": "align",
+    "kind": 4,
+    "tags": [],
+    "detail": "option<string>",
+    "documentation": null
+  }, {
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
 

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -181,3 +181,6 @@ Complete tests/src/Jsx.res 40:2
 Definition tests/src/Jsx.res 43:11
 {"uri": "Component.res", "range": {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 8}}}
 
+Complete tests/src/Jsx.res 52:2
+[]
+


### PR DESCRIPTION
…rnal.

See https://github.com/rescript-lang/rescript-vscode/issues/307

When a component is declared as external, its type is different. Instead of being a function type, it is a type `React.componentLike` (which internally is defined as a function).
The treatment of JSX autocomplete does not currently recognise that type.