### PR TITLE
Fix commit SHA in artifact name for PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,9 @@ jobs:
 
     - name: Store short commit SHA for filename
       id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      env:
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      run: echo "::set-output name=sha_short::${COMMIT_SHA:0:7}"
       
     - name: Package Extension
       run: npx vsce package -o rescript-vscode-${{ steps.vars.outputs.sha_short }}.vsix


### PR DESCRIPTION
This fixes the commit SHA used for the VSIX artifact name in PR builds.

Now it matches the last commit in the PR (9fe9e91 in this case).