### PR TITLE
Syntax highlighting: support more themes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Our highlighting works well with most popular VSCode themes, such as:
 - Monokai Dimmed
 - Tomorrow Night Blue
 - [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
-- [Mariana Pro](https://marketplace.visualstudio.com/items?itemName=rickynormandeau.mariana-pro)
 
 The only 2 themes we don't (and can't) support, due to their lack of coloring, are:
 

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -38,7 +38,7 @@
       "match": "\\b(false|true)\\b"
     },
     "RE_KEYWORD": {
-      "name": "keyword",
+      "name": "storage.type",
       "match": "\\b(include|let|module|of|open|type)\\b"
     },
     "commentLine": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 				"scopes": {
 					"jsx-lowercase": ["entity.name.tag"],
 					"jsx-tag": ["punctuation.definition.tag"],
-					"support-type": ["support.type"]
+					"support-type-primitive": ["support.type.primitive"]
 				}
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 			{
 				"scopes": {
 					"jsx-lowercase": ["entity.name.tag"],
-					"jsx-tag": ["punctuation.definition.tag"]
+					"jsx-tag": ["punctuation.definition.tag"],
+					"support-type": ["support.type"]
 				}
 			}
 		],

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -815,7 +815,7 @@ function onMessage(msg: m.Message) {
               tokenTypes: [
                 "operator",
                 "variable",
-                "type",
+                "support-type",
                 "jsx-tag",
                 "class",
                 "enumMember",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -815,7 +815,7 @@ function onMessage(msg: m.Message) {
               tokenTypes: [
                 "operator",
                 "variable",
-                "support-type",
+                "support-type-primitive",
                 "jsx-tag",
                 "class",
                 "enumMember",


### PR DESCRIPTION
Instead of semantic token `type` use `support.type.primitive` from the grammar. This is what TypeScript does too.

For keywords from the grammar, use `storage.type` instead of `keyword`. Again this is taken from what TS does.

This change is a no-op on the themes considered so far. But improves theme `Solarized Light` and `One Dark Pro`.

Remove `Mariana Pro (Warm)` from the list of recommended themes, as it seems to disable semantic highlighting entirely.
Looks like TS has the same problem there.