### PR TITLE
Dead code analysis editor mode via reanalyze

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,7 +1,10 @@
 import * as fs from "fs";
 import { window, DiagnosticCollection } from "vscode";
 import { LanguageClient, RequestType } from "vscode-languageclient/node";
-import { runDeadCodeAnalysisWithReanalyze } from "./commands/dead_code_analysis";
+import {
+  DiagnosticsResultCodeActionsMap,
+  runDeadCodeAnalysisWithReanalyze,
+} from "./commands/dead_code_analysis";
 
 interface CreateInterfaceRequestParams {
   uri: string;
@@ -34,7 +37,11 @@ export const createInterface = (client: LanguageClient) => {
 };
 
 export const deadCodeAnalysisWithReanalyze = (
-  diagnosticsCollection: DiagnosticCollection
+  diagnosticsCollection: DiagnosticCollection,
+  diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap
 ) => {
-  runDeadCodeAnalysisWithReanalyze(diagnosticsCollection);
+  runDeadCodeAnalysisWithReanalyze(
+    diagnosticsCollection,
+    diagnosticsResultCodeActions
+  );
 };

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -37,10 +37,12 @@ export const createInterface = (client: LanguageClient) => {
 };
 
 export const deadCodeAnalysisWithReanalyze = (
+  targetDir: string | null,
   diagnosticsCollection: DiagnosticCollection,
   diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap
 ) => {
   runDeadCodeAnalysisWithReanalyze(
+    targetDir,
     diagnosticsCollection,
     diagnosticsResultCodeActions
   );

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
-import { window } from "vscode";
+import { window, DiagnosticCollection } from "vscode";
 import { LanguageClient, RequestType } from "vscode-languageclient/node";
+import { runDeadCodeAnalysisWithReanalyze } from "./commands/dead_code_analysis";
 
 interface CreateInterfaceRequestParams {
   uri: string;
@@ -30,4 +31,10 @@ export const createInterface = (client: LanguageClient) => {
   client.sendRequest(createInterfaceRequest, {
     uri: editor.document.uri.toString(),
   });
+};
+
+export const deadCodeAnalysisWithReanalyze = (
+  diagnosticsCollection: DiagnosticCollection
+) => {
+  runDeadCodeAnalysisWithReanalyze(diagnosticsCollection);
 };

--- a/client/src/commands/dead_code_analysis.ts
+++ b/client/src/commands/dead_code_analysis.ts
@@ -105,7 +105,6 @@ let dceTextToDiagnostics = (
     if (processedFileInfo != null) {
       // reanalyze prints the severity first in the title, and then the rest of
       // the title after.
-      window.showInformationMessage(title);
       let [severityRaw, ...issueTitleParts] = title.split(" ");
       let issueTitle = issueTitleParts.join(" ");
 
@@ -189,6 +188,7 @@ let dceTextToDiagnostics = (
 };
 
 export const runDeadCodeAnalysisWithReanalyze = (
+  targetDir: string | null,
   diagnosticsCollection: DiagnosticCollection,
   diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap
 ) => {
@@ -197,12 +197,10 @@ export const runDeadCodeAnalysisWithReanalyze = (
   diagnosticsResultCodeActions.clear();
 
   let currentDocument = window.activeTextEditor.document;
+  let cwd = targetDir ?? path.dirname(currentDocument.uri.fsPath);
 
   let p = cp.spawn("npx", ["reanalyze", "-dce"], {
-    // Pointing reanalyze to the dir of the current file path is fine,
-    // because reanalyze will walk upwards looking for a bsconfig.json in
-    // order to find the correct project root.
-    cwd: path.dirname(currentDocument.uri.fsPath),
+    cwd,
   });
 
   if (p.stdout == null) {

--- a/client/src/commands/dead_code_analysis.ts
+++ b/client/src/commands/dead_code_analysis.ts
@@ -1,0 +1,242 @@
+import * as fs from "fs";
+import * as cp from "child_process";
+import * as path from "path";
+import {
+  window,
+  DiagnosticCollection,
+  Diagnostic,
+  Range,
+  Position,
+  DiagnosticSeverity,
+  Uri,
+} from "vscode";
+import { DocumentUri } from "vscode-languageclient";
+
+let findProjectRootOfFile = (source: DocumentUri): null | DocumentUri => {
+  let dir = path.dirname(source);
+  if (fs.existsSync(path.join(dir, "bsconfig.json"))) {
+    return dir;
+  } else {
+    if (dir === source) {
+      // reached top
+      return null;
+    } else {
+      return findProjectRootOfFile(dir);
+    }
+  }
+};
+
+let fileInfoRegex = /File "(.+)", line (\d)+, characters ([\d-]+)/;
+
+let extractFileInfo = (
+  fileInfo: string
+): {
+  filePath: string;
+  line: string;
+  characters: string;
+} | null => {
+  let m;
+
+  let filePath: string | null = null;
+  let line: string | null = null;
+  let characters: string | null = null;
+
+  while ((m = fileInfoRegex.exec(fileInfo)) !== null) {
+    if (m.index === fileInfoRegex.lastIndex) {
+      fileInfoRegex.lastIndex++;
+    }
+
+    m.forEach((match: string, groupIndex: number) => {
+      switch (groupIndex) {
+        case 1: {
+          filePath = match;
+          break;
+        }
+        case 2: {
+          line = match;
+          break;
+        }
+        case 3: {
+          characters = match;
+          break;
+        }
+      }
+    });
+  }
+
+  if (filePath != null && line != null && characters != null) {
+    return {
+      filePath,
+      line,
+      characters,
+    };
+  }
+
+  return null;
+};
+
+let dceTextToDiagnostics = (
+  dceText: string
+): {
+  diagnosticsMap: Map<string, Diagnostic[]>;
+  hasMoreDiagnostics: boolean;
+  totalDiagnosticsCount: number;
+  savedDiagnostics: number;
+} => {
+  let diagnosticsMap: Map<string, Diagnostic[]> = new Map();
+  let savedDiagnostics = 0;
+  let totalDiagnosticsCount = 0;
+
+  // Each section with a single issue found is seprated by two line breaks in
+  // the reanalyze output. Here's an example of how a section typically looks:
+  //
+  // Warning Dead Value
+  // File "/Users/zth/git/rescript-intro/src/Machine.res", line 2, characters 0-205
+  // +use is never used
+  // <-- line 2
+  // @dead("+use") let use = (initialState: 'a, handleEvent: ('a, 'b) => 'a) => {
+  dceText.split("\n\n").forEach((chunk) => {
+    let [
+      title,
+      fileInfo,
+      text,
+
+      // These aren't in use yet, but can power code actions that can
+      // automatically add the @dead annotations reanalyze is suggesting to us.
+      _lineNumToReplace,
+      _lineContentToReplace,
+
+      ..._rest
+    ] = chunk.split("\n");
+
+    let processedFileInfo = extractFileInfo(fileInfo);
+
+    if (processedFileInfo != null) {
+      // We'll limit the amount of diagnostics to display somewhat. This is also
+      // in part because we don't "watch" for changes with reanalyze, so the
+      // user will need to re-run the command fairly often anyway as issues are
+      // fixed, in order to get rid of the stale problems reported.
+      if (savedDiagnostics > 20) {
+        totalDiagnosticsCount++;
+        return;
+      }
+
+      // reanalyze prints the severity first in the title, and then the rest of
+      // the title after.
+      let [severityRaw, ...issueTitleParts] = title.split(" ");
+      let issueTitle = issueTitleParts.join(" ");
+
+      let [startCharacter, endCharacter] =
+        processedFileInfo.characters.split("-");
+
+      let startPos = new Position(
+        // reanalyze reports lines as index 1 based, while VSCode wants them
+        // index 0 based.
+        parseInt(processedFileInfo.line, 10) - 1,
+        parseInt(startCharacter, 10)
+      );
+
+      // This isn't correct, and will only highlight a single line, even if the
+      // highlight should in fact span multiple lines. This is because reanalyze
+      // gives us a line start, and a character interval. But, VSCode wants a
+      // line for the end of the selection too. And, to figure that out, we'd
+      // need to read the entire file with the issues present and calculate it.
+      // So, postponing that for now. Maybe there's a better way.
+      let endPos = new Position(
+        parseInt(processedFileInfo.line, 10) - 1,
+        parseInt(endCharacter, 10)
+      );
+
+      let severity =
+        severityRaw === "Error"
+          ? DiagnosticSeverity.Error
+          : DiagnosticSeverity.Warning;
+
+      let diagnostic = new Diagnostic(
+        new Range(startPos, endPos),
+        `${issueTitle}: ${text}`,
+        severity
+      );
+
+      savedDiagnostics++;
+
+      if (diagnosticsMap.has(processedFileInfo.filePath)) {
+        diagnosticsMap.get(processedFileInfo.filePath).push(diagnostic);
+      } else {
+        diagnosticsMap.set(processedFileInfo.filePath, [diagnostic]);
+      }
+    }
+  });
+
+  return {
+    diagnosticsMap,
+    hasMoreDiagnostics: totalDiagnosticsCount > savedDiagnostics,
+    savedDiagnostics,
+    totalDiagnosticsCount,
+  };
+};
+
+export const runDeadCodeAnalysisWithReanalyze = (
+  diagnosticsCollection: DiagnosticCollection
+) => {
+  diagnosticsCollection.clear();
+  let currentDocument = window.activeTextEditor.document;
+  let projectRootOfFile = findProjectRootOfFile(currentDocument.uri.fsPath);
+
+  if (!projectRootOfFile) {
+    window.showWarningMessage(
+      "Could not determine project root of current file."
+    );
+    return;
+  }
+
+  const p = cp.spawn("npx", ["reanalyze", "-dce"], {
+    cwd: projectRootOfFile,
+  });
+
+  if (p.stdout == null) {
+    window.showErrorMessage("Something went wrong.");
+    return;
+  }
+
+  let data = "";
+
+  p.stdout.on("data", (d) => {
+    data += d;
+  });
+
+  p.stderr?.on("data", (e) => {
+    // Sometimes the compiler artifacts has been corrupted in some way, and
+    // reanalyze will spit out a "End_of_file" exception. The solution is to
+    // clean and rebuild the ReScript project, which we can tell the user about
+    // here.
+    if (e.includes("End_of_file")) {
+      window.showErrorMessage(
+        `Something went wrong trying to run reanalyze. Please try cleaning and rebuilding your ReScript project, and then run this command again.`
+      );
+    } else {
+      window.showErrorMessage(
+        `Something went wrong trying to run reanalyze: '${e}'`
+      );
+    }
+  });
+
+  p.on("close", () => {
+    let {
+      diagnosticsMap,
+      hasMoreDiagnostics,
+      savedDiagnostics,
+      totalDiagnosticsCount,
+    } = dceTextToDiagnostics(data);
+
+    diagnosticsMap.forEach((diagnostics, filePath) => {
+      diagnosticsCollection.set(Uri.parse(filePath), diagnostics);
+    });
+
+    if (hasMoreDiagnostics) {
+      window.showInformationMessage(
+        `Showing ${savedDiagnostics} of in total ${totalDiagnosticsCount} issues found. Re-run this command again as you fix issues.`
+      );
+    }
+  });
+};

--- a/client/src/commands/dead_code_analysis.ts
+++ b/client/src/commands/dead_code_analysis.ts
@@ -243,9 +243,14 @@ export const runDeadCodeAnalysisWithReanalyze = (
       diagnosticsResultCodeActions
     );
 
-    // Clear old diagnostics and code actions state before setting up the new
-    // state.
-    diagnosticsCollection.clear();
+    // This smoothens the experience of the diagnostics updating a bit by
+    // clearing only the visible diagnostics that has been fixed after the
+    // updated diagnostics has been applied.
+    diagnosticsCollection.forEach((uri, _) => {
+      if (!diagnosticsMap.has(uri.fsPath)) {
+        diagnosticsCollection.delete(uri);
+      }
+    });
 
     diagnosticsMap.forEach((diagnostics, filePath) => {
       diagnosticsCollection.set(Uri.parse(filePath), diagnostics);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -106,15 +106,16 @@ export function activate(context: ExtensionContext) {
     clientOptions
   );
 
-  // Create a custom diagnostics collection, for cases where we want to report diagnostics
-  // programatically from inside of the extension.
+  // Create a custom diagnostics collection, for cases where we want to report
+  // diagnostics programatically from inside of the extension. The reason this
+  // is separate from the diagnostics provided by the LS server itself, is that
+  // this should be possible to clear independently of the other diagnostics
+  // coming from the ReScript compiler itself.
   let diagnosticsCollection = languages.createDiagnosticCollection("rescript");
 
   // This map will hold code actions produced by the dead code analysis.
   let diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap = new Map();
-
   let inDeadCodeAnalysisMode = { current: false };
-
   let deadCodeAnalysisRunningStatusBarItem = window.createStatusBarItem(
     StatusBarAlignment.Right
   );

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { workspace, ExtensionContext, commands } from "vscode";
+import { workspace, ExtensionContext, commands, languages } from "vscode";
 
 import {
   LanguageClient,
@@ -98,10 +98,25 @@ export function activate(context: ExtensionContext) {
     clientOptions
   );
 
+  // Create a custom diagnostics collection, for cases where we want to report diagnostics
+  // programatically from inside of the extension.
+  let diagnosticsCollection = languages.createDiagnosticCollection("rescript");
+
   // Register custom commands
   commands.registerCommand("rescript-vscode.create_interface", () => {
     customCommands.createInterface(client);
   });
+
+  commands.registerCommand("rescript-vscode.run_dead_code_analysis", () => {
+    customCommands.deadCodeAnalysisWithReanalyze(diagnosticsCollection);
+  });
+
+  commands.registerCommand(
+    "rescript-vscode.clear_dead_code_analysis_results",
+    () => {
+      diagnosticsCollection.clear();
+    }
+  );
 
   // Start the client. This will also launch the server
   client.start();

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -108,12 +108,13 @@ export function activate(context: ExtensionContext) {
 
   // Create a custom diagnostics collection, for cases where we want to report
   // diagnostics programatically from inside of the extension. The reason this
-  // is separate from the diagnostics provided by the LS server itself, is that
+  // is separate from the diagnostics provided by the LS server itself is that
   // this should be possible to clear independently of the other diagnostics
-  // coming from the ReScript compiler itself.
+  // coming from the ReScript compiler.
   let diagnosticsCollection = languages.createDiagnosticCollection("rescript");
 
-  // This map will hold code actions produced by the dead code analysis.
+  // This map will hold code actions produced by the dead code analysis, in a
+  // format that's cheap to look up.
   let diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap = new Map();
   let inDeadCodeAnalysisMode = { current: false };
   let deadCodeAnalysisRunningStatusBarItem = window.createStatusBarItem(
@@ -121,7 +122,7 @@ export function activate(context: ExtensionContext) {
   );
 
   // This code actions provider yields the code actions potentially extracted
-  // from the dead code analysis.
+  // from the dead code analysis to the editor.
   languages.registerCodeActionsProvider("rescript", {
     async provideCodeActions(document, rangeOrSelection) {
       let availableActions =

--- a/package.json
+++ b/package.json
@@ -40,12 +40,8 @@
 				"title": "ReScript: Create an interface file for this implementation file."
 			},
 			{
-				"command": "rescript-vscode.run_dead_code_analysis",
-				"title": "ReScript: Run dead code analysis."
-			},
-			{
-				"command": "rescript-vscode.clear_dead_code_analysis_results",
-				"title": "ReScript: Clear dead code analysis results."
+				"command": "rescript-vscode.start_dead_code_analysis",
+				"title": "ReScript: Start dead code analysis."
 			}
 		],
 		"snippets": [

--- a/package.json
+++ b/package.json
@@ -38,6 +38,14 @@
 			{
 				"command": "rescript-vscode.create_interface",
 				"title": "ReScript: Create an interface file for this implementation file."
+			},
+			{
+				"command": "rescript-vscode.run_dead_code_analysis",
+				"title": "ReScript: Run dead code analysis."
+			},
+			{
+				"command": "rescript-vscode.clear_dead_code_analysis_results",
+				"title": "ReScript: Clear dead code analysis results."
 			}
 		],
 		"snippets": [

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -115,6 +115,14 @@ let deleteProjectDiagnostics = (projectRootPath: string) => {
     projectsFiles.delete(projectRootPath);
   }
 };
+let sendCompilationFinishedMessage = () => {
+  let notification: m.NotificationMessage = {
+    jsonrpc: c.jsonrpcVersion,
+    method: "rescript/compilationFinished",
+  };
+  
+  send(notification);
+};
 
 let compilerLogsWatcher = chokidar
   .watch([], {
@@ -124,6 +132,7 @@ let compilerLogsWatcher = chokidar
   })
   .on("all", (_e, changedPath) => {
     sendUpdatedDiagnostics();
+    sendCompilationFinishedMessage();
   });
 let stopWatchingCompilerLog = () => {
   // TODO: cleanup of compilerLogs?


### PR DESCRIPTION
This implements a "Dead code analysis mode". When activated, the extension will run reanalyze continuously as the ReScript compiler runs, and report back any errors found directly into the editor. It'll also set up code actions leveraging the suggestions reanalyze gives for how to suppress the issues reported.

See the video below for more details.

https://user-images.githubusercontent.com/1457626/147784733-4eabe71f-7b20-441b-a9b7-bedda07b4d4e.mp4

Thank you @cristianoc for guidance both around reanalyze and details around how the extension does things.

Happy to hear any feedback or comments, and whether this is something you're interested in merging.
 