### PR TITLE
Fix issue with error recovery during label completions.

### DIFF
--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -295,20 +295,24 @@ let test ~path =
               ("Complete " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
             let currentFile, cout = Filename.open_temp_file "def" "txt" in
+            let removeLineComment l =
+              let len = String.length l in
+              let rec loop i =
+                if i + 2 <= len && l.[i] = '/' && l.[i + 1] = '/' then
+                  Some (i + 2)
+                else if i + 2 < len && l.[i] = ' ' then loop (i + 1)
+                else None
+              in
+              match loop 0 with
+              | None -> l
+              | Some indexAfterComment ->
+                String.make indexAfterComment ' '
+                ^ String.sub l indexAfterComment (len - indexAfterComment)
+            in
             lines
             |> List.iteri (fun j l ->
                    let lineToOutput =
-                     if
-                       j == i - 1
-                       && String.length l >= 2
-                       && String.sub l 0 2 = "//"
-                     then "  " ^ String.sub l 2 (String.length l - 2)
-                     else if
-                       j == i - 1
-                       && String.length l >= 4
-                       && String.sub l 0 4 = "  //"
-                     then "    " ^ String.sub l 4 (String.length l - 4)
-                     else l
+                     if j == i - 1 then removeLineComment l else l
                    in
                    Printf.fprintf cout "%s\n" lineToOutput);
             close_out cout;

--- a/analysis/tests/src/Completion.res
+++ b/analysis/tests/src/Completion.res
@@ -291,3 +291,14 @@ let funRecord: funRecord = assert false
 
 // let _ = funRecord.someFun(~ )
 //                            ^com
+
+let _ =
+  <div
+    onClick={_ => {
+      ()
+      //        let _: Res
+      //                  ^com
+    }}
+    name="abc">
+    {React.string(name)}
+  </div>

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1086,3 +1086,26 @@ Found type for function (~name: string) => unit
     "documentation": null
   }]
 
+Complete tests/src/Completion.res 298:26
+posCursor:[298:26] posNoWhite:[298:25] Found expr:[295:3->303:8]
+JSX <div:[295:3->295:6] onClick[296:4->296:11]=...[296:13->0:-1]> _children:None
+posCursor:[298:26] posNoWhite:[298:25] Found expr:[296:13->300:6]
+posCursor:[298:26] posNoWhite:[298:25] Found expr:[297:6->300:5]
+posCursor:[298:26] posNoWhite:[298:25] Found expr:[298:16->300:5]
+posCursor:[298:26] posNoWhite:[298:25] Found type:[298:23->300:5]
+Ptyp_constr Res:[298:23->300:5]
+Completable: Cpath Type[Res]
+[{
+    "label": "RescriptReactErrorBoundary",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }, {
+    "label": "RescriptReactRouter",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }]
+


### PR DESCRIPTION
Sometime the parser gets confused while parsing the expr assigned to a prop in `prop = expr`.
In that case the location of `expr` might end into a dummy location when the parser inserts a "rescript.exprhole".
What that happens, don't do label completion to be on the safe side.