### PR TITLE
Neovim: fix binary path

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -85,7 +85,7 @@ let findBinaryDirPathFromProjectRoot = (
 };
 
 let getBinaryDirPath = (projectRootPath: p.DocumentUri) =>
-  extensionConfiguration.binaryPath === null
+  extensionConfiguration.binaryPath == null
     ? findBinaryDirPathFromProjectRoot(projectRootPath)
     : extensionConfiguration.binaryPath;
 
@@ -980,7 +980,7 @@ function onMessage(msg: p.Message) {
       if (initialConfiguration != null) {
         extensionConfiguration = initialConfiguration;
         if (
-          extensionConfiguration.binaryPath !== null &&
+          extensionConfiguration.binaryPath != null &&
           extensionConfiguration.binaryPath[0] === "~"
         ) {
           // What should happen if the path contains the home directory symbol?


### PR DESCRIPTION
Using `rescritls` on Neovim client with following configuration raise a error.

```lua
require'lspconfig'.rescriptls.setup = {
  cmd = {
    'node',
    '/home/pedro/Desktop/Projects/rescript-vscode/server/out/server.js',
    '--stdio',
  },
  init_options = {
    extensionConfiguration = {
      askToStartBuild = false,
    },
  },
}
```

Steps to reproduce:

1. Open a project
2. Open `.res` file

LSP Log:

```
[START][2022-07-21 17:02:07] LSP logging initiated
[ERROR][2022-07-21 17:02:08] .../vim/lsp/rpc.lua:420	"rpc"	"node"	"stderr"	"/home/pedro/Desktop/Projects/rescript-vscode/server/out/server.js:805\n                    extensionConfiguration.binaryPath[0] === \"~\") {\n                                                     ^\n\nTypeError: Cannot read property '0' of undefined\n    at StreamMessageReader.onMessage [as callback] (/home/pedro/Desktop/Projects/rescript-vscode/server/out/server.js:805:54)\n    at /home/pedro/Desktop/Projects/rescript-vscode/server/node_modules/vscode-jsonrpc/lib/common/messageReader.js:162:26\n    at processTicksAndRejections (node:internal/process/task_queues:94:5)\n"
```