### PR TITLE
Use raw string instead of JSON for bump-version parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       id: increment_pre_release
       run: |
         JSON=$(npx vsce show chenglou92.rescript-vscode --json)
-        NEW_VERSION=$(echo $JSON | jq '.versions | .[0] | .["version"]')
+        NEW_VERSION=$(echo $JSON | jq -r '.versions | .[0] | .["version"]')
         node .github/workflows/bump-version.js ${NEW_VERSION}
 
     - name: Package Extension


### PR DESCRIPTION
This was due to consolidating the get-version-number and increment-version-number steps in the previous PR. The JSON string was probably converted automatically in between to a raw string.