### PR TITLE
custom LSP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :nail_care: Polish
+
+- Rename custom LSP methods names. https://github.com/rescript-lang/rescript-vscode/pull/611
+
 ## v1.8.2
 
 #### :rocket: New Feature

--- a/client/src/commands/create_interface.ts
+++ b/client/src/commands/create_interface.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as p from "vscode-languageserver-protocol";
 import { LanguageClient, RequestType } from "vscode-languageclient/node";
 import { window } from "vscode";
 
@@ -7,10 +8,10 @@ interface CreateInterfaceRequestParams {
 }
 
 export const createInterfaceRequest = new RequestType<
-  CreateInterfaceRequestParams,
-  string,
+  p.TextDocumentIdentifier,
+  p.TextDocumentIdentifier,
   void
->("rescript-vscode.create_interface");
+>("textDocument/createInterface");
 
 export const createInterface = (client: LanguageClient) => {
   if (!client) {

--- a/client/src/commands/create_interface.ts
+++ b/client/src/commands/create_interface.ts
@@ -3,10 +3,6 @@ import * as p from "vscode-languageserver-protocol";
 import { LanguageClient, RequestType } from "vscode-languageclient/node";
 import { window } from "vscode";
 
-interface CreateInterfaceRequestParams {
-  uri: string;
-}
-
 export const createInterfaceRequest = new RequestType<
   p.TextDocumentIdentifier,
   p.TextDocumentIdentifier,

--- a/client/src/commands/open_compiled.ts
+++ b/client/src/commands/open_compiled.ts
@@ -1,20 +1,13 @@
 import * as fs from "fs";
+import * as p from "vscode-languageserver-protocol";
 import { window, Uri, ViewColumn } from "vscode";
 import { LanguageClient, RequestType } from "vscode-languageclient/node";
 
-interface OpenCompiledFileRequestParams {
-  uri: string;
-}
-
-interface OpenCompiledFileResponseParams {
-  uri: string;
-}
-
 let openCompiledFileRequest = new RequestType<
-  OpenCompiledFileRequestParams,
-  OpenCompiledFileResponseParams,
+  p.TextDocumentIdentifier,
+  p.TextDocumentIdentifier,
   void
->("rescript-vscode.open_compiled");
+>("textDocument/openCompiled");
 
 export const openCompiled = (client: LanguageClient) => {
   if (!client) {
@@ -36,7 +29,7 @@ export const openCompiled = (client: LanguageClient) => {
       uri: editor.document.uri.toString(),
     })
     .then((response) => {
-      const document = Uri.file(response.uri);
+      const document = Uri.parse(response.uri);
 
       return window.showTextDocument(document, {
         viewColumn: ViewColumn.Beside,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -139,25 +139,17 @@ let findPlatformPath = (projectRootPath: p.DocumentUri | null) => {
 let findBscExeBinary = (projectRootPath: p.DocumentUri | null) =>
   utils.findBinary(findPlatformPath(projectRootPath), c.bscExeName);
 
-interface CreateInterfaceRequestParams {
-  uri: string;
-}
-
 let createInterfaceRequest = new v.RequestType<
-  CreateInterfaceRequestParams,
-  string,
+  p.TextDocumentIdentifier,
+  p.TextDocumentIdentifier,
   void
->("rescript-vscode.create_interface");
-
-interface OpenCompiledFileParams {
-  uri: string;
-}
+>("textDocument/createInterface");
 
 let openCompiledFileRequest = new v.RequestType<
-  OpenCompiledFileParams,
-  OpenCompiledFileParams,
+  p.TextDocumentIdentifier,
+  p.TextDocumentIdentifier,
   void
->("rescript-vscode.open_compiled");
+>("textDocument/openCompiled");
 
 let getCurrentCompilerDiagnosticsForFile = (
   fileUri: string
@@ -859,7 +851,7 @@ let updateDiagnosticSyntax = (fileUri: string, fileContent: string) => {
 };
 
 function createInterface(msg: p.RequestMessage): p.Message {
-  let params = msg.params as CreateInterfaceRequestParams;
+  let params = msg.params as p.TextDocumentIdentifier;
   let extension = path.extname(params.uri);
   let filePath = fileURLToPath(params.uri);
   let projDir = utils.findProjectRootOfFile(filePath);
@@ -953,7 +945,9 @@ function createInterface(msg: p.RequestMessage): p.Message {
     let response: p.ResponseMessage = {
       jsonrpc: c.jsonrpcVersion,
       id: msg.id,
-      result: "Interface successfully created.",
+      result: {
+        uri: utils.pathToURI(resiPath)
+      },
     };
     return response;
   } catch (e) {
@@ -970,7 +964,7 @@ function createInterface(msg: p.RequestMessage): p.Message {
 }
 
 function openCompiledFile(msg: p.RequestMessage): p.Message {
-  let params = msg.params as OpenCompiledFileParams;
+  let params = msg.params as p.TextDocumentIdentifier;
   let filePath = fileURLToPath(params.uri);
   let projDir = utils.findProjectRootOfFile(filePath);
 
@@ -1014,14 +1008,12 @@ function openCompiledFile(msg: p.RequestMessage): p.Message {
     return response;
   }
 
-  let result: OpenCompiledFileParams = {
-    uri: compiledFilePath.result,
-  };
-
   let response: p.ResponseMessage = {
     jsonrpc: c.jsonrpcVersion,
     id: msg.id,
-    result,
+    result: {
+      uri: utils.pathToURI(compiledFilePath.result),
+    }
   };
 
   return response;

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -323,7 +323,7 @@ export let runBuildWatcherUsingValidBuildPath = (
 */
 
 // parser helpers
-let pathToURI = (file: string) => {
+export let pathToURI = (file: string) => {
   return process.platform === "win32" ? `file:\\\\\\${file}` : `file://${file}`;
 };
 let parseFileAndRange = (fileAndRange: string) => {


### PR DESCRIPTION
I was writing some handlers in Neovim for `createInterface` and `openCompiled`. Methods names use the same format to register commands in vscode e.g `rescript-vscode.open_compiled`

Rename methods names, following LSP spec:
- `rescript-vscode.open_compiled` => `textDocument/openCompiled`
- `rescript-vscode.create_interface` => `textDocument/createInterface`

Response changes:
- `textDocument/openCompiled` now return uri file scheme
- `textDocument/createInterface` now return the path of the file, so that I can open the file after creation
