### PR TITLE
Fix creating interface files for namespaced packages

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -528,10 +528,17 @@ function createInterface(msg: p.RequestMessage): m.Message {
     return response;
   }
 
-  let cmiPartialPath = utils.replaceFileExtension(
-    filePath.split(projDir)[1],
-    c.cmiExt
+  let resPartialPath = filePath.split(projDir)[1];
+
+  // The .cmi filename may have a namespace suffix appended.
+  let namespace = utils.getNamespaceNameFromBsConfig(projDir);
+  let suffixToAppend = namespace ? "-" + namespace : "";
+
+  let cmiPartialPath = path.join(
+    path.dirname(resPartialPath),
+    path.basename(resPartialPath, c.resExt) + suffixToAppend + c.cmiExt
   );
+
   let cmiPath = path.join(projDir, c.compilerDirPartialPath, cmiPartialPath);
   let cmiAvailable = fs.existsSync(cmiPath);
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -531,8 +531,25 @@ function createInterface(msg: p.RequestMessage): m.Message {
   let resPartialPath = filePath.split(projDir)[1];
 
   // The .cmi filename may have a namespace suffix appended.
-  let namespace = utils.getNamespaceNameFromBsConfig(projDir);
-  let suffixToAppend = namespace ? "-" + namespace : "";
+  let namespaceResult = utils.getNamespaceNameFromBsConfig(projDir);
+
+  if (namespaceResult.kind === "error") {
+    let params: p.ShowMessageParams = {
+      type: p.MessageType.Error,
+      message: `Error reading bsconfig file.`,
+    };
+
+    let response: m.NotificationMessage = {
+      jsonrpc: c.jsonrpcVersion,
+      method: "window/showMessage",
+      params,
+    };
+
+    return response;
+  }
+
+  let namespace = namespaceResult.result
+  let suffixToAppend = namespace.length > 0 ? "-" + namespace : "";
 
   let cmiPartialPath = path.join(
     path.dirname(resPartialPath),

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -188,20 +188,31 @@ export const toCamelCase = (text: string): string => {
 
 export const getNamespaceNameFromBsConfig = (
   projDir: p.DocumentUri
-): string | null => {
-  let bsconfigFile = fs.readFileSync(
-    path.join(projDir, c.bsconfigPartialPath),
-    { encoding: "utf-8" }
-  );
+): execResult => {
+  try {
+    let bsconfigFile = fs.readFileSync(
+      path.join(projDir, c.bsconfigPartialPath),
+      { encoding: "utf-8" }
+    );
 
-  let bsconfig = JSON.parse(bsconfigFile);
+    let bsconfig = JSON.parse(bsconfigFile);
+    let result = "";
 
-  if (bsconfig.namespace === true) {
-    return toCamelCase(bsconfig.name);
-  } else if (typeof bsconfig.namespace === "string") {
-    return toCamelCase(bsconfig.namespace);
-  } else {
-    return null;
+    if (bsconfig.namespace === true) {
+      result = toCamelCase(bsconfig.name);
+    } else if (typeof bsconfig.namespace === "string") {
+      result = toCamelCase(bsconfig.namespace);
+    }
+
+    return {
+      kind: "success",
+      result,
+    };
+  } catch (e) {
+    return {
+      kind: "error",
+      error: e instanceof Error ? e.message : String(e),
+    };
   }
 };
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -180,6 +180,31 @@ export let replaceFileExtension = (filePath: string, ext: string): string => {
   return path.format({ dir: path.dirname(filePath), name, ext });
 };
 
+export const toCamelCase = (text: string): string => {
+  return text
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, (s: string) => s.toUpperCase())
+    .replace(/(\s|-)+/g, "");
+};
+
+export const getNamespaceNameFromBsConfig = (
+  projDir: p.DocumentUri
+): string | null => {
+  let bsconfigFile = fs.readFileSync(
+    path.join(projDir, c.bsconfigPartialPath),
+    { encoding: "utf-8" }
+  );
+
+  let bsconfig = JSON.parse(bsconfigFile);
+
+  if (bsconfig.namespace === true) {
+    return toCamelCase(bsconfig.name);
+  } else if (typeof bsconfig.namespace === "string") {
+    return toCamelCase(bsconfig.namespace);
+  } else {
+    return null;
+  }
+};
+
 export let createInterfaceFileUsingValidBscExePath = (
   filePath: string,
   cmiPath: string,


### PR DESCRIPTION
I found out that the compiler appends `-MyNamespace` to `cmi` file names if the `"namespace"` attribute is set in `bsconfig.json`. This case is now handled correctly by the `create-interface` command.