### PR TITLE
prompt user to explicitly allow formatting using the built in formatter

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -248,6 +248,14 @@ export function activate(context: ExtensionContext) {
   // language client, and because of that requires a full restart.
   context.subscriptions.push(
     workspace.onDidChangeConfiguration(({ affectsConfiguration }) => {
+      // Send a general message that configuration has updated. Clients
+      // interested can then pull the new configuration as they see fit.
+      client
+        .sendNotification("workspace/didChangeConfiguration")
+        .catch((err) => {
+          window.showErrorMessage(String(err));
+        });
+
       // Put any configuration that, when changed, requires a full restart of
       // the server here. That will typically be any configuration that affects
       // the capabilities declared by the server, since those cannot be updated

--- a/package.json
+++ b/package.json
@@ -121,6 +121,12 @@
 			"type": "object",
 			"title": "ReScript",
 			"properties": {
+				"rescript.settings.allowBuiltInFormatter": {
+					"scope": "language-overridable",
+					"type": "boolean",
+					"default": false,
+					"description": "Whether you want to allow the extension to format your code using its built in formatter when it cannot find a ReScript compiler version in your current project to use for formatting."
+				},
 				"rescript.settings.askToStartBuild": {
 					"scope": "language-overridable",
 					"type": "boolean",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -743,15 +743,18 @@ function format(msg: p.RequestMessage): Array<p.Message> {
 
     if (
       bscBinaryPath == null &&
-      !extensionConfiguration.allowBuiltInFormatter &&
-      !hasPromptedAboutBuiltInFormatter
+      !extensionConfiguration.allowBuiltInFormatter
     ) {
       // Let's only prompt the user once about this, or things might become annoying.
+      if (hasPromptedAboutBuiltInFormatter) {
+        return [fakeSuccessResponse];
+      }
       hasPromptedAboutBuiltInFormatter = true;
+
       let params: p.ShowMessageParams = {
         type: p.MessageType.Warning,
         message: `Formatting not applied! Could not find the ReScript compiler in the current project, and you haven't configured the extension to allow formatting using the built in formatter. To allow formatting files not strictly part of a ReScript project using the built in formatter, [please configure the extension to allow that.](command:workbench.action.openSettings?${encodeURIComponent(
-          "rescript.settings.allowBuiltInFormatter"
+          JSON.stringify(["rescript.settings.allowBuiltInFormatter"])
         )})`,
       };
       let response: p.NotificationMessage = {

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -75,11 +75,18 @@ type execResult =
       error: string;
     };
 
+type formatCodeResult =
+  | execResult
+  | {
+      kind: "blocked-using-built-in-formatter";
+    };
+
 export let formatCode = (
   bscPath: p.DocumentUri | null,
   filePath: string,
-  code: string
-): execResult => {
+  code: string,
+  allowBuiltInFormatter: boolean
+): formatCodeResult => {
   let extension = path.extname(filePath);
   let formatTempFileFullPath = createFileInTempDir(extension);
   fs.writeFileSync(formatTempFileFullPath, code, {
@@ -100,6 +107,12 @@ export let formatCode = (
         result: result.toString(),
       };
     } else {
+      if (!allowBuiltInFormatter) {
+        return {
+          kind: "blocked-using-built-in-formatter",
+        };
+      }
+
       let result = runAnalysisAfterSanityCheck(
         formatTempFileFullPath,
         ["format", formatTempFileFullPath],


### PR DESCRIPTION
This adds a setting for explicitly allowing the use of the built in formatter when trying to format a ReScript file that's not strictly part of a ReScript project. Whenever a user tries to format a file where the ReScript compiler can't be found, the user will be prompted that explicit permissions are needed, together with a link to that specific setting.

![image](https://user-images.githubusercontent.com/1457626/187521431-25a02011-e075-4bdd-81b6-74cd803c81e7.png)

![image](https://user-images.githubusercontent.com/1457626/187521461-9e2ebaa8-41f4-43ed-b78e-eb94e959777d.png)

![image](https://user-images.githubusercontent.com/1457626/187523087-59e4be7b-6050-4105-b9e7-1f8626acf730.png)

Closes https://github.com/rescript-lang/rescript-vscode/issues/556
