### PR TITLE
[poc] detect and transform JSX prop errors to something more readable

### DIFF
--- a/server/src/processDiagnosticMessage.ts
+++ b/server/src/processDiagnosticMessage.ts
@@ -1,0 +1,77 @@
+import { filter } from "./vendor/fuzzy";
+
+export let processDiagnosticMessage = (diagnosticMessage: string[]) => {
+  // TODO: This should be upstreamed to the compiler at some point soon.
+  // Heuristic for detecting whether this is a JSX call.
+  if (
+    diagnosticMessage[0]?.trim() ===
+      "The function applied to this argument has type" &&
+    // We assume that we can detect JSX calls by checking if they have an
+    // optional key label, and that it returns `ReactDOM.Props.domProps`.
+    diagnosticMessage.some((line) => line.trim().includes("~?key: string,")) &&
+    diagnosticMessage.some((line) =>
+      line.trim().endsWith(") => ReactDOM.Props.domProps")
+    )
+  ) {
+    let targetLabel = diagnosticMessage[diagnosticMessage.length - 1]
+      .split("This argument cannot be applied with label ~")[1]
+      ?.trim();
+
+    if (targetLabel != null) {
+      type jsxProp = {
+        name: string;
+        type: string;
+        optional: boolean;
+      };
+
+      let allLabels: jsxProp[] = [];
+
+      diagnosticMessage.forEach((line) => {
+        let trimmed = line.trim();
+        if (trimmed.startsWith("~")) {
+          let regex = /~(.+?): (.+),/;
+          let matched = trimmed.match(regex);
+
+          if (matched === null) {
+            return;
+          }
+
+          let [_, key, type] = matched;
+          let optional = key.startsWith("?");
+
+          allLabels.push({
+            name: optional ? key.slice(1) : key,
+            type,
+            optional,
+          });
+        }
+      });
+
+      if (allLabels.length > 0) {
+        let message = `This JSX element does not take the prop \`${targetLabel}\`.`;
+
+        let didYouMean = filter(targetLabel, allLabels, {
+          extract: (prop) => prop.name,
+        })[0];
+
+        if (didYouMean != null) {
+          let didYouMeanJsxProp = allLabels.find(
+            (label) => label.name === didYouMean.string
+          );
+          if (didYouMeanJsxProp != null) {
+            message += `\nDid you mean \`${didYouMeanJsxProp.name}\`?\n\n${
+              didYouMeanJsxProp.name
+            }: ${didYouMeanJsxProp.type}${
+              didYouMeanJsxProp.optional ? "=?" : ""
+            }`;
+          }
+        }
+
+        return message + "\n";
+      }
+    }
+  }
+
+  // remove start and end whitespaces/newlines
+  return diagnosticMessage.join("\n").trim() + "\n";
+};

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -9,6 +9,7 @@ import {
 } from "vscode-languageserver-protocol";
 import fs from "fs";
 import * as os from "os";
+import { processDiagnosticMessage } from "./processDiagnosticMessage";
 
 let tempFilePrefix = "rescript_format_file_" + process.pid + "_";
 let tempFileId = 0;
@@ -609,8 +610,7 @@ export let parseCompilerLogOutput = (
       code: parsedDiagnostic.code,
       range,
       source: "ReScript",
-      // remove start and end whitespaces/newlines
-      message: diagnosticMessage.join("\n").trim() + "\n",
+      message: processDiagnosticMessage(diagnosticMessage),
     });
   });
 

