### PR TITLE
Remove ".enable" from rescript.settings.codeLens in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
                     ],
                     "minimum": 0
 				},
-				"rescript.settings.codeLens.enable": {
+				"rescript.settings.codeLens": {
 					"type": "boolean",
 					"default": false,
 					"description": "Enable (experimental) code lens for function definitions."


### PR DESCRIPTION
The setting is called `rescript.settings.codeLens` instead of `rescript.settings.codeLens.enable`.