### PR TITLE
Investigate heuristics in jump to location.

### DIFF
--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -72,18 +72,22 @@ let main () =
       ~pos:(int_of_string line, int_of_string col)
       ~currentFile
   | [_; "definition"; path; line; col] ->
-    Commands.definition ~path ~line:(int_of_string line)
-      ~col:(int_of_string col)
+    Commands.definition ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~debug:false
   | [_; "typeDefinition"; path; line; col] ->
-    Commands.typeDefinition ~path ~line:(int_of_string line)
-      ~col:(int_of_string col)
+    Commands.typeDefinition ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~debug:false
   | [_; "documentSymbol"; path] -> DocumentSymbol.command ~path
   | [_; "hover"; path; line; col; currentFile] ->
-    Commands.hover ~path ~line:(int_of_string line) ~col:(int_of_string col)
+    Commands.hover ~path
+      ~pos:(int_of_string line, int_of_string col)
       ~currentFile ~debug:false
   | [_; "codeAction"; path; line; col; currentFile] ->
-    Commands.codeAction ~path ~line:(int_of_string line)
-      ~col:(int_of_string col) ~currentFile
+    Commands.codeAction ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~currentFile ~debug:false
   | _ :: "reanalyze" :: _ ->
     let len = Array.length Sys.argv in
     for i = 1 to len - 2 do
@@ -92,11 +96,13 @@ let main () =
     Sys.argv.(len - 1) <- "";
     Reanalyze.cli ()
   | [_; "references"; path; line; col] ->
-    Commands.references ~path ~line:(int_of_string line)
-      ~col:(int_of_string col)
+    Commands.references ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~debug:false
   | [_; "rename"; path; line; col; newName] ->
-    Commands.rename ~path ~line:(int_of_string line) ~col:(int_of_string col)
-      ~newName
+    Commands.rename ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~newName ~debug:false
   | [_; "semanticTokens"; currentFile] ->
     SemanticTokens.semanticTokens ~currentFile
   | [_; "createInterface"; path; cmiFile] ->

--- a/analysis/src/References.ml
+++ b/analysis/src/References.ml
@@ -66,7 +66,7 @@ let getLocItem ~full ~pos ~debug =
   ]
   (* For older compiler 9.0 or earlier *)
     when li1.loc = li2.loc && li2.loc = li3.loc ->
-    (* Not currently testable *)
+    (* Not currently testable on 9.1.4 *)
     log 6
       "heuristic for JSX and compiler combined:\n\
        ~x becomes Js_OO.unsafe_downgrade(Props)#x\n\
@@ -84,7 +84,7 @@ let getLocItem ~full ~pos ~debug =
        heuristic for: [Props, arg], give loc of `arg`";
     Some li2
   | [li1; li2; li3] when li1.loc = li2.loc && li2.loc = li3.loc ->
-    (* Not currently testable *)
+    (* Not currently testable on 9.1.4 *)
     log 8
       "heuristic for JSX with at most one child\n\
        heuristic for: [makeProps, make, createElement], give the loc of `make` ";

--- a/analysis/src/References.ml
+++ b/analysis/src/References.ml
@@ -66,6 +66,7 @@ let getLocItem ~full ~pos ~debug =
   ]
   (* For older compiler 9.0 or earlier *)
     when li1.loc = li2.loc && li2.loc = li3.loc ->
+    (* Not currently testable *)
     log 6
       "heuristic for JSX and compiler combined:\n\
        ~x becomes Js_OO.unsafe_downgrade(Props)#x\n\
@@ -83,6 +84,7 @@ let getLocItem ~full ~pos ~debug =
        heuristic for: [Props, arg], give loc of `arg`";
     Some li2
   | [li1; li2; li3] when li1.loc = li2.loc && li2.loc = li3.loc ->
+    (* Not currently testable *)
     log 8
       "heuristic for JSX with at most one child\n\
        heuristic for: [makeProps, make, createElement], give the loc of `make` ";

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -223,16 +223,14 @@ module AddTypeAnnotation = struct
     in
     {Ast_iterator.default_iterator with structure_item}
 
