### PR TITLE
fix undefined inlayHints

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -231,7 +231,7 @@ let compilerLogsWatcher = chokidar
   .on("all", (_e, changedPath) => {
     sendUpdatedDiagnostics();
     sendCompilationFinishedMessage();
-    if (extensionConfiguration.inlayHints.enable === true) {
+    if (extensionConfiguration.inlayHints?.enable === true) {
       sendInlayHintsRefresh();
     }
     if (extensionConfiguration.codeLens === true) {
@@ -1035,7 +1035,7 @@ function onMessage(msg: p.Message) {
             // TODO: Support range for full, and add delta support
             full: true,
           },
-          inlayHintProvider: extensionConfiguration.inlayHints.enable,
+          inlayHintProvider: extensionConfiguration.inlayHints?.enable,
           codeLensProvider: extensionConfiguration.codeLens
             ? {
                 workDoneProgress: false,


### PR DESCRIPTION
When then `inlayHints.enable` is not in `initializationOptions`

LSP Log:

```
[ERROR][2022-07-26 17:34:09] .../vim/lsp/rpc.lua:420	"rpc"	"node"	"stderr"	"/home/pedro/Desktop/Projects/rescript-vscode/server/out/server.js:839\n                    inlayHintProvider: extensionConfiguration.inlayHints.enable,\n                                                                         ^\n\nTypeError: Cannot read property 'enable' of undefined\n    at StreamMessageReader.onMessage [as callback] (/home/pedro/Desktop/Projects/rescript-vscode/server/out/server.js:839:74)\n    at /home/pedro/Desktop/Projects/rescript-vscode/server/node_modules/vscode-jsonrpc/lib/common/messageReader.js:162:26\n    at processTicksAndRejections (node:internal/process/task_queues:94:5)\n"
```