### PR TITLE
Fix formatter not being available for macOS ARM with ReScript <= 9.1.4

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 
-let platformDir =
+export let platformDir =
   process.arch == "arm64" ? process.platform + process.arch : process.platform;
 
 // See https://microsoft.github.io/language-server-protocol/specification Abstract Message

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -108,12 +108,28 @@ let findRescriptBinary = (projectRootPath: p.DocumentUri) =>
 let findBscBinary = (projectRootPath: p.DocumentUri) => {
   let rescriptBinaryPath = findRescriptBinary(projectRootPath);
   if (rescriptBinaryPath !== null) {
-    return path.join(
+    let rescriptDirPath = path.join(
       path.dirname(rescriptBinaryPath),
       "..",
-      c.platformPath,
-      c.bscExeName
+      "rescript"
     );
+
+    let bscBinaryPath = path.join(rescriptDirPath, c.platformDir, c.bscExeName);
+
+    // Workaround for darwinarm64 which has no folder yet in ReScript <= 9.1.4
+    if (
+      process.platform == "darwin" &&
+      process.arch == "arm64" &&
+      !fs.existsSync(bscBinaryPath)
+    ) {
+      bscBinaryPath = path.join(
+        rescriptDirPath,
+        process.platform,
+        c.bscExeName
+      );
+    }
+
+    return bscBinaryPath;
   }
   return null;
 };


### PR DESCRIPTION
Fixes #552 