### PR TITLE
Call bsc.exe directly, when no binaryPath is set in settings

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -6,12 +6,8 @@ let platformDir =
 // See https://microsoft.github.io/language-server-protocol/specification Abstract Message
 // version is fixed to 2.0
 export let jsonrpcVersion = "2.0";
-export let bscNativeReScriptPartialPath = path.join(
-  "node_modules",
-  "rescript",
-  platformDir,
-  "bsc.exe"
-);
+export let platformPath = path.join("node_modules", "rescript", platformDir);
+export let bscNativeReScriptPartialPath = path.join(platformPath, "bsc.exe");
 
 export let analysisDevPath = path.join(
   path.dirname(__dirname),
@@ -29,6 +25,7 @@ export let analysisProdPath = path.join(
 export let rescriptBinName = "rescript";
 
 export let bscBinName = "bsc";
+export let bscExeName = "bsc.exe";
 
 export let nodeModulesBinDir = path.join("node_modules", ".bin");
 

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -6,8 +6,13 @@ let platformDir =
 // See https://microsoft.github.io/language-server-protocol/specification Abstract Message
 // version is fixed to 2.0
 export let jsonrpcVersion = "2.0";
-export let platformPath = path.join("node_modules", "rescript", platformDir);
-export let bscNativeReScriptPartialPath = path.join(platformPath, "bsc.exe");
+export let platformPath = path.join("rescript", platformDir);
+export let nodeModulesPlatformPath = path.join("node_modules", platformPath);
+export let bscExeName = "bsc.exe";
+export let bscNativeReScriptPartialPath = path.join(
+  nodeModulesPlatformPath,
+  bscExeName
+);
 
 export let analysisDevPath = path.join(
   path.dirname(__dirname),
@@ -25,7 +30,6 @@ export let analysisProdPath = path.join(
 export let rescriptBinName = "rescript";
 
 export let bscBinName = "bsc";
-export let bscExeName = "bsc.exe";
 
 export let nodeModulesBinDir = path.join("node_modules", ".bin");
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -79,6 +79,8 @@ let codeActionsFromDiagnostics: codeActions.filesCodeActions = {};
 // will be properly defined later depending on the mode (stdio/node-rpc)
 let send: (msg: p.Message) => void = (_) => {};
 
+// Check if the rescript binary is available at node_modules/.bin/rescript,
+// otherwise recursively check parent directories for it.
 let findBinaryPathFromProjectRoot = (
   directory: p.DocumentUri // This must be a directory and not a file!
 ): null | p.DocumentUri => {
@@ -321,7 +323,10 @@ let openedFile = (fileUri: string, fileContent: string) => {
             type: p.MessageType.Error,
             message:
               extensionConfiguration.binaryPath == null
-                ? "Can't find ReScript binary"
+                ? `Can't find ReScript binary in  ${path.join(
+                    projectRootPath,
+                    c.nodeModulesBinDir
+                  )} or parent directories. Did you install it? It's required to use "rescript" > 9.1`
                 : `Can't find ReScript binary in the directory ${extensionConfiguration.binaryPath}`,
           },
         };


### PR DESCRIPTION
This should fix #514 and also will make formatting faster (at least on windows).
Supersedes #521 

I refactored the binary lookup a bit so that:
* we do not need to call existsSync twice on the same file
* the function returns the binary path itself

When no binaryPath is set, the extension will lookup and use the `bsc.exe` now (again).

Also the message when no binary has been found could have shown null as path. I simplified it for that case.

Edit: Fixes #530 now as well.