### PR TITLE
Fix missing nameSpaceToName call

### DIFF
--- a/analysis/src/FindFiles.ml
+++ b/analysis/src/FindFiles.ml
@@ -100,7 +100,7 @@ let getNamespace config =
   if isNamespaced then
     let fromString = ns |> bind Json.string in
     let fromName = config |> Json.get "name" |> bind Json.string in
-    either fromString fromName
+    either fromString fromName |> Option.map nameSpaceToName
   else None
 
 let collectFiles directory =


### PR DESCRIPTION
Fixes #506. 

In commit 4f072736099fa8842f05643b289de005f9193bdb the `nameSpaceToName` call did not survive a refactoring. I brought it back with this PR.