-  let xform ~path ~pos ~full ~structure ~codeActions =
-    let line, col = pos in
-
+  let xform ~path ~pos ~full ~structure ~codeActions ~debug =
     let result = ref None in
     let iterator = mkIterator ~pos ~result in
     iterator.structure iterator structure;
     match !result with
     | None -> ()
     | Some annotation -> (
-      match References.getLocItem ~full ~line ~col with
+      match References.getLocItem ~full ~pos ~debug with
       | None -> ()
       | Some locItem -> (
         match locItem.locType with
@@ -297,14 +295,14 @@ let parse ~filename =
   in
   (structure, printExpr, printStructureItem)
 
-let extractCodeActions ~path ~pos ~currentFile =
+let extractCodeActions ~path ~pos ~currentFile ~debug =
   match Cmt.fullFromPath ~path with
   | Some full when Filename.check_suffix currentFile ".res" ->
     let structure, printExpr, printStructureItem =
       parse ~filename:currentFile
     in
     let codeActions = ref [] in
-    AddTypeAnnotation.xform ~path ~pos ~full ~structure ~codeActions;
+    AddTypeAnnotation.xform ~path ~pos ~full ~structure ~codeActions ~debug;
     IfThenElse.xform ~pos ~codeActions ~printExpr ~path structure;
     AddBracesToFn.xform ~pos ~codeActions ~path ~printStructureItem structure;
     !codeActions

--- a/analysis/tests/package-lock.json
+++ b/analysis/tests/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "rescript": "9.1.2"
+        "rescript": "^9.1.4"
       },
       "devDependencies": {
         "@rescript/react": "^0.10.3"
@@ -18,9 +18,9 @@
       "dev": true
     },
     "node_modules/rescript": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-9.1.2.tgz",
-      "integrity": "sha512-4wHvTDv3nyYnAPJHcg1RGG8z7u3HDiBf6RN3P/dITDv859Qo35aKOzJWQtfBzbAs0EKNafLqei3TnUqiAv6BwQ==",
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-9.1.4.tgz",
+      "integrity": "sha512-aXANK4IqecJzdnDpJUsU6pxMViCR5ogAxzuqS0mOr8TloMnzAjJFu63fjD6LCkWrKAhlMkFFzQvVQYaAaVkFXw==",
       "hasInstallScript": true,
       "bin": {
         "bsc": "bsc",
@@ -38,9 +38,9 @@
       "dev": true
     },
     "rescript": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-9.1.2.tgz",
-      "integrity": "sha512-4wHvTDv3nyYnAPJHcg1RGG8z7u3HDiBf6RN3P/dITDv859Qo35aKOzJWQtfBzbAs0EKNafLqei3TnUqiAv6BwQ=="
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-9.1.4.tgz",
+      "integrity": "sha512-aXANK4IqecJzdnDpJUsU6pxMViCR5ogAxzuqS0mOr8TloMnzAjJFu63fjD6LCkWrKAhlMkFFzQvVQYaAaVkFXw=="
     }
   }
 }

--- a/analysis/tests/package.json
+++ b/analysis/tests/package.json
@@ -3,11 +3,11 @@
     "build": "rescript",
     "clean": "rescript clean -with-deps"
   },
-  "dependencies": {
-    "rescript": "9.1.2"
-  },
   "private": true,
   "devDependencies": {
     "@rescript/react": "^0.10.3"
+  },
+  "dependencies": {
+    "rescript": "^9.1.4"
   }
 }

--- a/analysis/tests/src/expected/Div.res.txt
+++ b/analysis/tests/src/expected/Div.res.txt
@@ -1,4 +1,5 @@
 Hover src/Div.res 0:10
+getLocItem #3: heuristic for <div>
 {"contents": "```rescript\n(\n  string,\n  ~props: ReactDOMRe.domProps=?,\n  array<React.element>,\n) => React.element\n```"}
 
 Complete src/Div.res 3:17

