### PR TITLE
relax requirement of files being in a ReScript project for formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Report "Fatal error" when it happens in the compiler log (e.g. a make function with type annotation) and don't crash the extension.
 - Fix issue in functions the form "~foo as name" where the location would only cover "ame".
 - Extend the command to create an interface file, to support components and ReScript decorators used in bindings.
+- Enable formatting files without needing the file to be in an actual ReScript project.
 
 ## 1.2.1
 

--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -56,6 +56,10 @@ Options:
 
     ./rescript-editor-analysis.exe createInterface src/MyFile.res lib/bs/src/MyFile.cmi
 
+  format: print to stdout the formatted version of the provided file
+
+    ./rescript-editor-analysis.exe format src/MyFile.res
+
   test: run tests specified by special comments in file src/MyFile.res
 
     ./rescript-editor-analysis.exe test src/src/MyFile.res
@@ -86,6 +90,7 @@ let main () =
   | [_; "createInterface"; path; cmiFile] ->
     Printf.printf "\"%s\""
       (Json.escape (CreateInterface.command ~path ~cmiFile))
+  | [_; "format"; path] -> Commands.format ~path
   | [_; "test"; path] -> Commands.test ~path
   | args when List.mem "-h" args || List.mem "--help" args -> prerr_endline help
   | _ ->

--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -90,7 +90,8 @@ let main () =
   | [_; "createInterface"; path; cmiFile] ->
     Printf.printf "\"%s\""
       (Json.escape (CreateInterface.command ~path ~cmiFile))
-  | [_; "format"; path] -> Commands.format ~path
+  | [_; "format"; path] ->
+    Printf.printf "\"%s\"" (Json.escape (Commands.format ~path))
   | [_; "test"; path] -> Commands.test ~path
   | args when List.mem "-h" args || List.mem "--help" args -> prerr_endline help
   | _ ->

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -250,6 +250,19 @@ let rename ~path ~line ~col ~newName =
   in
   print_endline result
 
+let format ~path =
+  if Filename.check_suffix path ".res" then
+    let {Res_driver.parsetree = structure; comments} =
+      Res_driver.parsingEngine.parseImplementation ~forPrinter:true
+        ~filename:path
+    in
+    Res_driver.printEngine.printImplementation 80 path comments structure
+  else if Filename.check_suffix path ".resi" then
+    let {Res_driver.parsetree = structure; comments} =
+      Res_driver.parsingEngine.parseInterface ~forPrinter:true ~filename:path
+    in
+    Res_driver.printEngine.printInterface 80 path comments structure
+
 let test ~path =
   Uri2.stripPath := true;
   match Files.readFile path with

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -212,16 +212,20 @@ let rename ~path ~line ~col ~newName =
 
 let format ~path =
   if Filename.check_suffix path ".res" then
-    let {Res_driver.parsetree = structure; comments} =
+    let {Res_driver.parsetree = structure; comments; diagnostics} =
       Res_driver.parsingEngine.parseImplementation ~forPrinter:true
         ~filename:path
     in
-    Res_printer.printImplementation !Res_cli.ResClflags.width structure comments
+    if List.length diagnostics > 0 then ""
+    else
+      Res_printer.printImplementation !Res_cli.ResClflags.width structure
+        comments
   else if Filename.check_suffix path ".resi" then
-    let {Res_driver.parsetree = signature; comments} =
+    let {Res_driver.parsetree = signature; comments; diagnostics} =
       Res_driver.parsingEngine.parseInterface ~forPrinter:true ~filename:path
     in
-    Res_printer.printInterface !Res_cli.ResClflags.width signature comments
+    if List.length diagnostics > 0 then ""
+    else Res_printer.printInterface !Res_cli.ResClflags.width signature comments
   else ""
 
 let test ~path =

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -256,12 +256,14 @@ let format ~path =
       Res_driver.parsingEngine.parseImplementation ~forPrinter:true
         ~filename:path
     in
-    Res_driver.printEngine.printImplementation 80 path comments structure
+    Res_driver.printEngine.printImplementation !Res_cli.ResClflags.width path
+      comments structure
   else if Filename.check_suffix path ".resi" then
-    let {Res_driver.parsetree = structure; comments} =
+    let {Res_driver.parsetree = signature; comments} =
       Res_driver.parsingEngine.parseInterface ~forPrinter:true ~filename:path
     in
-    Res_driver.printEngine.printInterface 80 path comments structure
+    Res_driver.printEngine.printInterface !Res_cli.ResClflags.width path
+      comments signature
 
 let test ~path =
   Uri2.stripPath := true;

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -256,14 +256,13 @@ let format ~path =
       Res_driver.parsingEngine.parseImplementation ~forPrinter:true
         ~filename:path
     in
-    Res_driver.printEngine.printImplementation !Res_cli.ResClflags.width path
-      comments structure
+    Res_printer.printImplementation !Res_cli.ResClflags.width structure comments
   else if Filename.check_suffix path ".resi" then
     let {Res_driver.parsetree = signature; comments} =
       Res_driver.parsingEngine.parseInterface ~forPrinter:true ~filename:path
     in
