### PR TITLE
Add vsce pre-release step to CI

### DIFF
--- a/.github/workflows/bump-version.js
+++ b/.github/workflows/bump-version.js
@@ -23,6 +23,12 @@ if (semver.minor(latestPublish) === semver.minor(release)) {
 else if (semver.minor(latestPublish) > semver.minor(release)) {
   newVersion = semver.inc(newVersion, "patch", semver.rel);
 }
+// If the main release gets a minor bump but did not get published yet, the package.json version
+// will be higher than the one retrieved from the marketplace, so we need to increment from the main release
+// E.g. package.json gets bumped to 1.5.0 -> 1.6.0
+else if (semver.minor(release) - semver.minor(latestPublish) === 1) {
+  newVersion = semver.inc(release, "minor", semver.rel);
+}
 // Otherwise throw an error, because the pre-release version should always be just one
 // minor higher than the release version.
 else {

--- a/.github/workflows/bump-version.js
+++ b/.github/workflows/bump-version.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const path = require("path");
+const semver = require("semver");
+
+const latestPublish = process.argv[2];
+
+const packageJson = fs.readFileSync(path.join("./", "package.json"), {
+  encoding: "utf-8",
+});
+
+let release = JSON.parse(packageJson).version;
+
+let newVersion = latestPublish;
+
+// A prepublished version must be one minor higher than a regular published version.
+// E.g. if package.json has version 1.3.0 and there is no prepublished version yet,
+// increment minor by one -> 1.4.0.
+if (semver.minor(latestPublish) === semver.minor(release)) {
+  newVersion = semver.inc(newVersion, "minor", semver.rel);
+}
+// Increment the version patch. E.g. if we fetch version 1.4.0 as the latest pre-release,
+// increment patch by one -> 1.4.1.
+else if (semver.minor(latestPublish) > semver.minor(release)) {
+  newVersion = semver.inc(newVersion, "patch", semver.rel);
+}
+// Otherwise throw an error, because the pre-release version should always be just one
+// minor higher than the release version.
+else {
+  throw new Error(
+    "Version number minors are more than off by one, check package.json and (pre-)published versions manually."
+  );
+}
+
+if (!semver.valid(newVersion)) {
+  throw new Error("Invalid version string: ", newVersion);
+}
+
+console.log(`::set-output name=new_version::${newVersion}`);

--- a/.github/workflows/bump-version.js
+++ b/.github/workflows/bump-version.js
@@ -12,10 +12,16 @@ let release = JSON.parse(packageJson).version;
 
 let newVersion = latestPublish;
 
+// If the main release gets a major bump but did not get published yet, the package.json version
+// will be higher than the one retrieved from the marketplace, so we need to increment from the main release
+// E.g. package.json gets bumped to 1.5.0 -> 1.6.0
+if (semver.major(release) - semver.major(latestPublish) === 1) {
+  newVersion = semver.inc(release, "minor", semver.rel);
+}
 // A prepublished version must be one minor higher than a regular published version.
 // E.g. if package.json has version 1.3.0 and there is no prepublished version yet,
 // increment minor by one -> 1.4.0.
-if (semver.minor(latestPublish) === semver.minor(release)) {
+else if (semver.minor(latestPublish) === semver.minor(release)) {
   newVersion = semver.inc(newVersion, "minor", semver.rel);
 }
 // Increment the version patch. E.g. if we fetch version 1.4.0 as the latest pre-release,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,10 @@ jobs:
   package:
     needs: test
     runs-on: ubuntu-18.04
-  
+
     steps:
     - uses: actions/checkout@v2.3.4
-    
+
     - name: Use Node.js
       uses: actions/setup-node@v2.1.5
       with:
@@ -92,7 +92,7 @@ jobs:
 
     - run: npm ci
     - run: npm run compile
-    
+
     - name: Download MacOS binary
       uses: actions/download-artifact@v3.0.0
       with:
@@ -126,11 +126,52 @@ jobs:
       env:
         COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: echo "::set-output name=sha_short::${COMMIT_SHA:0:7}"
-      
+
+    - name: Get current pre-release version
+      if: github.ref == 'refs/heads/master'
+      id: get_pre_release
+      run: |
+        JSON=$(npx vsce show chenglou92.rescript-vscode --json)
+        VERSION=$(echo $JSON | jq '.versions | .[0] | .["version"]')
+        echo "::set-output name=current_version::${VERSION}"
+
+    - name: Increment pre-release version
+      if: github.ref == 'refs/heads/master'
+      id: increment_pre_release
+      run: |
+        NEW_VERSION=$(echo ${{ steps.get_pre_release.outputs.current_version }})
+        node .github/workflows/bump-version.js ${NEW_VERSION}
+
     - name: Package Extension
-      run: npx vsce package -o rescript-vscode-${{ steps.vars.outputs.sha_short }}.vsix
-      
+      if: github.ref != 'refs/heads/master'
+      run: npx vsce package  -o rescript-vscode-${{ steps.vars.outputs.sha_short }}.vsix
+
+    - name: Package Extension
+      if: github.ref == 'refs/heads/master'
+      run: npx vsce package  -o rescript-vscode-${{ steps.increment_pre_release.outputs.new_version }}.vsix ${{ steps.increment_pre_release.outputs.new_version }} --no-git-tag-version
+
     - uses: actions/upload-artifact@v2
+      if: github.ref != 'refs/heads/master'
       with:
         name: rescript-vscode-${{ steps.vars.outputs.sha_short }}.vsix
         path: rescript-vscode-${{ steps.vars.outputs.sha_short }}.vsix
+
+    - uses: actions/upload-artifact@v2
+      if: github.ref == 'refs/heads/master'
+      with:
+        name: rescript-vscode-${{ steps.increment_pre_release.outputs.new_version }}.vsix
+        path: rescript-vscode-${{ steps.increment_pre_release.outputs.new_version }}.vsix
+
+    - name: Publish latest master to GitHub
+      if: github.ref == 'refs/heads/master'
+      uses: marvinpinto/action-automatic-releases@latest
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest-master"
+        prerelease: true
+        title: "Latest master"
+        files: rescript-vscode-${{ steps.increment_pre_release.outputs.new_version }}.vsix
+
+    - name: Publish extension as pre-release
+      if: github.ref == 'refs/heads/master'
+      run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --pre-release ${{ steps.increment_pre_release.outputs.new_version }} --no-git-tag-version

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			"devDependencies": {
 				"@types/node": "^14.14.41",
 				"@types/vscode": "1.68.0",
+				"semver": "^7.3.7",
 				"typescript": "^4.7.3"
 			},
 			"engines": {
@@ -30,6 +31,33 @@
 			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
 			"dev": true
 		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "4.7.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
@@ -42,6 +70,12 @@
 			"engines": {
 				"node": ">=4.2.0"
 			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		}
 	},
 	"dependencies": {
@@ -57,10 +91,34 @@
 			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
 			"dev": true
 		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"semver": {
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
+		},
 		"typescript": {
 			"version": "4.7.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
 			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
 	"devDependencies": {
 		"@types/node": "^14.14.41",
 		"@types/vscode": "1.68.0",
-		"typescript": "^4.7.3"
+		"typescript": "^4.7.3",
+		"semver": "^7.3.7"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
 	"devDependencies": {
 		"@types/node": "^14.14.41",
 		"@types/vscode": "1.68.0",
-		"typescript": "^4.7.3",
-		"semver": "^7.3.7"
+		"semver": "^7.3.7",
+		"typescript": "^4.7.3"
 	}
 }


### PR DESCRIPTION
~~This is a first step to having automatic pre-releases published in the VSCode marketplace.~~

Somebody with access rights needs to create a `secrets` environment in this GitHub repository and add (one of) the ReScript team's [Personal Access Token (PAT)](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token) as an environment variable, named  `MARKETPLACE_TOKEN `.

EDIT: 
This PR is basically done, but there is probably still room for some fine-tuning. As mentioned above, someone with write access needs to provide the token(s). 

Also the `chenglou92.rescript-vscode` needs to be updated to whatever will be the VSCode publisher name afterwards.