### PR TITLE
Add GH action to package VSIX file for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,11 +120,15 @@ jobs:
     - name: Cleanup tar file
       run: rm binary.tar
       working-directory: ./server/analysis_binaries
+
+    - name: Store short commit SHA for filename
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       
     - name: Package Extension
-      run: npx vsce package -o rescript-vscode-${{ github.ref_name }}.vsix
+      run: npx vsce package -o rescript-vscode-${{ steps.vars.outputs.sha_short }}.vsix
       
     - uses: actions/upload-artifact@v2
       with:
-        name: rescript-vscode-${{ github.ref_name }}.vsix
-        path: rescript-vscode-${{ github.ref_name }}.vsix
+        name: rescript-vscode-${{ steps.vars.outputs.sha_short }}.vsix
+        path: rescript-vscode-${{ steps.vars.outputs.sha_short }}.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,54 @@ jobs:
       with:
         name: ${{matrix.os}}
         path: analysis/binary.tar
+
+  package:
+    needs: test
+    runs-on: ubuntu-18.04
+  
+    steps:
+    - uses: actions/checkout@v2.3.4
+    
+    - name: Use Node.js
+      uses: actions/setup-node@v2.1.5
+      with:
+        node-version: 14.4.0
+
+    - run: npm ci
+    - run: npm run compile
+    
+    - name: Download MacOS binary
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: macos-latest
+        path: ./server/analysis_binaries
+    - run: tar -xvf binary.tar
+      working-directory: ./server/analysis_binaries
+
+    - name: Download Linux binary
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: ubuntu-18.04
+        path: ./server/analysis_binaries
+    - run: tar -xvf binary.tar
+      working-directory: ./server/analysis_binaries
+
+    - name: Download Windows binary
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: windows-latest
+        path: ./server/analysis_binaries
+    - run: tar -xvf binary.tar
+      working-directory: ./server/analysis_binaries
+
+    - name: Cleanup tar file
+      run: rm binary.tar
+      working-directory: ./server/analysis_binaries
+      
+    - name: Package Extension
+      run: npx vsce package -o rescript-vscode-${{ github.ref_name }}.vsix
+      
+    - uses: actions/upload-artifact@v2
+      with:
+        name: rescript-vscode-${{ github.ref_name }}.vsix
+        path: rescript-vscode-${{ github.ref_name }}.vsix


### PR DESCRIPTION
I thought this would be useful for testing, since it makes it easier for everybody to just download and install the VSIX directly after any master or PR build.

This adds about half a minute of build time.