### PR TITLE
Don't crash on hover when a dependency contains lident application.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master
 - Fix issue with highlighting of templates introduced in release 1.2.0.
 - Fix crash when the project contains OCaml files that have warnings.
-- Fix crash on hover when a dependency (OCaml) contains a type with functor application.
+- Fix crash on hover when a dependency contains a type with functor application. This is not expressible in ReScript syntax, but can appear in a dependent OCaml package and be pulled in for processing by the extension.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 - Fix issue with highlighting of templates introduced in release 1.2.0.
 - Fix crash when the project contains OCaml files that have warnings.
+- Fix crash on hover when a dependency (OCaml) contains a type with functor application.
 
 ## 1.2.0
 

--- a/analysis/tests/src/LongIdentTest.res
+++ b/analysis/tests/src/LongIdentTest.res
@@ -1,0 +1,4 @@
+module Map = TableclothMap
+
+let zz = Map.add
+//           ^hov

--- a/analysis/tests/src/LongIdentTest.res
+++ b/analysis/tests/src/LongIdentTest.res
@@ -2,3 +2,6 @@ module Map = TableclothMap
 
 let zz = Map.add
 //           ^hov
+// Triggers the processing of `Of(M)._t` and Lident.Apply ends up in the AST
+// even though it's not expressible in ReScript syntax.
+// This simulates ReScript projects with OCaml dependencies containing ident apply.

--- a/analysis/tests/src/TableclothMap.ml
+++ b/analysis/tests/src/TableclothMap.ml
@@ -1,0 +1,11 @@
+let add = 3
+
+module Of (M : sig end) = struct
+  type t = int
+end
+
+module M = struct end
+
+module Int = struct
+  type t = Of(M).t
+end

--- a/analysis/tests/src/TableclothMap.ml
+++ b/analysis/tests/src/TableclothMap.ml
@@ -1,11 +1,11 @@
 let add = 3
 
 module Of (M : sig end) = struct
-  type t = int
+  type _t = int
 end
 
 module M = struct end
 
 module Int = struct
-  type t = Of(M).t
+  type _t = Of(M)._t
 end

--- a/analysis/tests/src/TableclothMap.mli
+++ b/analysis/tests/src/TableclothMap.mli
@@ -1,1 +1,3 @@
 val add : int
+
+module Int : sig end

--- a/analysis/tests/src/TableclothMap.mli
+++ b/analysis/tests/src/TableclothMap.mli
@@ -1,0 +1,1 @@
+val add : int

--- a/analysis/tests/src/expected/Debug.res.txt
+++ b/analysis/tests/src/expected/Debug.res.txt
@@ -4,7 +4,7 @@ Dependencies: @rescript/react
 Source directories: tests/node_modules/@rescript/react/./src tests/node_modules/@rescript/react/./src/legacy
 Source files: tests/node_modules/@rescript/react/./src/React.res tests/node_modules/@rescript/react/./src/ReactDOM.res tests/node_modules/@rescript/react/./src/ReactDOMServer.res tests/node_modules/@rescript/react/./src/ReactDOMStyle.res tests/node_modules/@rescript/react/./src/ReactEvent.res tests/node_modules/@rescript/react/./src/ReactEvent.resi tests/node_modules/@rescript/react/./src/ReactTestUtils.res tests/node_modules/@rescript/react/./src/ReactTestUtils.resi tests/node_modules/@rescript/react/./src/RescriptReactErrorBoundary.res tests/node_modules/@rescript/react/./src/RescriptReactErrorBoundary.resi tests/node_modules/@rescript/react/./src/RescriptReactRouter.res tests/node_modules/@rescript/react/./src/RescriptReactRouter.resi tests/node_modules/@rescript/react/./src/legacy/ReactDOMRe.res tests/node_modules/@rescript/react/./src/legacy/ReasonReact.res
 Source directories: tests/src
