### PR TITLE
Fix issue with JSX autocompletion not working after `foo=#variant`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix issue where values for autocomplete were pulled from implementations instead of interfaces.
 - Add autocompletion for object access of the form foo["bar"].
 - Fix issue with autocomplete then punned props are used in JSX. E.g. `<M foo ...>`.
+- Fix issue with JSX autocompletion not working after `foo=#variant`.
 
 ## 1.1.3
 

--- a/analysis/src/PartialParser.ml
+++ b/analysis/src/PartialParser.ml
@@ -107,7 +107,7 @@ let skipOptVariantExtension text i =
    Find JSX context ctx for component M to autocomplete id (already parsed) as a prop.
    ctx ::= <M args id
    arg ::= id | id = [?] atomicExpr
-   atomicExpr ::= id | "abc" | 'a' | 42 | `...` | optVariant {...} | optVariant (...) | <...> | [...]
+   atomicExpr ::= id | #id | "abc" | 'a' | 42 | `...` | optVariant {...} | optVariant (...) | <...> | [...]
    optVariant ::= id | #id | %id |  _nothing_
 *)
 let findJsxContext text offset =
@@ -143,7 +143,10 @@ let findJsxContext text offset =
           match ident.[0] with
           | ('a' .. 'z' | 'A' .. 'Z') when i1 >= 1 && text.[i1 - 1] = '<' ->
             Some (ident, identsSeen)
-          | _ -> beforeIdent ~ident identsSeen (i1 - 1)
+          | _ ->
+            if i1 >= 1 && text.[i1 - 1] = '#' then
+              beforeValue identsSeen (i1 - 2)
+            else beforeIdent ~ident identsSeen (i1 - 1)
         else None
     else None
   and beforeIdent ~ident identsSeen i =

--- a/analysis/tests/src/Jsx.res
+++ b/analysis/tests/src/Jsx.res
@@ -54,3 +54,7 @@ let _ = (Ext.make, Ext.makeProps)
 //^com <Ext al
 
 //^com <M first 
+
+//^com <M first=#a k
+
+//^com <M first =  ?   #a k

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -211,3 +211,21 @@ Complete tests/src/Jsx.res 54:2
     "documentation": null
   }]
 
+Complete tests/src/Jsx.res 56:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+
+Complete tests/src/Jsx.res 58:2
+[{
+    "label": "key",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }]
+


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/313