--- a/server/src/vendor/fuzzy.ts
+++ b/server/src/vendor/fuzzy.ts
@@ -1,0 +1,188 @@
+// @ts-nocheck
+// NOTE: Taken and inlined from https://github.com/mattyork/fuzzy/
+
+/*
+ * Fuzzy
+ * https://github.com/myork/fuzzy
+ *
+ * Copyright (c) 2012 Matt York
+ * Licensed under the MIT license.
+ */
+
+/**
+ * Return all elements of `array` that have a fuzzy match against `pattern`.
+ */
+export declare function simpleFilter(
+  pattern: string,
+  array: string[]
+): string[];
+
+/**
+ * Does `pattern` fuzzy match `inputString`?
+ */
+export declare function test(pattern: string, inputString: string): boolean;
+
+export interface MatchOptions {
+  pre?: string;
+  post?: string;
+  caseSensitive?: boolean;
+}
+
+export interface MatchResult {
+  rendered: string;
+  score: number;
+}
+
+/**
+ * If `pattern` matches `inputString`, wrap each matching character in `opts.pre`
+ * and `opts.post`. If no match, return null.
+ */
+export declare function match(
+  pattern: string,
+  inputString: string,
+  opts?: MatchOptions
+): MatchResult;
+
+export interface FilterOptions<T> {
+  pre?: string;
+  post?: string;
+  extract?(input: T): string;
+}
+
+export interface FilterResult<T> {
+  string: string;
+  score: number;
+  index: number;
+  original: T;
+}
+
+/**
+ * The normal entry point. Filters `arr` for matches against `pattern`.
+ */
+export declare function filter<T>(
+  pattern: string,
+  arr: T[],
+  opts?: FilterOptions<T>
+): FilterResult<T>[];
+
+// Return all elements of `array` that have a fuzzy
+// match against `pattern`.
+export const simpleFilter = function (pattern, array) {
+  return array.filter(function (str) {
+    return test(pattern, str);
+  });
+};
+
+// Does `pattern` fuzzy match `str`?
+export const test = function (pattern, str) {
+  return match(pattern, str) !== null;
+};
+
+// If `pattern` matches `str`, wrap each matching character
+// in `opts.pre` and `opts.post`. If no match, return null
+export const match = function (pattern, str, opts) {
+  opts = opts || {};
+  var patternIdx = 0,
+    result = [],
+    len = str.length,
+    totalScore = 0,
+    currScore = 0,
+    // prefix
+    pre = opts.pre || "",
+    // suffix
+    post = opts.post || "",
+    // String to compare against. This might be a lowercase version of the
+    // raw string
+    compareString = (opts.caseSensitive && str) || str.toLowerCase(),
+    ch;
+
+  pattern = (opts.caseSensitive && pattern) || pattern.toLowerCase();
+
+  // For each character in the string, either add it to the result
+  // or wrap in template if it's the next string in the pattern
+  for (var idx = 0; idx < len; idx++) {
+    ch = str[idx];
+    if (compareString[idx] === pattern[patternIdx]) {
+      ch = pre + ch + post;
+      patternIdx += 1;
+
+      // consecutive characters should increase the score more than linearly
+      currScore += 1 + currScore;
+    } else {
+      currScore = 0;
+    }
+    totalScore += currScore;
+    result[result.length] = ch;
+  }
+
+  // return rendered string if we have a match for every char
+  if (patternIdx === pattern.length) {
+    // if the string is an exact match with pattern, totalScore should be maxed
+    totalScore = compareString === pattern ? Infinity : totalScore;
+    return { rendered: result.join(""), score: totalScore };
+  }
+
+  return null;
+};
+
+// The normal entry point. Filters `arr` for matches against `pattern`.
+// It returns an array with matching values of the type:
+//
+//     [{
+//         string:   '<b>lah' // The rendered string
+//       , index:    2        // The index of the element in `arr`
+//       , original: 'blah'   // The original element in `arr`
+//     }]
+//
+// `opts` is an optional argument bag. Details:
+//
+//    opts = {
+//        // string to put before a matching character
+//        pre:     '<b>'
+//
+//        // string to put after matching character
+//      , post:    '</b>'
+//
+//        // Optional function. Input is an entry in the given arr`,
+//        // output should be the string to test `pattern` against.
+//        // In this example, if `arr = [{crying: 'koala'}]` we would return
+//        // 'koala'.
+//      , extract: function(arg) { return arg.crying; }
+//    }
+export const filter = function (pattern, arr, opts) {
+  if (!arr || arr.length === 0) {
+    return [];
+  }
+  if (typeof pattern !== "string") {
+    return arr;
+  }
+  opts = opts || {};
+  return (
+    arr
+      .reduce(function (prev, element, idx, arr) {
+        var str = element;
+        if (opts.extract) {
+          str = opts.extract(element);
+        }
+        var rendered = match(pattern, str, opts);
+        if (rendered != null) {
+          prev[prev.length] = {
+            string: rendered.rendered,
+            score: rendered.score,
+            index: idx,
+            original: element,
+          };
+        }
+        return prev;
+      }, [])
+
+      // Sort by score. Browsers are inconsistent wrt stable/unstable
+      // sorting, so force stable by using the index in the case of tie.
+      // See http://ofb.net/~sethml/is-sort-stable.html
+      .sort(function (a, b) {
+        var compare = b.score - a.score;
+        if (compare) return compare;
+        return a.index - b.index;
+      })
+  );
+};


### PR DESCRIPTION
_This is a PoC, and should probably be implemented for real in the compiler instead of here._

This PR detects and modifies errors that come from trying to set a prop on a JSX DOM element that does not exist. Example:

```rescript
// It's "onChange", not "onchange"
<div onchange={_ => {....
```

When doing so currently the error produced by the compiler prints the full `domProps` record (which has almost 500 props), and in general doesn't really help the user figuring out what went wrong (and what it can do to fix it). The current error looks something like this:

```
...
 ~?typeof: string,
  ~?vocab: string,
  ~?dangerouslySetInnerHTML: {"__html": string},
  ~?suppressContentEditableWarning: bool,
) => ReactDOM.Props.domProps
This argument cannot be applied with label ~onchange
```

And after this fix, that same error will look like this:
```
This JSX element does not take the prop `onchange`. 
Did you mean `onChange`?

`onChange: ReactEvent.Form.t => unit=?`
```

Here's a GIF showing what it looks like in the editor:

![rescript-intro-1649834066802](https://user-images.githubusercontent.com/1457626/163164007-754f9222-f36f-4fcb-aebe-f4850ee1af49.gif)

A few extra things to note:
- This only applies for _DOM JSX elements_, not for custom components like `<MyComponent someProp />`. Those errors are a lot better than the DOM JSX errors (although they could probably use some cleaning up eventually too).
- The full, underlying error is still displayed in the terminal (or wherever the ReScript compiler is run).
- The error message itself will be upstreamed to the compiler if users end up liking this representation.
- The loc's for the error does not point to the label itself because of reasons, but in the future if it does, we can also produce a quick fix code action here to replace the prop name with the hint provided.
- A technical note - I vendored a small and self contained fuzzy match implementation I found, so we can continue having 0 dependencies.