-Source files: tests/src/Auto.res tests/src/CompletePrioritize1.res tests/src/CompletePrioritize2.res tests/src/Completion.res tests/src/Component.res tests/src/Component.resi tests/src/Cross.res tests/src/Debug.res tests/src/Definition.res tests/src/DefinitionWithInterface.res tests/src/DefinitionWithInterface.resi tests/src/Div.res tests/src/Fragment.res tests/src/Hover.res tests/src/Jsx.res tests/src/Jsx.resi tests/src/Obj.res tests/src/Patterns.res tests/src/RecModules.res tests/src/RecordCompletion.res tests/src/References.res tests/src/ReferencesWithInterface.res tests/src/ReferencesWithInterface.resi tests/src/Rename.res tests/src/RenameWithInterface.res tests/src/RenameWithInterface.resi tests/src/TypeDefinition.res
+Source files: tests/src/Auto.res tests/src/CompletePrioritize1.res tests/src/CompletePrioritize2.res tests/src/Completion.res tests/src/Component.res tests/src/Component.resi tests/src/Cross.res tests/src/Debug.res tests/src/Definition.res tests/src/DefinitionWithInterface.res tests/src/DefinitionWithInterface.resi tests/src/Div.res tests/src/Fragment.res tests/src/Hover.res tests/src/Jsx.res tests/src/Jsx.resi tests/src/LongIdentTest.res tests/src/Obj.res tests/src/Patterns.res tests/src/RecModules.res tests/src/RecordCompletion.res tests/src/References.res tests/src/ReferencesWithInterface.res tests/src/ReferencesWithInterface.resi tests/src/Rename.res tests/src/RenameWithInterface.res tests/src/RenameWithInterface.resi tests/src/TableclothMap.ml tests/src/TableclothMap.mli tests/src/TypeDefinition.res
 Impl cmt:tests/lib/bs/./src/Auto.cmt res:tests/src/Auto.res
 Impl cmt:tests/lib/bs/./src/CompletePrioritize1.cmt res:tests/src/CompletePrioritize1.res
 Impl cmt:tests/lib/bs/./src/CompletePrioritize2.cmt res:tests/src/CompletePrioritize2.res
@@ -18,6 +18,7 @@ Impl cmt:tests/lib/bs/./src/Div.cmt res:tests/src/Div.res
 Impl cmt:tests/lib/bs/./src/Fragment.cmt res:tests/src/Fragment.res
 Impl cmt:tests/lib/bs/./src/Hover.cmt res:tests/src/Hover.res
 IntfAndImpl cmti:tests/lib/bs/./src/Jsx.cmti resi:tests/src/Jsx.resi cmt:tests/lib/bs/./src/Jsx.cmt res:tests/src/Jsx.res
+Impl cmt:tests/lib/bs/./src/LongIdentTest.cmt res:tests/src/LongIdentTest.res
 Impl cmt:tests/lib/bs/./src/Obj.cmt res:tests/src/Obj.res
 Impl cmt:tests/lib/bs/./src/Patterns.cmt res:tests/src/Patterns.res
 Impl cmt:tests/lib/bs/./src/RecModules.cmt res:tests/src/RecModules.res
@@ -26,6 +27,7 @@ Impl cmt:tests/lib/bs/./src/References.cmt res:tests/src/References.res
 IntfAndImpl cmti:tests/lib/bs/./src/ReferencesWithInterface.cmti resi:tests/src/ReferencesWithInterface.resi cmt:tests/lib/bs/./src/ReferencesWithInterface.cmt res:tests/src/ReferencesWithInterface.res
 Impl cmt:tests/lib/bs/./src/Rename.cmt res:tests/src/Rename.res
 IntfAndImpl cmti:tests/lib/bs/./src/RenameWithInterface.cmti resi:tests/src/RenameWithInterface.resi cmt:tests/lib/bs/./src/RenameWithInterface.cmt res:tests/src/RenameWithInterface.res
+IntfAndImpl cmti:tests/lib/bs/./src/TableclothMap.cmti resi:tests/src/TableclothMap.mli cmt:tests/lib/bs/./src/TableclothMap.cmt res:tests/src/TableclothMap.ml
 Impl cmt:tests/lib/bs/./src/TypeDefinition.cmt res:tests/src/TypeDefinition.res
 Dependency dirs: tests/node_modules/@rescript/react/lib/bs/./src tests/node_modules/@rescript/react/lib/bs/./src/legacy
 Opens from bsconfig: 

--- a/analysis/tests/src/expected/LongIdentTest.res.txt
+++ b/analysis/tests/src/expected/LongIdentTest.res.txt
@@ -1,0 +1,3 @@
+Hover tests/src/LongIdentTest.res 2:13
+{"contents": "```rescript\nint\n```"}
+


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/350

Lonident applications in types are only possible in ml, not in rescript. They might show up in the AST with OCaml dependencies.