### PR TITLE
New function to extract record type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix issue with autocomplete then punned props are used in JSX. E.g. `<M foo ...>`.
 - Fix issue with JSX autocompletion not working after `foo=#variant`.
 - Fix issue in JSX autocompletion where the `key` label would always appear.
+- Fix issue in record field autocomplete not working with type aliases.
 
 ## 1.1.3
 

--- a/analysis/tests/src/Completion.res
+++ b/analysis/tests/src/Completion.res
@@ -83,3 +83,8 @@ let o : Obj.objT = assert false
 type nestedObjT = {"x": Obj.nestedObjT}
 let no : nestedObjT = assert false
 //^com no["x"]["y"]["
+
+type r = {x:int, y:string}
+type rAlias = r
+let r:rAlias = assert false
+// ^com r.

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -554,6 +554,21 @@ DocumentSymbol tests/src/Completion.res
         "name": "no",
         "kind": 13,
         "location": {"uri": "Completion.res", "range": {"start": {"line": 83, "character": 4}, "end": {"line": 83, "character": 6}}}
+},
+{
+        "name": "r",
+        "kind": 11,
+        "location": {"uri": "Completion.res", "range": {"start": {"line": 86, "character": 0}, "end": {"line": 86, "character": 26}}}
+},
+{
+        "name": "rAlias",
+        "kind": 26,
+        "location": {"uri": "Completion.res", "range": {"start": {"line": 87, "character": 0}, "end": {"line": 87, "character": 15}}}
+},
+{
+        "name": "r",
+        "kind": 13,
+        "location": {"uri": "Completion.res", "range": {"start": {"line": 88, "character": 4}, "end": {"line": 88, "character": 5}}}
 }
 ]
 
@@ -662,6 +677,21 @@ Complete tests/src/Completion.res 83:2
     "kind": 4,
     "tags": [],
     "detail": "int",
+    "documentation": null
+  }]
+
+Complete tests/src/Completion.res 88:3
+[{
+    "label": "x",
+    "kind": 5,
+    "tags": [],
+    "detail": "x: int\n\ntype r = {x: int, y: string}",
+    "documentation": null
+  }, {
+    "label": "y",
+    "kind": 5,
+    "tags": [],
+    "detail": "y: string\n\ntype r = {x: int, y: string}",
     "documentation": null
   }]
 


### PR DESCRIPTION
The current function to extract record types looks for a type definition, and expect it to be a record.
The new one keeps on expanding type definitions until it finds a record. In this way, it handles type aliases.

Fixes https://github.com/rescript-lang/rescript-vscode/issues/311