### PR TITLE
Fix escaped backtick highlighting in string literal (#324)

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -127,7 +127,7 @@
         {
           "name": "string.template",
           "begin": "([a-z_][0-9a-zA-Z_]*)?(`)",
-          "end": "[^\\]`",
+          "end": "[^\\\\]`",
           "beginCaptures": {
             "1": {
               "name": "variables.annotation"

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -127,7 +127,7 @@
         {
           "name": "string.template",
           "begin": "([a-z_][0-9a-zA-Z_]*)?(`)",
-          "end": "`",
+          "end": "[^\\]`",
           "beginCaptures": {
             "1": {
               "name": "variables.annotation"


### PR DESCRIPTION
should fix #324:
```res
let regex = `\``

let foo = 10
```

Should I first create a PR in [rescript-lang/rescript-sublime](https://github.com/rescript-lang/rescript-sublime)? 