### PR TITLE
Don't crash when the file has a self cycle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Fixes:
 - Fix issue in record field autocomplete not working with type aliases.
 - Fix issue where autocomplete for local values would not work in the presence of `@react.component` annotations.
 - Fix issue where the server would crash on large output produced by the binary command.
+- Fix issue where the server would crash when a file has a self cycle.
 
 ## 1.1.3
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -389,6 +389,14 @@ export let parseCompilerLogOutput = (
         tag: undefined,
         content: [],
       });
+    } else if (line.startsWith("FAILED:")) {
+      // File with a self cycle
+      parsedDiagnostics.push({
+        code: undefined,
+        severity: t.DiagnosticSeverity.Error,
+        tag: undefined,
+        content: [line],
+      });
     } else if (line.startsWith("  Warning number ")) {
       let warningNumber = parseInt(line.slice("  Warning number ".length));
       let tag: t.DiagnosticTag | undefined = undefined;


### PR DESCRIPTION
When there's a self cycle, the compiler.log gives an (out-of-spec) error of the form:
```
FAILED: Tst has a self cycle
```

Notice the compiler is silent when the cycle involves more than one file (the terminal shows an error, but compiler.log is empty).