-    Res_driver.printEngine.printInterface !Res_cli.ResClflags.width path
-      comments signature
+    Res_printer.printInterface !Res_cli.ResClflags.width signature comments
+  else ""
 
 let test ~path =
   Uri2.stripPath := true;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -466,7 +466,7 @@ function format(msg: p.RequestMessage): Array<m.Message> {
 
     // code will always be defined here, even though technically it can be undefined
     let code = getOpenedFileContent(params.textDocument.uri);
-    let formattedResult = utils.formatUsingValidBscNativePath(
+    let formattedResult = utils.formatCode(
       code,
       bscNativePath,
       extension === c.resiExt

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -457,49 +457,37 @@ function format(msg: p.RequestMessage): Array<m.Message> {
     // See comment on findBscNativeDirOfFile for why we need
     // to recursively search for bsc.exe upward
     let bscNativePath = utils.findBscNativeOfFile(filePath);
-    if (bscNativePath === null) {
-      let params: p.ShowMessageParams = {
-        type: p.MessageType.Error,
-        message: `Cannot find a nearby bsc.exe in rescript or bs-platform. It's needed for formatting.`,
-      };
-      let response: m.NotificationMessage = {
-        jsonrpc: c.jsonrpcVersion,
-        method: "window/showMessage",
-        params: params,
-      };
-      return [fakeSuccessResponse, response];
-    } else {
-      // code will always be defined here, even though technically it can be undefined
-      let code = getOpenedFileContent(params.textDocument.uri);
-      let formattedResult = utils.formatUsingValidBscNativePath(
-        code,
-        bscNativePath,
-        extension === c.resiExt
-      );
-      if (formattedResult.kind === "success") {
-        let max = code.length;
-        let result: p.TextEdit[] = [
-          {
-            range: {
-              start: { line: 0, character: 0 },
-              end: { line: max, character: max },
-            },
-            newText: formattedResult.result,
+
+    // code will always be defined here, even though technically it can be undefined
+    let code = getOpenedFileContent(params.textDocument.uri);
+    let formattedResult = utils.formatUsingValidBscNativePath(
+      code,
+      bscNativePath,
+      extension === c.resiExt
+    );
+    if (formattedResult.kind === "success") {
+      let max = code.length;
+      let result: p.TextEdit[] = [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: max, character: max },
           },
-        ];
-        let response: m.ResponseMessage = {
-          jsonrpc: c.jsonrpcVersion,
-          id: msg.id,
-          result: result,
-        };
-        return [response];
-      } else {
-        // let the diagnostics logic display the updated syntax errors,
-        // from the build.
-        // Again, not sending the actual errors. See fakeSuccessResponse
-        // above for explanation
-        return [fakeSuccessResponse];
-      }
+          newText: formattedResult.result,
+        },
+      ];
+      let response: m.ResponseMessage = {
+        jsonrpc: c.jsonrpcVersion,
+        id: msg.id,
+        result: result,
+      };
+      return [response];
+    } else {
+      // let the diagnostics logic display the updated syntax errors,
+      // from the build.
+      // Again, not sending the actual errors. See fakeSuccessResponse
+      // above for explanation
+      return [fakeSuccessResponse];
     }
   }
 }

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -121,7 +121,6 @@ export let formatUsingValidBscNativePath = (
       let result = runAnalysisAfterSanityCheck(
         formatTempFileFullPath,
         ["format", formatTempFileFullPath],
-        false,
         false
       );
 
@@ -144,8 +143,7 @@ export let formatUsingValidBscNativePath = (
 export let runAnalysisAfterSanityCheck = (
   filePath: p.DocumentUri,
   args: Array<any>,
-  projectRequired = false,
-  parseJson = true
+  projectRequired = false
 ) => {
   let binaryPath;
   if (fs.existsSync(c.analysisDevPath)) {
@@ -166,11 +164,7 @@ export let runAnalysisAfterSanityCheck = (
   };
   let stdout = childProcess.execFileSync(binaryPath, args, options);
 
-  if (parseJson) {
-    return JSON.parse(stdout.toString());
-  } else {
-    return stdout.toString();
-  }
+  return JSON.parse(stdout.toString());
 };
 
 export let runAnalysisCommand = (

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -93,7 +93,7 @@ type execResult =
       kind: "error";
       error: string;
     };
-export let formatUsingValidBscNativePath = (
+export let formatCode = (
   code: string,
   bscNativePath: p.DocumentUri | null,
   isInterface: boolean
@@ -123,6 +123,16 @@ export let formatUsingValidBscNativePath = (
         ["format", formatTempFileFullPath],
         false
       );
+
+      // The formatter returning an empty string means it couldn't format the
+      // sources, probably because of errors. In that case, we bail from
+      // formatting by returning the unformatted content.
+      if (result === "") {
+        return {
+          kind: "success",
+          result: code,
+        };
+      }
 
       return {
         kind: "success",


### PR DESCRIPTION
This lifts the current requirement for files to be located in an actual ReScript project to be formatted. It falls back to formatting using the vendored parser pretty printer in the extension itself if the file isn't located in a ReScript project.