### PR TITLE
Support paths to rescript executables in arm64 architectures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add configuration option for suppressing the "Do you want to start a build?" prompt.
 - Add configuration option for autostarting the Code Analyzer.
 - Sync with latest parser/printer.
+- Support paths to rescript executables in arm64 architectures.
 
 ## 1.3.0
 

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -1,4 +1,8 @@
 import * as path from "path";
+import { ProcessExecution } from "vscode";
+
+let platformDir =
+  process.arch == "arm64" ? process.platform + process.arch : process.platform;
 
 // See https://microsoft.github.io/language-server-protocol/specification Abstract Message
 // version is fixed to 2.0
@@ -6,13 +10,13 @@ export let jsonrpcVersion = "2.0";
 export let bscNativeReScriptPartialPath = path.join(
   "node_modules",
   "rescript",
-  process.platform,
+  platformDir,
   "bsc.exe"
 );
 export let bscNativePartialPath = path.join(
   "node_modules",
   "bs-platform",
-  process.platform,
+  platformDir,
   "bsc.exe"
 );
 


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/426