### PR TITLE
Generalize named argument completion

### DIFF
--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -20,8 +20,9 @@ let completion ~debug ~path ~pos ~currentFile =
           | Some full ->
             let env = SharedTypes.QueryEnv.fromFile full.file in
             let package = full.package in
-            NewCompletions.computeCompletions ~completable ~package ~pos ~scope
-              ~env)
+            completable
+            |> NewCompletions.processCompletable ~debug ~package ~pos ~scope
+                 ~env)
       in
       completionItems
   in

--- a/analysis/src/Completion.ml
+++ b/analysis/src/Completion.ml
@@ -166,7 +166,7 @@ let findExpApplyCompletable ~(args : arg list) ~endPos ~posBeforeCursor
         && posBeforeCursor < labelled.posEnd
       then
         Some
-          (Completable.Clabel
+          (Completable.CnamedArg
              (Completable.CPId (funPath, Value), labelled.name, allNames))
       else if exp.pexp_loc |> Loc.hasPos ~pos:posBeforeCursor then None
       else loop rest
@@ -175,7 +175,7 @@ let findExpApplyCompletable ~(args : arg list) ~endPos ~posBeforeCursor
       else loop rest
     | [] ->
       if posAfterFunName <= posBeforeCursor && posBeforeCursor < endPos then
-        Some (Clabel (Completable.CPId (funPath, Value), "", allNames))
+        Some (CnamedArg (Completable.CPId (funPath, Value), "", allNames))
       else None
   in
   loop args

--- a/analysis/src/Completion.ml
+++ b/analysis/src/Completion.ml
@@ -164,7 +164,10 @@ let findExpApplyCompletable ~(args : arg list) ~endPos ~posBeforeCursor
       if
         labelled.posStart <= posBeforeCursor
         && posBeforeCursor < labelled.posEnd
-      then Some (Completable.Clabel (funPath, labelled.name, allNames))
+      then
+        Some
+          (Completable.Clabel
+             (Completable.CPId (funPath, Value), labelled.name, allNames))
       else if exp.pexp_loc |> Loc.hasPos ~pos:posBeforeCursor then None
       else loop rest
     | {label = None; exp} :: rest ->
@@ -172,7 +175,7 @@ let findExpApplyCompletable ~(args : arg list) ~endPos ~posBeforeCursor
       else loop rest
     | [] ->
       if posAfterFunName <= posBeforeCursor && posBeforeCursor < endPos then
-        Some (Clabel (funPath, "", allNames))
+        Some (Clabel (Completable.CPId (funPath, Value), "", allNames))
       else None
   in
   loop args

--- a/analysis/src/Completion.ml
+++ b/analysis/src/Completion.ml
@@ -75,28 +75,6 @@ let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor ~posAfterCompName
   in
   loop jsxProps.props
 
-let rec skipLineComment ~pos ~i str =
-  if i < String.length str then
-    match str.[i] with
-    | '\n' -> Some ((fst pos + 1, 0), i + 1)
-    | _ -> skipLineComment ~pos:(fst pos, snd pos + 1) ~i:(i + 1) str
-  else None
-
-let rec skipComment ~pos ~i ~depth str =
-  if i < String.length str then
-    match str.[i] with
-    | '\n' -> skipComment ~depth ~pos:(fst pos + 1, 0) ~i:(i + 1) str
-    | '/' when i + 1 < String.length str && str.[i + 1] = '*' ->
-      skipComment ~depth:(depth + 1) ~pos:(fst pos, snd pos + 2) ~i:(i + 2) str
-    | '*' when i + 1 < String.length str && str.[i + 1] = '/' ->
-      if depth > 1 then
-        skipComment ~depth:(depth - 1)
-          ~pos:(fst pos, snd pos + 2)
-          ~i:(i + 2) str
-      else Some ((fst pos, snd pos + 2), i + 2)
-    | _ -> skipComment ~depth ~pos:(fst pos, snd pos + 1) ~i:(i + 1) str
-  else None
-
 let extractJsxProps ~(compName : Longident.t Location.loc) ~args =
   let thisCaseShouldNotHappen =
     {
@@ -147,9 +125,7 @@ type label = labelled option
 type arg = {label : label; exp : Parsetree.expression}
 
 let findExpApplyCompletable ~(args : arg list) ~endPos ~posBeforeCursor
-    ~(funName : Longident.t Location.loc) =
-  let funPath = Utils.flattenLongIdent funName.txt in
-  let posAfterFunName = Loc.end_ funName.loc in
+    ~(contextPath : Completable.contextPath) ~posAfterFunExpr =
   let allNames =
     List.fold_right
       (fun arg allLabels ->
@@ -164,18 +140,15 @@ let findExpApplyCompletable ~(args : arg list) ~endPos ~posBeforeCursor
       if
         labelled.posStart <= posBeforeCursor
         && posBeforeCursor < labelled.posEnd
-      then
-        Some
-          (Completable.CnamedArg
-             (Completable.CPId (funPath, Value), labelled.name, allNames))
+      then Some (Completable.CnamedArg (contextPath, labelled.name, allNames))
       else if exp.pexp_loc |> Loc.hasPos ~pos:posBeforeCursor then None
       else loop rest
     | {label = None; exp} :: rest ->
       if exp.pexp_loc |> Loc.hasPos ~pos:posBeforeCursor then None
       else loop rest
     | [] ->
-      if posAfterFunName <= posBeforeCursor && posBeforeCursor < endPos then
-        Some (CnamedArg (Completable.CPId (funPath, Value), "", allNames))
+      if posAfterFunExpr <= posBeforeCursor && posBeforeCursor < endPos then
+        Some (CnamedArg (contextPath, "", allNames))
       else None
   in
   loop args
@@ -574,10 +547,11 @@ let completionWithParser ~debug ~path ~posCursor ~currentFile ~text =
           setPipeResult ~lhs ~id:"" |> ignore
         | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident "|."}}, [_; _]) ->
           ()
