### PR TITLE
Add `workspace/didChangeConfiguration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 
 - Fix Incorrect semantic highlighting of `external` declarations https://github.com/rescript-lang/rescript-vscode/pull/517
 
+#### :nail_care: Polish
+
+- Update server on change configuration `rescript.settings`.
+- Simplifies the `initializationOptions`.
+
 ## v1.4.2
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@
 
 #### :nail_care: Polish
 
-- Update server on change configuration `rescript.settings`.
-- Simplifies the `initializationOptions`.
+- Don't restart server on change configuration `rescript.settings`. https://github.com/rescript-lang/rescript-vscode/pull/528
+- Simplifies the `initializationOptions`. https://github.com/rescript-lang/rescript-vscode/pull/528
 
 ## v1.4.2
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You'll find all ReScript specific settings under the scope `rescript.settings`.
 | Prompt to Start Build  | If there's no ReScript build running already in the opened project, the extension will prompt you and ask if you want to start a build automatically. You can turn off this automatic prompt via the setting `rescript.settings.askToStartBuild`.                                                                                                                                                                                                                                    |
 | ReScript Binary Path           | The extension will look for the existence of a `/node_modules/.bin/rescript` file and use its directory as the `binaryPath`. If it does not find it at the project root (which is where the nearest `bsconfig.json` resides), it goes up folders in the filesystem recursively until it either finds it (often the case in monorepos) or hits the top level. To override this lookup process, the path can be configured explicitly using the setting `rescript.settings.binaryPath` |
 | Inlay Hints (experimental) | This allows an editor to place annotations inline with text to display type hints. Enable using `rescript.settings.inlayHints.enable: true` |
-| Code Lens (experimental) | This tells the editor to add code lenses to function definitions, showing its full type above the definition. Enable using `rescript.settings.codeLens: true` |
+| Code Lens (experimental) | This tells the editor to add code lenses to function definitions, showing its full type above the definition. Enable using `rescript.settings.codeLens.enable: true` |
 | Autostarting the Code Analyzer | The Code Analyzer needs to be started manually by default. However, you can configure the extension to start the Code Analyzer automatically via the setting `rescript.settings.autoRunCodeAnalysis`.                                                                                                                                                                                                                                                                                |
 
 **Default settings:**
@@ -129,7 +129,7 @@ You'll find all ReScript specific settings under the scope `rescript.settings`.
 "rescript.settings.inlayHints.maxLength": 25
 
 // Enable (experimental) code lens for function definitions.
-"rescript.settings.codeLens": true
+"rescript.settings.codeLens.enable": true
 ```
 
 ## 🚀 Code Analyzer

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -96,9 +96,7 @@ export function activate(context: ExtensionContext) {
       // We'll send the initial configuration in here, but this might be
       // problematic because every consumer of the LS will need to mimic this.
       // We'll leave it like this for now, but might be worth revisiting later on.
-      initializationOptions: {
-        extensionConfiguration: workspace.getConfiguration("rescript.settings"),
-      },
+      initializationOptions: workspace.getConfiguration("rescript.settings"),
     };
 
     const client = new LanguageClient(
@@ -235,21 +233,14 @@ export function activate(context: ExtensionContext) {
   // Start the client. This will also launch the server
   client.start();
 
-  // Restart the language client automatically when certain configuration
-  // changes. These are typically settings that affect the capabilities of the
-  // language client, and because of that requires a full restart.
   context.subscriptions.push(
     workspace.onDidChangeConfiguration(({ affectsConfiguration }) => {
-      // Put any configuration that, when changed, requires a full restart of
-      // the server here. That will typically be any configuration that affects
-      // the capabilities declared by the server, since those cannot be updated
-      // on the fly, and require a full restart with new capabilities set when
-      // initializing.
       if (
-        affectsConfiguration("rescript.settings.inlayHints") ||
-        affectsConfiguration("rescript.settings.codeLens")
+        affectsConfiguration("rescript.settings")
       ) {
-        commands.executeCommand("rescript-vscode.restart_language_server");
+        client.sendNotification(
+          "workspace/didChangeConfiguration",
+          { settings: workspace.getConfiguration("rescript.settings") }).catch((err) => { window.showErrorMessage(String(err)) })
       }
     })
   );

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -52,4 +52,3 @@ export let bsconfigModuleDefault = "commonjs";
 export let bsconfigSuffixDefault = ".js";
 
 export let configurationRequestId = "rescript_configuration_request";
-export let pullConfigurationInterval = 10_000;


### PR DESCRIPTION
#### Change

- We don't need to restart the server when change `rescript.settings`. Just send a notification and update the settings

#### Polish

- Also, no need an extra field in `initializationOptions`. This makes setup easier on other clients like Neovim

```diff
require'lspconfig'.rescriptls.setup = {
  cmd = {
    'node',
    '/home/pedro/Desktop/Projects/rescript-vscode/server/out/server.js',
    '--stdio',
  },
  init_options = {
-    extensionConfiguration = {
-      askToStartBuild = false
-    },
+    askToStartBuild = false
  },
}
```