### PR TITLE
ensure updated config is synced on use of restart command

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -69,7 +69,44 @@ let client: LanguageClient;
 // });
 
 export function activate(context: ExtensionContext) {
-  function attachCodeAnalysis(client: LanguageClient) {
+  function createLanguageClient() {
+    // The server is implemented in node
+    let serverModule = context.asAbsolutePath(
+      path.join("server", "out", "server.js")
+    );
+    // The debug options for the server
+    // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
+    let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
+
+    // If the extension is launched in debug mode then the debug server options are used
+    // Otherwise the run options are used
+    let serverOptions: ServerOptions = {
+      run: { module: serverModule, transport: TransportKind.ipc },
+      debug: {
+        module: serverModule,
+        transport: TransportKind.ipc,
+        options: debugOptions,
+      },
+    };
+
+    // Options to control the language client
+    let clientOptions: LanguageClientOptions = {
+      documentSelector: [{ scheme: "file", language: "rescript" }],
+      // We'll send the initial configuration in here, but this might be
+      // problematic because every consumer of the LS will need to mimic this.
+      // We'll leave it like this for now, but might be worth revisiting later on.
+      initializationOptions: {
+        extensionConfiguration: workspace.getConfiguration("rescript.settings"),
+      },
+    };
+
+    const client = new LanguageClient(
+      "ReScriptLSP",
+      "ReScript Language Server",
+      serverOptions,
+      clientOptions
+    );
+
     // This sets up a listener that, if we're in code analysis mode, triggers
     // code analysis as the LS server reports that ReScript compilation has
     // finished. This is needed because code analysis must wait until
@@ -89,52 +126,8 @@ export function activate(context: ExtensionContext) {
         })
       );
     });
-  }
 
-  /** creates a language client and attaches code analysis */
-  function createLanguageClient() {
-    const client = new LanguageClient(
-      "ReScriptLSP",
-      "ReScript Language Server",
-      serverOptions,
-      createClientOptions()
-    );
-    attachCodeAnalysis(client);
     return client;
-  }
-
-  // The server is implemented in node
-  let serverModule = context.asAbsolutePath(
-    path.join("server", "out", "server.js")
-  );
-  // The debug options for the server
-  // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-  let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
-
-  // If the extension is launched in debug mode then the debug server options are used
-  // Otherwise the run options are used
-  let serverOptions: ServerOptions = {
-    run: { module: serverModule, transport: TransportKind.ipc },
-    debug: {
-      module: serverModule,
-      transport: TransportKind.ipc,
-      options: debugOptions,
-    },
-  };
-
-  function createClientOptions() {
-    // Options to control the language client
-    let clientOptions: LanguageClientOptions = {
-      documentSelector: [{ scheme: "file", language: "rescript" }],
-      // We'll send the initial configuration in here, but this might be
-      // problematic because every consumer of the LS will need to mimic this.
-      // We'll leave it like this for now, but might be worth revisiting later on.
-      initializationOptions: {
-        extensionConfiguration: workspace.getConfiguration("rescript.settings"),
-      },
-    };
-
-    return clientOptions;
   }
 
   // Create the language client and start the client.

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -97,7 +97,7 @@ export function activate(context: ExtensionContext) {
       "ReScriptLSP",
       "ReScript Language Server",
       serverOptions,
-      clientOptions
+      createClientOptions()
     );
     attachCodeAnalysis(client);
     return client;
@@ -122,21 +122,20 @@ export function activate(context: ExtensionContext) {
     },
   };
 
-  // Options to control the language client
-  let clientOptions: LanguageClientOptions = {
-    // Register the server for plain text documents
-    documentSelector: [{ scheme: "file", language: "rescript" }],
-    synchronize: {
-      // Notify the server about file changes to '.clientrc files contained in the workspace
-      fileEvents: workspace.createFileSystemWatcher("**/.clientrc"),
-    },
-    // We'll send the initial configuration in here, but this might be
-    // problematic because every consumer of the LS will need to mimic this.
-    // We'll leave it like this for now, but might be worth revisiting later on.
-    initializationOptions: {
-      extensionConfiguration: workspace.getConfiguration("rescript.settings"),
-    },
-  };
+  function createClientOptions() {
+    // Options to control the language client
+    let clientOptions: LanguageClientOptions = {
+      documentSelector: [{ scheme: "file", language: "rescript" }],
+      // We'll send the initial configuration in here, but this might be
+      // problematic because every consumer of the LS will need to mimic this.
+      // We'll leave it like this for now, but might be worth revisiting later on.
+      initializationOptions: {
+        extensionConfiguration: workspace.getConfiguration("rescript.settings"),
+      },
+    };
+
+    return clientOptions;
+  }
 
   // Create the language client and start the client.
   client = createLanguageClient();


### PR DESCRIPTION
Initial read configuration was never refreshed as the restart command runs, which means you'd always get potentially stale initial config after a restart.

Also clean up a few init things that I suspect has never been cleaned up after the initial adaption of the LS client example.