--- a/analysis/tests/src/expected/Fragment.res.txt
+++ b/analysis/tests/src/expected/Fragment.res.txt
@@ -1,7 +1,10 @@
 Hover src/Fragment.res 6:19
+getLocItem #4: heuristic for </Comp> within fragments: take make as makeProps does not work
+the type is not great but jump to definition works
 {"contents": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n```rescript\ntype component<'props> = componentLike<'props, element>\n```"}
 
 Hover src/Fragment.res 9:56
+getLocItem #2: heuristic for </Comp> within a fragment
 Nothing at that position. Now trying to use completion.
 posCursor:[9:56] posNoWhite:[9:55] Found expr:[9:10->9:67]
 Pexp_construct :::[9:13->9:67] [9:13->9:67]

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -20,9 +20,17 @@ Hover src/Hover.res 33:4
 {"contents": "```rescript\nunit => int\n```\n\nDoc comment for functionWithTypeAnnotation"}
 
 Hover src/Hover.res 37:13
+getLocItem #5: SX and compiler combined:
+~x becomes Props#x
+heuristic for: [Props, x], give loc of `x`
 {"contents": "```rescript\nstring\n```"}
 
 Hover src/Hover.res 41:13
+getLocItem #7: JSX on type-annotated labeled (~arg:t):
+(~arg:t) becomes Props#arg
+Props has the location range of arg:t
+arg has the location range of arg
+heuristic for: [Props, arg], give loc of `arg`
 {"contents": "```rescript\nstring\n```"}
 
 Hover src/Hover.res 44:10
@@ -47,9 +55,13 @@ Hover src/Hover.res 75:7
 {"contents": "```rescript\nmodule A = {\n  let x: int\n}\n```"}
 
 Hover src/Hover.res 85:10
+getLocItem #9: JSX variadic, e.g. <C> {x} {y} </C>
+heuristic for: [makeProps  , React.null, make, createElementVariadic], give the loc of `make`
 {"contents": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n```rescript\ntype component<'props> = componentLike<'props, element>\n```"}
 
 Hover src/Hover.res 88:10
+getLocItem #9: JSX variadic, e.g. <C> {x} {y} </C>
+heuristic for: [makeProps  , React.null, make, createElementVariadic], give the loc of `make`
 {"contents": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n```rescript\ntype component<'props> = componentLike<'props, element>\n```"}
 
 Hover src/Hover.res 93:25

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -20,13 +20,13 @@ Hover src/Hover.res 33:4
 {"contents": "```rescript\nunit => int\n```\n\nDoc comment for functionWithTypeAnnotation"}
 
 Hover src/Hover.res 37:13
-getLocItem #5: SX and compiler combined:
+getLocItem #5: heuristic for JSX and compiler combined:
 ~x becomes Props#x
 heuristic for: [Props, x], give loc of `x`
 {"contents": "```rescript\nstring\n```"}
 
 Hover src/Hover.res 41:13
-getLocItem #7: JSX on type-annotated labeled (~arg:t):
+getLocItem #7: heuristic for JSX on type-annotated labeled (~arg:t):
 (~arg:t) becomes Props#arg
 Props has the location range of arg:t
 arg has the location range of arg
@@ -55,12 +55,12 @@ Hover src/Hover.res 75:7
 {"contents": "```rescript\nmodule A = {\n  let x: int\n}\n```"}
 
 Hover src/Hover.res 85:10
-getLocItem #9: JSX variadic, e.g. <C> {x} {y} </C>
+getLocItem #9: heuristic for JSX variadic, e.g. <C> {x} {y} </C>
 heuristic for: [makeProps  , React.null, make, createElementVariadic], give the loc of `make`
 {"contents": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n```rescript\ntype component<'props> = componentLike<'props, element>\n```"}
 
 Hover src/Hover.res 88:10
-getLocItem #9: JSX variadic, e.g. <C> {x} {y} </C>
+getLocItem #9: heuristic for JSX variadic, e.g. <C> {x} {y} </C>
 heuristic for: [makeProps  , React.null, make, createElementVariadic], give the loc of `make`
 {"contents": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n```rescript\ntype component<'props> = componentLike<'props, element>\n```"}
 

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -23,6 +23,7 @@ Hover src/Hover.res 37:13
 getLocItem #5: heuristic for JSX and compiler combined:
 ~x becomes Props#x
 heuristic for: [Props, x], give loc of `x`
+n1:Props n2:name
 {"contents": "```rescript\nstring\n```"}
 
 Hover src/Hover.res 41:13
@@ -31,6 +32,7 @@ getLocItem #7: heuristic for JSX on type-annotated labeled (~arg:t):
 Props has the location range of arg:t
 arg has the location range of arg
 heuristic for: [Props, arg], give loc of `arg`
+n1:Props n2:name
 {"contents": "```rescript\nstring\n```"}
 
 Hover src/Hover.res 44:10
@@ -56,12 +58,14 @@ Hover src/Hover.res 75:7
 
 Hover src/Hover.res 85:10
 getLocItem #9: heuristic for JSX variadic, e.g. <C> {x} {y} </C>
-heuristic for: [makeProps  , React.null, make, createElementVariadic], give the loc of `make`
+heuristic for: [React.null, makeProps, make, createElementVariadic], give the loc of `make`
+n1:null n2:makeProps n3:make n4:createElementVariadic
 {"contents": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n```rescript\ntype component<'props> = componentLike<'props, element>\n```"}
 
 Hover src/Hover.res 88:10
 getLocItem #9: heuristic for JSX variadic, e.g. <C> {x} {y} </C>
-heuristic for: [makeProps  , React.null, make, createElementVariadic], give the loc of `make`
+heuristic for: [React.null, makeProps, make, createElementVariadic], give the loc of `make`
+n1:null n2:makeProps n3:make n4:createElementVariadic
 {"contents": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n```rescript\ntype component<'props> = componentLike<'props, element>\n```"}
 
 Hover src/Hover.res 93:25

--- a/analysis/tests/src/expected/Jsx.res.txt
+++ b/analysis/tests/src/expected/Jsx.res.txt
@@ -1,4 +1,6 @@
 Definition src/Jsx.res 5:9
+getLocItem #4: heuristic for </Comp> within fragments: take make as makeProps does not work
+the type is not great but jump to definition works
 {"uri": "Jsx.res", "range": {"start": {"line": 2, "character": 6}, "end": {"line": 2, "character": 10}}}
 
 Complete src/Jsx.res 8:15
@@ -196,6 +198,8 @@ Completable: Cjsx([M], k, [prop, k])
   }]
 
 Definition src/Jsx.res 58:11
+getLocItem #4: heuristic for </Comp> within fragments: take make as makeProps does not work
+the type is not great but jump to definition works
 {"uri": "Component.res", "range": {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 8}}}
 
 Complete src/Jsx.res 68:10

--- a/analysis/tests/src/expected/Jsx.resi.txt
+++ b/analysis/tests/src/expected/Jsx.resi.txt
@@ -1,4 +1,5 @@
 Hover src/Jsx.resi 1:4
+getLocItem #1: heuristic for makeProps in interface files
 {"contents": "```rescript\n(~first: string, ~key: string=?, unit) => {\"first\": string}\n```"}
 
 Hover src/Jsx.resi 4:4

--- a/analysis/tests/src/expected/Jsx.resi.txt
+++ b/analysis/tests/src/expected/Jsx.resi.txt
@@ -1,5 +1,6 @@
 Hover src/Jsx.resi 1:4
 getLocItem #1: heuristic for makeProps in interface files
+n1:componentLike n2:unit n3:string
 {"contents": "```rescript\n(~first: string, ~key: string=?, unit) => {\"first\": string}\n```"}
 
 Hover src/Jsx.resi 4:4


### PR DESCRIPTION
There are a number of heuristics when getting a loc item from a text position.
These heuristics are related to the behaviours of the JSX ppx and internal compiler behaviours that leak into the position of elements.