### PR TITLE
More elaborate error message for users on reanalyze json error

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,4 +1,4 @@
-import { DiagnosticCollection } from "vscode";
+import { DiagnosticCollection, OutputChannel } from "vscode";
 
 import {
   DiagnosticsResultCodeActionsMap,
@@ -12,11 +12,13 @@ export { switchImplIntf } from "./commands/switch_impl_intf";
 export const codeAnalysisWithReanalyze = (
   targetDir: string | null,
   diagnosticsCollection: DiagnosticCollection,
-  diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap
+  diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap,
+  outputChannel: OutputChannel
 ) => {
   runCodeAnalysisWithReanalyze(
     targetDir,
     diagnosticsCollection,
-    diagnosticsResultCodeActions
+    diagnosticsResultCodeActions,
+    outputChannel
   );
 };

--- a/client/src/commands/code_analysis.ts
+++ b/client/src/commands/code_analysis.ts
@@ -170,7 +170,8 @@ export const runCodeAnalysisWithReanalyze = (
     return;
   }
 
-  let p = cp.spawn(binaryPath, ["reanalyze", "-json"], {
+  let opts = ["reanalyze", "-json"];
+  let p = cp.spawn(binaryPath, opts, {
     cwd,
   });
 
@@ -218,12 +219,16 @@ export const runCodeAnalysisWithReanalyze = (
           outputChannel.show();
         });
 
-      outputChannel.appendLine("--invalid json start--");
-      outputChannel.append(data);
-      outputChannel.appendLine("--invalid json end--");
+      outputChannel.appendLine("\n\n>>>>");
       outputChannel.appendLine(
-        "Parsing JSON from reanalyze failed. The raw, invalid JSON is logged above this message. Please report this on the extension bug tracker: https://github.com/rescript-lang/rescript-vscode/issues"
+        "Parsing JSON from reanalyze failed. The raw, invalid JSON can be reproduced by following the instructions below. Please run that command and report the issue + failing JSON on the extension bug tracker: https://github.com/rescript-lang/rescript-vscode/issues"
       );
+      outputChannel.appendLine(
+        `> To reproduce, run "${binaryPath} ${opts.join(
+          " "
+        )}" in directory: "${cwd}"`
+      );
+      outputChannel.appendLine("\n");
     }
 
     if (json == null) {

--- a/client/src/commands/code_analysis.ts
+++ b/client/src/commands/code_analysis.ts
@@ -12,6 +12,7 @@ import {
   CodeAction,
   CodeActionKind,
   WorkspaceEdit,
+  OutputChannel,
 } from "vscode";
 
 export type DiagnosticsResultCodeActionsMap = Map<
@@ -157,7 +158,8 @@ let getAnalysisBinaryPath = (): string | null => {
 export const runCodeAnalysisWithReanalyze = (
   targetDir: string | null,
   diagnosticsCollection: DiagnosticCollection,
-  diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap
+  diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap,
+  outputChannel: OutputChannel
 ) => {
   let currentDocument = window.activeTextEditor.document;
   let cwd = targetDir ?? path.dirname(currentDocument.uri.fsPath);
@@ -207,8 +209,20 @@ export const runCodeAnalysisWithReanalyze = (
     try {
       json = JSON.parse(data);
     } catch (e) {
-      window.showErrorMessage(
-        `Something went wrong parsing the json output of reanalyze: '${e}'`
+      window
+        .showErrorMessage(
+          `Something went wrong when running the code analyzer.`,
+          "See details in error log"
+        )
+        .then((_choice) => {
+          outputChannel.show();
+        });
+
+      outputChannel.appendLine("--invalid json start--");
+      outputChannel.append(data);
+      outputChannel.appendLine("--invalid json end--");
+      outputChannel.appendLine(
+        "Parsing JSON from reanalyze failed. The raw, invalid JSON is logged above this message. Please report this on the extension bug tracker: https://github.com/rescript-lang/rescript-vscode/issues"
       );
     }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -70,6 +70,11 @@ let client: LanguageClient;
 // });
 
 export function activate(context: ExtensionContext) {
+  let outputChannel = window.createOutputChannel(
+    "ReScript Language Server",
+    "rescript"
+  );
+
   function createLanguageClient() {
     // The server is implemented in node
     let serverModule = context.asAbsolutePath(
@@ -99,6 +104,7 @@ export function activate(context: ExtensionContext) {
       initializationOptions: {
         extensionConfiguration: workspace.getConfiguration("rescript.settings"),
       },
+      outputChannel,
     };
 
     const client = new LanguageClient(
@@ -123,7 +129,8 @@ export function activate(context: ExtensionContext) {
                 customCommands.codeAnalysisWithReanalyze(
                   inCodeAnalysisState.activatedFromDirectory,
                   diagnosticsCollection,
-                  diagnosticsResultCodeActions
+                  diagnosticsResultCodeActions,
+                  outputChannel
                 );
               }
             })
@@ -207,7 +214,8 @@ export function activate(context: ExtensionContext) {
     customCommands.codeAnalysisWithReanalyze(
       inCodeAnalysisState.activatedFromDirectory,
       diagnosticsCollection,
-      diagnosticsResultCodeActions
+      diagnosticsResultCodeActions,
+      outputChannel
     );
   });
 


### PR DESCRIPTION
Follow up for: https://github.com/rescript-lang/rescript-vscode/issues/537

This logs a more elaborate error for the user, including instructions on how to report the error, when reanalyze json is invalid for some reason. 

<img width="456" alt="image" src="https://user-images.githubusercontent.com/1457626/182436499-5595ecb6-e958-43d9-8faa-c922446e40fb.png">

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1457626/182436538-6600cdb0-99b6-46f7-ba77-0148f283506c.png">
