### PR TITLE
Add autocompletion for object access of the form foo["bar"]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fix issue in JSX autocomplete when the component is declared external.
 - Fix jump-to-definition for uncurried calls.
 - Fix issue where values for autocomplete were pulled from implementations instead of interfaces.
+- Add autocompletion for object access of the form foo['bar'].
 
 ## 1.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Fix issue in JSX autocomplete when the component is declared external.
 - Fix jump-to-definition for uncurried calls.
 - Fix issue where values for autocomplete were pulled from implementations instead of interfaces.
-- Add autocompletion for object access of the form foo['bar'].
+- Add autocompletion for object access of the form foo["bar"].
 
 ## 1.1.3
 

--- a/analysis/tests/src/Completion.res
+++ b/analysis/tests/src/Completion.res
@@ -68,3 +68,7 @@ let zzz = 11
 let _ = Lib.foo(//~age,
 //^com ~
 ~age=3, ~name="")
+
+let someObj = {"name": "a", "age": 32}
+
+//^com someObj["a

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -535,6 +535,11 @@ DocumentSymbol tests/src/Completion.res
         "name": "zzz",
         "kind": 13,
         "location": {"uri": "Completion.res", "range": {"start": {"line": 49, "character": 4}, "end": {"line": 49, "character": 7}}}
+},
+{
+        "name": "someObj",
+        "kind": 19,
+        "location": {"uri": "Completion.res", "range": {"start": {"line": 71, "character": 4}, "end": {"line": 71, "character": 11}}}
 }
 ]
 
@@ -595,6 +600,15 @@ Complete tests/src/Completion.res 67:2
     "kind": 4,
     "tags": [],
     "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Completion.res 72:2
+[{
+    "label": "age",
+    "kind": 4,
+    "tags": [],
+    "detail": "int",
     "documentation": null
   }]
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -637,7 +637,7 @@ function onMessage(msg: m.Message) {
           renameProvider: { prepareProvider: true },
           // disabled right now until we use the parser to show non-stale symbols per keystroke
           // documentSymbolProvider: true,
-          completionProvider: { triggerCharacters: [".", ">", "@", "~"] },
+          completionProvider: { triggerCharacters: [".", ">", "@", "~", '"'] },
         },
       };
       let response: m.ResponseMessage = {


### PR DESCRIPTION
Currently only covers the case of simple variable 'foo' accessed a `foo["...`