-        | Pexp_apply ({pexp_desc = Pexp_ident funName}, args) ->
+        | Pexp_apply (funExpr, args) ->
           let args = extractExpApplyArgs ~args in
           if debug then
-            Printf.printf "Pexp_apply ...%s (%s)\n" (Loc.toString funName.loc)
+            Printf.printf "Pexp_apply ...%s (%s)\n"
+              (Loc.toString funExpr.pexp_loc)
               (args
               |> List.map (fun {label; exp} ->
                      Printf.sprintf "%s...%s"
@@ -590,9 +564,14 @@ let completionWithParser ~debug ~path ~posCursor ~currentFile ~text =
                        (Loc.toString exp.pexp_loc))
               |> String.concat ", ");
           let expApplyCompletable =
-            findExpApplyCompletable ~funName ~args
-              ~endPos:(Loc.end_ expr.pexp_loc) ~posBeforeCursor
+            match exprToContextPath funExpr with
+            | Some contextPath ->
+              findExpApplyCompletable ~contextPath ~args
+                ~endPos:(Loc.end_ expr.pexp_loc) ~posBeforeCursor
+                ~posAfterFunExpr:(Loc.end_ funExpr.pexp_loc)
+            | None -> None
           in
+
           setResultOpt expApplyCompletable
         | Pexp_send (lhs, {txt; loc}) -> (
           (* e["txt"]

--- a/analysis/src/NewCompletions.ml
+++ b/analysis/src/NewCompletions.ml
@@ -1338,9 +1338,14 @@ let processCompletable ~package ~scope ~env ~pos (completable : Completable.t) =
            in
            dec2)
     |> List.map mkDecorator
-  | Clabel (funPath, prefix, identsSeen) ->
+  | Clabel (cp, prefix, identsSeen) ->
     let labels =
-      match funPath |> findTypeOfValue with
+      match
+        cp
+        |> getCompletionsForContextPath ~package ~opens ~rawOpens ~allFiles ~pos
+             ~env ~exact:true ~scope
+        |> completionsGetTypeEnv
+      with
       | Some (typ, _env) ->
         let rec getLabels (t : Types.type_expr) =
           match t.desc with

--- a/analysis/src/NewCompletions.ml
+++ b/analysis/src/NewCompletions.ml
@@ -1338,7 +1338,7 @@ let processCompletable ~package ~scope ~env ~pos (completable : Completable.t) =
            in
            dec2)
     |> List.map mkDecorator
