### PR TITLE
Fix issue where module paths in `-open` in `bsc-flags` such as "-open Re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :bug: Bug Fix
+
+- Fix issue where module paths in `-open` `bsc-flags` such as "-open ReScriptJs.Js" were not recognized https://github.com/rescript-lang/rescript-vscode/issues/607
+
 ## v1.8.1
 
 #### :rocket: New Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :bug: Bug Fix
 
-- Fix issue where module paths in `-open` `bsc-flags` such as "-open ReScriptJs.Js" were not recognized https://github.com/rescript-lang/rescript-vscode/issues/607
+- Fix issue where module paths in `-open` in `bsc-flags` such as "-open ReScriptJs.Js" were not recognized https://github.com/rescript-lang/rescript-vscode/issues/607
 
 ## v1.8.1
 

--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -68,7 +68,9 @@ let newBsPackage ~rootPath =
                      | Some s -> (
                        let parts = String.split_on_char ' ' s in
                        match parts with
-                       | "-open" :: name :: _ -> name :: opens
+                       | "-open" :: name :: _ ->
+                         let names = name |> String.split_on_char '.' in
+                         names @ opens
                        | _ -> opens))
                    [] l
                | None -> []


### PR DESCRIPTION
…ScriptJs.Js" were not recognized

Fixes https://github.com/rescript-lang/rescript-vscode/issues/607