### PR TITLE
Dce touchups

### DIFF
--- a/client/src/commands/dead_code_analysis.ts
+++ b/client/src/commands/dead_code_analysis.ts
@@ -132,15 +132,21 @@ let dceTextToDiagnostics = (
       }
 
       let issueLocationRange = new Range(startPos, endPos);
+      let diagnosticText = text.trim();
 
       let diagnostic = new Diagnostic(
         issueLocationRange,
-        text.trim(),
+        diagnosticText,
         DiagnosticSeverity.Warning
       );
 
-      // This will render the part of the code as unused
-      diagnostic.tags = [DiagnosticTag.Unnecessary];
+      // Everything reanalyze reports is about dead code, except for redundant
+      // optional arguments. This will ensure that everything but reduntant
+      // optional arguments is highlighted as unecessary/unused code in the
+      // editor.
+      if (!diagnosticText.toLowerCase().startsWith("optional argument")) {
+        diagnostic.tags = [DiagnosticTag.Unnecessary];
+      }
 
       if (diagnosticsMap.has(processedFileInfo.filePath)) {
         diagnosticsMap.get(processedFileInfo.filePath).push(diagnostic);

--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
 			{
 				"command": "rescript-vscode.start_dead_code_analysis",
 				"title": "ReScript: Start dead code analysis."
+			},
+			{
+				"command": "rescript-vscode.stop_dead_code_analysis",
+				"title": "ReScript: Stop dead code analysis."
 			}
 		],
 		"menus": {


### PR DESCRIPTION
- Expose the "Stop dead code analysis" command to the user so it can be run via the command palette. We already have the start command exposed, so I think it makes sense to expose the stop command as well, in addition to the stop button in the status bar.
- Do not mark "redundant optional argument" warnings as dead/unused code, since it's not really. Closes https://github.com/rescript-lang/rescript-vscode/issues/362