### PR TITLE
Bugfix: add safeguards for array push in server

### DIFF
--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -575,9 +575,11 @@ export let parseCompilerLogOutput = (
       //   10 ┆
     } else if (line.startsWith("  ")) {
       // part of the actual diagnostics message
-      parsedDiagnostics[parsedDiagnostics.length - 1].content.push(
-        line.slice(2)
-      );
+      if (parsedDiagnostics[parsedDiagnostics.length - 1] !== undefined) {
+        parsedDiagnostics[parsedDiagnostics.length - 1].content.push(
+          line.slice(2)
+        );
+      }
     } else if (line.trim() != "") {
       // We'll assume that everything else is also part of the diagnostics too.
       // Most of these should have been indented 2 spaces; sadly, some of them
@@ -585,7 +587,9 @@ export let parseCompilerLogOutput = (
       // messages not printing with indent). We used to get bug reports and fix
       // the messages, but that strategy turned out too slow. One day we should
       // revert to not having this branch...
-      parsedDiagnostics[parsedDiagnostics.length - 1].content.push(line);
+      if (parsedDiagnostics[parsedDiagnostics.length - 1] !== undefined) {
+        parsedDiagnostics[parsedDiagnostics.length - 1].content.push(line);
+      }
     }
   }
 


### PR DESCRIPTION
I hit a pretty annoying error with the plugin where the server would crash upon opening one of the rescript projects at work with the following error

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/5692995/179217978-42f4aa43-6411-4073-a30b-8961f675d4d7.png">

I've added this to my local version and the error subsided