### PR TITLE
sharing config between client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Currently does not work for full monorepo dead code analysis (although it should
 
 ## Configuration
 
+You'll find all ReScript specific settings under the scope `rescript.settings`. Open your VSCode settings and type `rescript.settings` to see them.
+
+### Autostarting ReScript builds
+
+If there's no ReScript build running already in the opened project, the extension will prompt you and ask if you want to start a build automatically. You can turn off this automatic prompt via the setting `rescript.settings.askToStartBuild`.
+
 ### Hide generated files
 
 You can configure VSCode to collapse the JavaScript files ReScript generates under its source ReScript file. This will "hide" the generated files in the VSCode file explorer, but still leaving them accessible by expanding the source ReScript file they belong to.
@@ -97,7 +103,7 @@ The example has two patterns added:
 
 ![Shows configuration of file nesting patterns in VSCode.](https://user-images.githubusercontent.com/1457626/168123605-43ef53cf-f371-4f38-b488-d3cd081879de.png)
 
-This nests implementations under interfaces if they're present and nests all generated files under the main ReScript file. Adapt and tweak to your liking. 
+This nests implementations under interfaces if they're present and nests all generated files under the main ReScript file. Adapt and tweak to your liking.
 
 A screenshot of the result:
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -130,6 +130,12 @@ export function activate(context: ExtensionContext) {
       // Notify the server about file changes to '.clientrc files contained in the workspace
       fileEvents: workspace.createFileSystemWatcher("**/.clientrc"),
     },
+    // We'll send the initial configuration in here, but this might be
+    // problematic because every consumer of the LS will need to mimic this.
+    // We'll leave it like this for now, but might be worth revisiting later on.
+    initializationOptions: {
+      extensionConfiguration: workspace.getConfiguration("rescript.settings"),
+    },
   };
 
   // Create the language client and start the client.
@@ -199,8 +205,7 @@ export function activate(context: ExtensionContext) {
     codeAnalysisRunningStatusBarItem.command =
       "rescript-vscode.stop_code_analysis";
     codeAnalysisRunningStatusBarItem.show();
-    codeAnalysisRunningStatusBarItem.text =
-      "$(debug-stop) Stop Code Analyzer";
+    codeAnalysisRunningStatusBarItem.text = "$(debug-stop) Stop Code Analyzer";
 
     customCommands.codeAnalysisWithReanalyze(
       inCodeAnalysisState.activatedFromDirectory,

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
 				"rescript.settings.askToStartBuild": {
 					"scope": "language-overridable",
 					"type": "boolean",
-					"default": 	true,
+					"default": true,
 					"description": "Whether you want the extension to prompt for autostarting a ReScript build if a project is opened with no build running."
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -121,22 +121,11 @@
 			"type": "object",
 			"title": "ReScript",
 			"properties": {
-				"languageServerExample.maxNumberOfProblems": {
-					"scope": "resource",
-					"type": "number",
-					"default": 100,
-					"description": "Controls the maximum number of problems produced by the server."
-				},
-				"languageServerExample.trace.server": {
-					"scope": "window",
-					"type": "string",
-					"enum": [
-						"off",
-						"messages",
-						"verbose"
-					],
-					"default": "off",
-					"description": "Traces the communication between VS Code and the language server."
+				"rescript.settings.askToStartBuild": {
+					"scope": "language-overridable",
+					"type": "boolean",
+					"default": 	true,
+					"description": "Whether you want the extension to prompt for autostarting a ReScript build if a project is opened with no build running."
 				}
 			}
 		},

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -49,3 +49,5 @@ export let startBuildAction = "Start Build";
 // bsconfig defaults according configuration schema (https://rescript-lang.org/docs/manual/latest/build-configuration-schema)
 export let bsconfigModuleDefault = "commonjs";
 export let bsconfigSuffixDefault = ".js";
+
+export let configurationRequestId = "rescript_configuration_request";

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -51,3 +51,4 @@ export let bsconfigModuleDefault = "commonjs";
 export let bsconfigSuffixDefault = ".js";
 
 export let configurationRequestId = "rescript_configuration_request";
+export let pullConfigurationInterval = 10_000;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,6 +11,7 @@ import {
   DidChangeTextDocumentNotification,
   DidCloseTextDocumentNotification,
   DidChangeConfigurationNotification,
+  InitializeParams,
 } from "vscode-languageserver-protocol";
 import * as utils from "./utils";
 import * as codeActions from "./codeActions";
@@ -280,8 +281,6 @@ if (process.argv.includes("--stdio")) {
   send = (msg: m.Message) => process.send!(msg);
   process.on("message", onMessage);
 }
-
-askForAllCurrentConfiguration();
 
 function hover(msg: p.RequestMessage) {
   let params = msg.params as p.HoverParams;
@@ -860,8 +859,14 @@ function onMessage(msg: m.Message) {
         askForAllCurrentConfiguration();
       }, 10_000);
 
-      // Pull config right away as we've initied.
-      askForAllCurrentConfiguration();
+      // Save initial configuration, if present
+      let initParams = msg.params as InitializeParams;
+      let initialConfiguration = initParams.initializationOptions
+        ?.extensionConfiguration as extensionConfiguration | undefined;
+
+      if (initialConfiguration != null) {
+        extensionConfiguration = initialConfiguration;
+      }
 
       send(response);
     } else if (msg.method === "initialized") {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -28,7 +28,7 @@ interface extensionConfiguration {
 let extensionConfiguration: extensionConfiguration = {
   askToStartBuild: true,
 };
-let pullConfigurationInterval: NodeJS.Timeout | null = null;
+let pullConfigurationPeriodically: NodeJS.Timeout | null = null;
 
 // https://microsoft.github.io/language-server-protocol/specification#initialize
 // According to the spec, there could be requests before the 'initialize' request. Link in comment tells how to handle them.
@@ -855,9 +855,9 @@ function onMessage(msg: m.Message) {
       initialized = true;
 
       // Periodically pull configuration from the client.
-      pullConfigurationInterval = setInterval(() => {
+      pullConfigurationPeriodically = setInterval(() => {
         askForAllCurrentConfiguration();
-      }, 10_000);
+      }, c.pullConfigurationInterval);
 
       // Save initial configuration, if present
       let initParams = msg.params as InitializeParams;
@@ -895,8 +895,8 @@ function onMessage(msg: m.Message) {
         stopWatchingCompilerLog();
         // TODO: delete bsb watchers
 
-        if (pullConfigurationInterval != null) {
-          clearInterval(pullConfigurationInterval);
+        if (pullConfigurationPeriodically != null) {
+          clearInterval(pullConfigurationPeriodically);
         }
 
         let response: m.ResponseMessage = {


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/23

This introduces configuration in the extension, periodically synced to the language server for use. We'll probably need to revisit this if we get more intricate configuration needs later on, but for now this is simple enough and will do for the cases we currently have.