### PR TITLE
Don't crash when the binary command returns a large json.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixes:
 - Fix issue in JSX autocompletion where the `key` label would always appear.
 - Fix issue in record field autocomplete not working with type aliases.
 - Fix issue where autocomplete for local values would not work in the presence of `@react.component` annotations.
+- Fix issue where the server would crash on large output produced by the binary command.
 
 ## 1.1.3
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -142,9 +142,11 @@ export let runAnalysisAfterSanityCheck = (
   if (projectRootPath == null) {
     return null;
   }
-  let stdout = childProcess.execFileSync(binaryPath, args, {
+  let options: childProcess.ExecFileSyncOptions = {
     cwd: projectRootPath,
-  });
+    maxBuffer: Infinity,
+  };
+  let stdout = childProcess.execFileSync(binaryPath, args, options);
   return JSON.parse(stdout.toString());
 };
 


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/305