### PR TITLE
fix problem tab accidentally being cleared

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -82,7 +82,9 @@ let openCompiledFileRequest = new v.RequestType<
   void
 >("rescript-vscode.open_compiled");
 
-let getDiagnosticsForFile = (fileUri: string): p.Diagnostic[] => {
+let getCurrentCompilerDiagnosticsForFile = (
+  fileUri: string
+): p.Diagnostic[] => {
   let diagnostics: p.Diagnostic[] | null = null;
 
   projectsFiles.forEach((projectFile, _projectRootPath) => {
@@ -630,7 +632,8 @@ let updateDiagnosticSyntax = (fileUri: string, fileContent: string) => {
   // diagnostics if there's no syntax diagostics to send. This is because
   // publishing an empty diagnostics array is equivalent to saying "clear all
   // errors".
-  let compilerDiagnosticsForFile = getDiagnosticsForFile(fileUri);
+  let compilerDiagnosticsForFile =
+    getCurrentCompilerDiagnosticsForFile(fileUri);
   let syntaxDiagnosticsForFile: p.Diagnostic[] =
     utils.runAnalysisAfterSanityCheck(filePath, ["diagnosticSyntax", tmpname]);
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -603,9 +603,9 @@ export let parseCompilerLogOutput = (
       //   10 ┆
     } else if (line.startsWith("  ")) {
       // part of the actual diagnostics message
-      parsedDiagnostics[parsedDiagnostics.length - 1].content.push(
-        line.slice(2)
-      );
+        parsedDiagnostics[parsedDiagnostics.length - 1].content.push(
+          line.slice(2)
+        );
     } else if (line.trim() != "") {
       // We'll assume that everything else is also part of the diagnostics too.
       // Most of these should have been indented 2 spaces; sadly, some of them

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -474,7 +474,7 @@ let parseFileAndRange = (fileAndRange: string) => {
 };
 
 // main parsing logic
-type filesDiagnostics = {
+export type filesDiagnostics = {
   [key: string]: p.Diagnostic[];
 };
 type parsedCompilerLogResult = {
@@ -589,7 +589,7 @@ export let parseCompilerLogOutput = (
         code: undefined,
         severity: t.DiagnosticSeverity.Error,
         tag: undefined,
-        content: [lines[i], lines[i+1]],
+        content: [lines[i], lines[i + 1]],
       });
       i++;
     } else if (/^  +([0-9]+| +|\.) (│|┆)/.test(line)) {
@@ -603,9 +603,9 @@ export let parseCompilerLogOutput = (
       //   10 ┆
     } else if (line.startsWith("  ")) {
       // part of the actual diagnostics message
-        parsedDiagnostics[parsedDiagnostics.length - 1].content.push(
-          line.slice(2)
-        );
+      parsedDiagnostics[parsedDiagnostics.length - 1].content.push(
+        line.slice(2)
+      );
     } else if (line.trim() != "") {
       // We'll assume that everything else is also part of the diagnostics too.
       // Most of these should have been indented 2 spaces; sadly, some of them

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -589,7 +589,7 @@ export let parseCompilerLogOutput = (
         code: undefined,
         severity: t.DiagnosticSeverity.Error,
         tag: undefined,
-        content: [lines[i], lines[i + 1]],
+        content: [lines[i], lines[i+1]],
       });
       i++;
     } else if (/^  +([0-9]+| +|\.) (│|┆)/.test(line)) {


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/477

Problems tab was accidentally being cleared because the logic handling syntax error diagnostics did not account for pre-existing compiler errors.