-  | Clabel (cp, prefix, identsSeen) ->
+  | CnamedArg (cp, prefix, identsSeen) ->
     let labels =
       match
         cp

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -412,7 +412,7 @@ module Completable = struct
 
   type t =
     | Cdecorator of string  (** e.g. @module *)
-    | Clabel of contextPath * string * string list
+    | CnamedArg of contextPath * string * string list
         (** e.g. (..., "label", ["l1", "l2"]) for ...(...~l1...~l2...~label...) *)
     | Cnone  (** e.g. don't complete inside strings *)
     | Cpath of contextPath
@@ -440,8 +440,8 @@ module Completable = struct
     function
     | Cpath cp -> "Cpath " ^ contextPathToString cp
     | Cdecorator s -> "Cdecorator(" ^ str s ^ ")"
-    | Clabel (cp, s, sl2) ->
-      "Clabel("
+    | CnamedArg (cp, s, sl2) ->
+      "CnamedArg("
       ^ (cp |> contextPathToString)
       ^ ", " ^ str s ^ ", " ^ (sl2 |> list) ^ ")"
     | Cnone -> "Cnone"

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -412,8 +412,8 @@ module Completable = struct
 
   type t =
     | Cdecorator of string  (** e.g. @module *)
-    | Clabel of string list * string * string list
-        (** e.g. (["M", "foo"], "label", ["l1", "l2"]) for M.foo(...~l1...~l2...~label...) *)
+    | Clabel of contextPath * string * string list
+        (** e.g. (..., "label", ["l1", "l2"]) for ...(...~l1...~l2...~label...) *)
     | Cnone  (** e.g. don't complete inside strings *)
     | Cpath of contextPath
     | Cjsx of string list * string * string list
@@ -440,8 +440,10 @@ module Completable = struct
     function
     | Cpath cp -> "Cpath " ^ contextPathToString cp
     | Cdecorator s -> "Cdecorator(" ^ str s ^ ")"
-    | Clabel (sl1, s, sl2) ->
-      "Clabel(" ^ (sl1 |> list) ^ ", " ^ str s ^ ", " ^ (sl2 |> list) ^ ")"
+    | Clabel (cp, s, sl2) ->
+      "Clabel("
+      ^ (cp |> contextPathToString)
+      ^ ", " ^ str s ^ ", " ^ (sl2 |> list) ^ ")"
     | Cnone -> "Cnone"
     | Cjsx (sl1, s, sl2) ->
       "Cjsx(" ^ (sl1 |> list) ^ ", " ^ str s ^ ", " ^ (sl2 |> list) ^ ")"

--- a/analysis/tests/src/Completion.res
+++ b/analysis/tests/src/Completion.res
@@ -281,3 +281,13 @@ let _foo = _world => {
 type someType = {hello: string}
 // type t = SomeType(s)
 //                    ^com
+
+type funRecord = {
+  someFun: (~name: string) => unit,
+  stuff: string,
+}
+
+let funRecord: funRecord = assert false
+
+// let _ = funRecord.someFun(~ )
+//                            ^com

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -362,6 +362,7 @@ Complete tests/src/Completion.res 23:20
 posCursor:[23:20] posNoWhite:[23:19] Found expr:[23:11->23:20]
 Pexp_apply ...[23:11->23:18] ()
 Completable: CnamedArg(Value[Lib, foo], "", [])
+Found type for function (~age: int, ~name: string) => string
 [{
     "label": "age",
     "kind": 4,
@@ -513,6 +514,7 @@ Complete tests/src/Completion.res 71:27
 posCursor:[71:27] posNoWhite:[71:26] Found expr:[71:11->71:27]
 Pexp_apply ...[71:11->71:18] (~name71:20->71:24=...[71:20->71:24])
 Completable: CnamedArg(Value[Lib, foo], "", [name])
+Found type for function (~age: int, ~name: string) => string
 [{
     "label": "age",
     "kind": 4,
@@ -525,6 +527,7 @@ Complete tests/src/Completion.res 74:26
 posCursor:[74:26] posNoWhite:[74:25] Found expr:[74:11->74:26]
 Pexp_apply ...[74:11->74:18] (~age74:20->74:23=...[74:20->74:23])
 Completable: CnamedArg(Value[Lib, foo], "", [age])
+Found type for function (~age: int, ~name: string) => string
 [{
     "label": "name",
     "kind": 4,
@@ -537,6 +540,7 @@ Complete tests/src/Completion.res 77:32
 posCursor:[77:32] posNoWhite:[77:31] Found expr:[77:11->77:32]
 Pexp_apply ...[77:11->77:18] (~age77:20->77:23=...[77:25->77:28])
 Completable: CnamedArg(Value[Lib, foo], "", [age])
+Found type for function (~age: int, ~name: string) => string
 [{
     "label": "name",
     "kind": 4,
@@ -549,6 +553,7 @@ Complete tests/src/Completion.res 82:5
 posCursor:[82:5] posNoWhite:[82:4] Found expr:[80:8->86:1]
 Pexp_apply ...[80:8->80:15] (~age84:3->84:6=...[84:7->84:8], ~name85:3->85:7=...[85:8->85:10])
 Completable: CnamedArg(Value[Lib, foo], "", [age, name])
+Found type for function (~age: int, ~name: string) => string
 []
 
 Complete tests/src/Completion.res 90:13
@@ -1065,6 +1070,19 @@ Completable: Cpath Type[s]
     "kind": 22,
     "tags": [],
     "detail": "type someLocalVariant =  SomeLocalVariantItem",
+    "documentation": null
+  }]
+
+Complete tests/src/Completion.res 291:30
+posCursor:[291:30] posNoWhite:[291:29] Found expr:[291:11->291:32]
+Pexp_apply ...[291:11->291:28] ()
+Completable: CnamedArg(Value[funRecord].someFun, "", [])
+Found type for function (~name: string) => unit
+[{
+    "label": "name",
+    "kind": 4,
+    "tags": [],
+    "detail": "string",
     "documentation": null
   }]
 

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -361,7 +361,7 @@ Completable: Cpath Value[Dep, c]
 Complete tests/src/Completion.res 23:20
 posCursor:[23:20] posNoWhite:[23:19] Found expr:[23:11->23:20]
 Pexp_apply ...[23:11->23:18] ()
-Completable: Clabel(Value[Lib, foo], "", [])
+Completable: CnamedArg(Value[Lib, foo], "", [])
 [{
     "label": "age",
     "kind": 4,
@@ -512,7 +512,7 @@ Completable: Cdecorator(react.)
 Complete tests/src/Completion.res 71:27
 posCursor:[71:27] posNoWhite:[71:26] Found expr:[71:11->71:27]
 Pexp_apply ...[71:11->71:18] (~name71:20->71:24=...[71:20->71:24])
-Completable: Clabel(Value[Lib, foo], "", [name])
+Completable: CnamedArg(Value[Lib, foo], "", [name])
 [{
     "label": "age",
     "kind": 4,
@@ -524,7 +524,7 @@ Completable: Clabel(Value[Lib, foo], "", [name])
 Complete tests/src/Completion.res 74:26
 posCursor:[74:26] posNoWhite:[74:25] Found expr:[74:11->74:26]
 Pexp_apply ...[74:11->74:18] (~age74:20->74:23=...[74:20->74:23])
-Completable: Clabel(Value[Lib, foo], "", [age])
+Completable: CnamedArg(Value[Lib, foo], "", [age])
 [{
     "label": "name",
     "kind": 4,
@@ -536,7 +536,7 @@ Completable: Clabel(Value[Lib, foo], "", [age])
 Complete tests/src/Completion.res 77:32
 posCursor:[77:32] posNoWhite:[77:31] Found expr:[77:11->77:32]
 Pexp_apply ...[77:11->77:18] (~age77:20->77:23=...[77:25->77:28])
-Completable: Clabel(Value[Lib, foo], "", [age])
+Completable: CnamedArg(Value[Lib, foo], "", [age])
 [{
     "label": "name",
     "kind": 4,
@@ -548,7 +548,7 @@ Completable: Clabel(Value[Lib, foo], "", [age])
 Complete tests/src/Completion.res 82:5
 posCursor:[82:5] posNoWhite:[82:4] Found expr:[80:8->86:1]
 Pexp_apply ...[80:8->80:15] (~age84:3->84:6=...[84:7->84:8], ~name85:3->85:7=...[85:8->85:10])
-Completable: Clabel(Value[Lib, foo], "", [age, name])
+Completable: CnamedArg(Value[Lib, foo], "", [age, name])
 []
 
 Complete tests/src/Completion.res 90:13

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -361,7 +361,7 @@ Completable: Cpath Value[Dep, c]
 Complete tests/src/Completion.res 23:20
 posCursor:[23:20] posNoWhite:[23:19] Found expr:[23:11->23:20]
 Pexp_apply ...[23:11->23:18] ()
-Completable: Clabel([Lib, foo], "", [])
+Completable: Clabel(Value[Lib, foo], "", [])
 [{
     "label": "age",
     "kind": 4,
@@ -512,7 +512,7 @@ Completable: Cdecorator(react.)
 Complete tests/src/Completion.res 71:27
 posCursor:[71:27] posNoWhite:[71:26] Found expr:[71:11->71:27]
 Pexp_apply ...[71:11->71:18] (~name71:20->71:24=...[71:20->71:24])
-Completable: Clabel([Lib, foo], "", [name])
+Completable: Clabel(Value[Lib, foo], "", [name])
 [{
     "label": "age",
     "kind": 4,
@@ -524,7 +524,7 @@ Completable: Clabel([Lib, foo], "", [name])
 Complete tests/src/Completion.res 74:26
 posCursor:[74:26] posNoWhite:[74:25] Found expr:[74:11->74:26]
 Pexp_apply ...[74:11->74:18] (~age74:20->74:23=...[74:20->74:23])
-Completable: Clabel([Lib, foo], "", [age])
+Completable: Clabel(Value[Lib, foo], "", [age])
 [{
     "label": "name",
     "kind": 4,
@@ -536,7 +536,7 @@ Completable: Clabel([Lib, foo], "", [age])
 Complete tests/src/Completion.res 77:32
 posCursor:[77:32] posNoWhite:[77:31] Found expr:[77:11->77:32]
 Pexp_apply ...[77:11->77:18] (~age77:20->77:23=...[77:25->77:28])
-Completable: Clabel([Lib, foo], "", [age])
+Completable: Clabel(Value[Lib, foo], "", [age])
 [{
     "label": "name",
     "kind": 4,
@@ -548,7 +548,7 @@ Completable: Clabel([Lib, foo], "", [age])
 Complete tests/src/Completion.res 82:5
 posCursor:[82:5] posNoWhite:[82:4] Found expr:[80:8->86:1]
 Pexp_apply ...[80:8->80:15] (~age84:3->84:6=...[84:7->84:8], ~name85:3->85:7=...[85:8->85:10])
-Completable: Clabel([Lib, foo], "", [age, name])
+Completable: Clabel(Value[Lib, foo], "", [age, name])
 []
 
 Complete tests/src/Completion.res 90:13


### PR DESCRIPTION
Instead of requiring the lhs to be a long identifier, now allow a generic context.
E.g. `funRecord.someFun(~ )`