### PR TITLE
Restore some modules and JSX grammar

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -350,8 +350,133 @@
       ]
     },
     "jsx": {
-      "match": "<>|</>|</|/>",
-      "name": "punctuation.definition.tag"
+      "patterns": [
+        {
+          "match": "<>|</>|</|/>",
+          "name": "punctuation.definition.tag"
+        },
+        {
+          "match": "</([A-Z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.tag"
+            },
+            "1": {
+              "name": "entity.name.namespace"
+            }
+          }
+        },
+        {
+          "match": "</([a-z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.tag"
+            },
+            "1": {
+              "name": "variable"
+            }
+          }
+        },
+        {
+          "match": "<([A-Z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.tag"
+            },
+            "1": {
+              "name": "entity.name.namespace"
+            }
+          }
+        }
+      ]
+    },
+    "openOrIncludeModule": {
+      "patterns": [
+        {
+          "match": "\\b(open|include)\\s+([A-Z_][0-9a-zA-Z_]*((\\.)([A-Z_][0-9a-zA-Z_]*))*)",
+          "captures": {
+            "1": {
+              "name": "keyword"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#moduleAccessEndsWithModule"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "match": "\\b(open|include)\\s+",
+          "name": "keyword"
+        }
+      ]
+    },
+    "moduleAccessEndsWithModule": {
+      "patterns": [
+        {
+          "match": "[A-Z_][0-9a-zA-Z_]*",
+          "name": "entity.name.namespace"
+        },
+        {
+          "match": "(\\.)([A-Z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "1": {
+              "name": "punctuation.accessor"
+            },
+            "2": {
+              "name": "entity.name.namespace"
+            }
+          }
+        }
+      ]
+    },
+    "moduleAccess": {
+      "patterns": [
+        {
+          "match": "\\b([A-Z_][0-9a-zA-Z_]*)(\\.)",
+          "captures": {
+            "1": {
+              "name": "entity.name.namespace"
+            },
+            "2": {
+              "name": "punctuation.accessor"
+            }
+          }
+        }
+      ]
+    },
+    "moduleDeclaration": {
+      "patterns": [
+        {
+          "match": "\\b(module)\\s+(type\\s+)?(of\\s+)?([A-Z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "1": {
+              "name": "keyword"
+            },
+            "2": {
+              "name": "keyword"
+            },
+            "3": {
+              "name": "keyword"
+            },
+            "4": {
+              "name": "entity.name.namespace"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\s*:\\s*([A-Z_][0-9a-zA-Z_]*)",
+              "captures": {
+                "1": {
+                  "name": "entity.name.namespace"
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   },
   "patterns": [

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -248,6 +248,10 @@
     "constructor": {
       "patterns": [
         {
+          "match": "\\b[A-Z][0-9a-zA-Z_]*\\b",
+          "name": "variable.other.enummember"
+        },
+        {
           "match": "(#)\\s*([a-zA-Z][0-9a-zA-Z_]*)\\b",
           "captures": {
             "1": {

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -362,7 +362,7 @@
               "name": "punctuation.definition.tag"
             },
             "1": {
-              "name": "entity.name.namespace"
+              "name": "entity.name.class"
             }
           }
         },
@@ -384,7 +384,7 @@
               "name": "punctuation.definition.tag"
             },
             "1": {
-              "name": "entity.name.namespace"
+              "name": "entity.name.class"
             }
           }
         }
@@ -417,7 +417,7 @@
       "patterns": [
         {
           "match": "[A-Z_][0-9a-zA-Z_]*",
-          "name": "entity.name.namespace"
+          "name": "entity.name.class"
         },
         {
           "match": "(\\.)([A-Z_][0-9a-zA-Z_]*)",
@@ -426,7 +426,7 @@
               "name": "punctuation.accessor"
             },
             "2": {
-              "name": "entity.name.namespace"
+              "name": "entity.name.class"
             }
           }
         }
@@ -438,7 +438,7 @@
           "match": "\\b([A-Z_][0-9a-zA-Z_]*)(\\.)",
           "captures": {
             "1": {
-              "name": "entity.name.namespace"
+              "name": "entity.name.class"
             },
             "2": {
               "name": "punctuation.accessor"
@@ -462,7 +462,7 @@
               "name": "keyword"
             },
             "4": {
-              "name": "entity.name.namespace"
+              "name": "entity.name.class"
             }
           },
           "patterns": [
@@ -470,7 +470,7 @@
               "match": "\\s*:\\s*([A-Z_][0-9a-zA-Z_]*)",
               "captures": {
                 "1": {
-                  "name": "entity.name.namespace"
+                  "name": "entity.name.class"
                 }
               }
             }


### PR DESCRIPTION
As discussed in #380, this PR restores some grammar that got cleaned up in https://github.com/rescript-lang/rescript-vscode/commit/0e56b5e9f061ef06921e5fbde64590fecf77ec9b and https://github.com/rescript-lang/rescript-vscode/commit/dd9c37566522df7ca137f82798c489518309c312.

Here's how it looks with this PR (semantic highlighting on the right for comparison):

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/18074327/161813632-a5328282-c32e-41a1-a5b2-d1c1134bc894.png">
<img width="1729" alt="image" src="https://user-images.githubusercontent.com/18074327/161813710-2cfa7ccd-1867-4dcc-9bcb-e47cd1497809.png">
