### PR TITLE
Fix issue in the calculation of struct/signature scopes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix issue in JSX autocompletion where the `key` label would always appear.
 - Fix issue in record field autocomplete not working with type aliases.
 - Support autocomplete of records for variables defined in other files.
+- Fix issue where autocomplete for local values would not work in the presence of `@react.component` annotations.
 
 ## 1.1.3
 

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -2,6 +2,7 @@ open Typedtree
 open SharedTypes
 
 let itemsExtent items =
+  let items = items |> List.filter (fun item -> not item.str_loc.loc_ghost) in
   match items with
   | [] -> Location.none
   | first :: _ ->
@@ -18,6 +19,7 @@ let itemsExtent items =
     }
 
 let sigItemsExtent items =
+  let items = items |> List.filter (fun item -> not item.sig_loc.loc_ghost) in
   match items with
   | [] -> Location.none
   | first :: _ ->

--- a/analysis/tests/src/Completion.res
+++ b/analysis/tests/src/Completion.res
@@ -90,3 +90,11 @@ let r:rAlias = assert false
 // ^com r.
 
 // ^com Obj.Rec.recordVal.
+
+let myAmazingFunction = (x,y) => x+y
+
+@react.component
+let make = () => {
+// ^com my
+  <> </>
+}

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -569,6 +569,16 @@ DocumentSymbol tests/src/Completion.res
         "name": "r",
         "kind": 13,
         "location": {"uri": "Completion.res", "range": {"start": {"line": 88, "character": 4}, "end": {"line": 88, "character": 5}}}
+},
+{
+        "name": "myAmazingFunction",
+        "kind": 12,
+        "location": {"uri": "Completion.res", "range": {"start": {"line": 93, "character": 4}, "end": {"line": 93, "character": 21}}}
+},
+{
+        "name": "make",
+        "kind": 12,
+        "location": {"uri": "Completion.res", "range": {"start": {"line": 96, "character": 4}, "end": {"line": 96, "character": 8}}}
 }
 ]
 
@@ -707,6 +717,15 @@ Complete tests/src/Completion.res 90:3
     "kind": 5,
     "tags": [],
     "detail": "ss: string\n\ntype recordt = {xx: int, ss: string}",
+    "documentation": null
+  }]
+
+Complete tests/src/Completion.res 96:3
+[{
+    "label": "myAmazingFunction",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
     "documentation": null
   }]
 


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/323

The computation of scope for a struct/signatures takes the first and last items, ignoring the fact that they could be ghost locations.
In particular, using `@react.component` triggers the ppx which leaves ghost definitions at the end, making the end scope wrong.