### PR TITLE
Do not complete from Pervasives by default.

### DIFF
--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -225,6 +225,8 @@ module Completion = struct
   let create ~name ~kind ~env =
     {name; env; deprecated = None; docstring = []; kind}
 
+  (* https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion *)
+  (* https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemKind *)
   let kindToInt kind =
     match kind with
     | Module _ -> 9

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1308,12 +1308,6 @@ Completable: Cpath Value[na]
     "tags": [],
     "detail": "string",
     "documentation": null
-  }, {
-    "label": "nan",
-    "kind": 12,
-    "tags": [],
-    "detail": "float",
-    "documentation": null
   }]
 
 Complete tests/src/Completion.res 239:17

--- a/analysis/tests/src/expected/Debug.res.txt
+++ b/analysis/tests/src/expected/Debug.res.txt
@@ -63,20 +63,16 @@ Complete tests/src/Debug.res 13:8
 posCursor:[13:8] posNoWhite:[13:7] Found expr:[13:5->13:8]
 Pexp_ident eqN:[13:5->13:8]
 Completable: Cpath Value[eqN]
-Opens folkz > 1 Js.place holder
-Package opens Pervasives
-Package opens Pervasives
-fileForModule Impl cmt:tests/node_modules/rescript/lib/ocaml/pervasives.cmti res:tests/node_modules/rescript/lib/ocaml/pervasives.mli
+Raw ppens: 1 Js.place holder
+Package opens 
 resolving open Js.place holder
 resolvePath path:Js.place holder
 Not local
-resolvePath path:Js.place holder
 fileForModule Impl cmt:tests/node_modules/rescript/lib/ocaml/js.cmt res:tests/node_modules/rescript/lib/ocaml/js.ml
 resolvePath path:place holder
-Opens nows 2 pervasives.mli js.ml
+Resolved opens 1 js.ml
 findLocalCompletionsWithOpens uri:Debug.res pos:13:8
 findAllCompletions uri:js.ml
-findAllCompletions uri:pervasives.mli
 [{
     "label": "eqNullable",
     "kind": 12,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -428,6 +428,7 @@ function semanticTokens(msg: p.RequestMessage) {
 }
 
 function completion(msg: p.RequestMessage) {
+  // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
   let params = msg.params as p.ReferenceParams;
   let filePath = fileURLToPath(params.textDocument.uri);
   let extension = path.extname(params.textDocument.uri);


### PR DESCRIPTION
Pervasives can lead to very noisy autocompletion.
Don't use values from Pervasives by default.
Can be explicitly triggered by `Pervasives.`.