### PR TITLE
hover: remove spacing between type definition 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ## master
 
+#### :nail_care: Polish
+- Remove spacing between type definition in clients that do not support markdown links. https://github.com/rescript-lang/rescript-vscode/pull/619
+
 #### :bug: Bug Fix
 
 - Fix issue where `-open Some.Path` in `"bsc-flags"` would sometimes be treated differently from `open Some.Path` locally in a file https://github.com/rescript-lang/rescript-vscode/pull/616

--- a/analysis/src/Hover.ml
+++ b/analysis/src/Hover.ml
@@ -100,12 +100,12 @@ let hoverWithExpandedTypes ~docstring ~file ~package ~supportsMarkdownLinks typ
                Markdown.goToDefinitionText ~env ~pos:loc.Warnings.loc_start
              else ""
            in
-           "\n" ^ Markdown.spacing
+           Markdown.divider ^ (if supportsMarkdownLinks then Markdown.spacing else "")
            ^ Markdown.codeBlock
                (decl
                |> Shared.declToString ~printNameAsIs:true
                     (SharedTypes.pathIdentToString path))
-           ^ linkToTypeDefinitionStr ^ "\n" ^ Markdown.divider)
+           ^ linkToTypeDefinitionStr ^ "\n")
   in
   (typeString :: typeDefinitions |> String.concat "\n", docstring)
 

--- a/analysis/src/Protocol.ml
+++ b/analysis/src/Protocol.ml
@@ -97,7 +97,7 @@ let stringifyCompletionItem c =
     | None -> null
     | Some doc -> stringifyMarkupContent doc)
 
-let stringifyHover s = Printf.sprintf {|{"contents": "%s"}|} (Json.escape s)
+let stringifyHover value = Printf.sprintf {|{"contents": %s}|} (stringifyMarkupContent {kind = "markdown"; value})
 
 let stringifyLocation (h : location) =
   Printf.sprintf {|{"uri": "%s", "range": %s}|} (Json.escape h.uri)

--- a/analysis/tests/src/expected/Auto.res.txt
+++ b/analysis/tests/src/expected/Auto.res.txt
@@ -1,3 +1,3 @@
 Hover src/Auto.res 2:13
-{"contents": "```rescript\n(Belt.List.t<'a>, 'a => 'b) => Belt.List.t<'b>\n```\n\n\n```\n \n```\n```rescript\ntype Belt.List.t<'a> = list<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22belt_List.mli%22%2C34%2C0%5D)\n\n---\n\n\n\n  Returns a new list with `f` applied to each element of `someList`.\n\n  ```res example\n  list{1, 2}->Belt.List.map(x => x + 1) // list{3, 4}\n  ```\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(Belt.List.t<'a>, 'a => 'b) => Belt.List.t<'b>\n```\n\n---\n\n```\n \n```\n```rescript\ntype Belt.List.t<'a> = list<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22belt_List.mli%22%2C34%2C0%5D)\n\n\n\n  Returns a new list with `f` applied to each element of `someList`.\n\n  ```res example\n  list{1, 2}->Belt.List.map(x => x + 1) // list{3, 4}\n  ```\n"}}
 

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1406,7 +1406,7 @@ JSX <div:[346:9->346:12] name[346:13->346:17]=...[346:18->346:20]> _children:346
 Completable: Cjsx([div], name, [name])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Resolved opens 2 Completion.res Completion.res
-{"contents": "```rescript\nstring\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
 
 Hover src/Completion.res 349:17
 Nothing at that position. Now trying to use completion.
@@ -1417,7 +1417,7 @@ Pexp_ident FAO.forAutoObject:[349:11->349:28]
 Completable: Cpath Value[FAO, forAutoObject]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Resolved opens 2 Completion.res Completion.res
-{"contents": "```rescript\n{\"age\": int, \"forAutoLabel\": FAR.forAutoRecord}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\n{\"age\": int, \"forAutoLabel\": FAR.forAutoRecord}\n```"}}
 
 Hover src/Completion.res 352:17
 Nothing at that position. Now trying to use completion.
@@ -1435,7 +1435,7 @@ Found type for function (
   unit,
   ~c: int,
 ) => int
-{"contents": "```rescript\noption<int>\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\noption<int>\n```"}}
 
 Complete src/Completion.res 355:23
 posCursor:[355:23] posNoWhite:[355:22] Found expr:[0:-1->355:23]

--- a/analysis/tests/src/expected/Definition.res.txt
+++ b/analysis/tests/src/expected/Definition.res.txt
@@ -5,13 +5,13 @@ Definition src/Definition.res 10:23
 {"uri": "Definition.res", "range": {"start": {"line": 6, "character": 7}, "end": {"line": 6, "character": 13}}}
 
 Hover src/Definition.res 14:14
-{"contents": "```rescript\n('a => 'b, list<'a>) => list<'b>\n```\n\n [List.map f [a1; ...; an]] applies function [f] to [a1, ..., an],\n   and builds the list [[f a1; ...; f an]]\n   with the results returned by [f].  Not tail-recursive. "}
+{"contents": {"kind": "markdown", "value": "```rescript\n('a => 'b, list<'a>) => list<'b>\n```\n\n [List.map f [a1; ...; an]] applies function [f] to [a1, ..., an],\n   and builds the list [[f a1; ...; f an]]\n   with the results returned by [f].  Not tail-recursive. "}}
 
 Hover src/Definition.res 18:14
-{"contents": "```rescript\n(Belt.List.t<'a>, 'a => 'b) => Belt.List.t<'b>\n```\n\n\n```\n \n```\n```rescript\ntype Belt.List.t<'a> = list<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22belt_List.mli%22%2C34%2C0%5D)\n\n---\n\n\n\n  Returns a new list with `f` applied to each element of `someList`.\n\n  ```res example\n  list{1, 2}->Belt.List.map(x => x + 1) // list{3, 4}\n  ```\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(Belt.List.t<'a>, 'a => 'b) => Belt.List.t<'b>\n```\n\n---\n\n```\n \n```\n```rescript\ntype Belt.List.t<'a> = list<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22belt_List.mli%22%2C34%2C0%5D)\n\n\n\n  Returns a new list with `f` applied to each element of `someList`.\n\n  ```res example\n  list{1, 2}->Belt.List.map(x => x + 1) // list{3, 4}\n  ```\n"}}
 
 Hover src/Definition.res 23:3
-{"contents": "```rescript\n(. int, int) => int\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(. int, int) => int\n```"}}
 
 Definition src/Definition.res 26:3
 {"uri": "Definition.res", "range": {"start": {"line": 21, "character": 4}, "end": {"line": 21, "character": 13}}}

--- a/analysis/tests/src/expected/Div.res.txt
+++ b/analysis/tests/src/expected/Div.res.txt
@@ -1,6 +1,6 @@
 Hover src/Div.res 0:10
 getLocItem #3: heuristic for <div>
-{"contents": "```rescript\n(\n  string,\n  ~props: ReactDOM_V3.domProps=?,\n  array<React.element>,\n) => React.element\n```\n\n\n```\n \n```\n```rescript\ntype ReactDOM_V3.domProps = Props.domProps\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22ReactDOM_V3.res%22%2C57%2C2%5D)\n\n---\n\n\n\n```\n \n```\n```rescript\ntype React.element = Jsx.element\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C0%2C0%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(\n  string,\n  ~props: ReactDOM_V3.domProps=?,\n  array<React.element>,\n) => React.element\n```\n\n---\n\n```\n \n```\n```rescript\ntype ReactDOM_V3.domProps = Props.domProps\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22ReactDOM_V3.res%22%2C57%2C2%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype React.element = Jsx.element\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C0%2C0%5D)\n"}}
 
 Complete src/Div.res 3:17
 posCursor:[3:17] posNoWhite:[3:16] Found expr:[3:4->3:17]

--- a/analysis/tests/src/expected/DocComments.res.txt
+++ b/analysis/tests/src/expected/DocComments.res.txt
@@ -1,12 +1,12 @@
 Hover src/DocComments.res 9:9
-{"contents": "```rescript\nint\n```\n\n  Doc comment with a triple-backquote example\\n  \\n  ```res example\\n    let a = 10\\n    /*\\n     * stuff\\n     */\\n  ```\\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n  Doc comment with a triple-backquote example\\n  \\n  ```res example\\n    let a = 10\\n    /*\\n     * stuff\\n     */\\n  ```\\n"}}
 
 Hover src/DocComments.res 22:6
-{"contents": "```rescript\nint\n```\n\n\n  Doc comment with a triple-backquote example\n  \n  ```res example\n    let a = 10\n    /*\n     * stuff\n     */\n  ```\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n\n  Doc comment with a triple-backquote example\n  \n  ```res example\n    let a = 10\n    /*\n     * stuff\n     */\n  ```\n"}}
 
 Hover src/DocComments.res 33:9
-{"contents": "```rescript\nint\n```\n\n  Doc comment with a triple-backquote example\\n  \\n  ```res example\\n    let a = 10\\n    let b = 20\\n  ```\\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n  Doc comment with a triple-backquote example\\n  \\n  ```res example\\n    let a = 10\\n    let b = 20\\n  ```\\n"}}
 
 Hover src/DocComments.res 44:6
-{"contents": "```rescript\nint\n```\n\n\n  Doc comment with a triple-backquote example\n  \n  ```res example\n    let a = 10\n    let b = 20\n  ```\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n\n  Doc comment with a triple-backquote example\n  \n  ```res example\n    let a = 10\n    let b = 20\n  ```\n"}}
 

--- a/analysis/tests/src/expected/Fragment.res.txt
+++ b/analysis/tests/src/expected/Fragment.res.txt
@@ -1,7 +1,7 @@
 Hover src/Fragment.res 6:19
 getLocItem #4: heuristic for </Comp> within fragments: take make as makeProps does not work
 the type is not great but jump to definition works
-{"contents": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n\n```\n \n```\n```rescript\ntype React.component<'props> = Jsx.component<'props>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C12%2C0%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nReact.component<{\"children\": React.element}>\n```\n\n---\n\n```\n \n```\n```rescript\ntype React.component<'props> = Jsx.component<'props>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C12%2C0%5D)\n"}}
 
 Hover src/Fragment.res 9:56
 Nothing at that position. Now trying to use completion.

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -1,30 +1,30 @@
 Hover src/Hover.res 0:4
-{"contents": "```rescript\nint\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
 Hover src/Hover.res 3:5
-{"contents": "```rescript\ntype t = (int, float)\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\ntype t = (int, float)\n```"}}
 
 Hover src/Hover.res 6:7
-{"contents": "```rescript\nmodule Id = {\n  type x = int\n}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule Id = {\n  type x = int\n}\n```"}}
 
 Hover src/Hover.res 19:11
-{"contents": "\nThis module is commented\n```rescript\nmodule Dep = {\n  let customDouble: int => int\n}\n```"}
+{"contents": {"kind": "markdown", "value": "\nThis module is commented\n```rescript\nmodule Dep = {\n  let customDouble: int => int\n}\n```"}}
 
 Hover src/Hover.res 22:11
-{"contents": "```rescript\nint => int\n```\n\nSome doc comment"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint => int\n```\n\nSome doc comment"}}
 
 Hover src/Hover.res 26:6
-{"contents": "```rescript\nint\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
 Hover src/Hover.res 33:4
-{"contents": "```rescript\nunit => int\n```\n\nDoc comment for functionWithTypeAnnotation"}
+{"contents": {"kind": "markdown", "value": "```rescript\nunit => int\n```\n\nDoc comment for functionWithTypeAnnotation"}}
 
 Hover src/Hover.res 37:13
 getLocItem #5: heuristic for JSX and compiler combined:
 ~x becomes Props#x
 heuristic for: [Props, x], give loc of `x`
 n1:Props n2:name
-{"contents": "```rescript\nstring\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
 
 Hover src/Hover.res 42:15
 getLocItem #7: heuristic for JSX on type-annotated labeled (~arg:t):
@@ -33,28 +33,28 @@ Props has the location range of arg:t
 arg has the location range of arg
 heuristic for: [Props, arg], give loc of `arg`
 n1:Props n2:name
-{"contents": "```rescript\nstring\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
 
 Hover src/Hover.res 46:10
-{"contents": "```rescript\nint\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
 Hover src/Hover.res 49:13
-{"contents": "```rescript\nmodule Logger = {\n  let log: string => unit\n}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule Logger = {\n  let log: string => unit\n}\n```"}}
 
 Hover src/Hover.res 54:7
-{"contents": "```rescript\nmodule Logger = {\n  let log: string => unit\n}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule Logger = {\n  let log: string => unit\n}\n```"}}
 
 Definition src/Hover.res 60:14
 {"uri": "Hover.res", "range": {"start": {"line": 49, "character": 12}, "end": {"line": 49, "character": 18}}}
 
 Hover src/Hover.res 63:9
-{"contents": "```rescript\nmodule IdDefinedTwice = {\n  let y: int\n  let _x: int\n}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule IdDefinedTwice = {\n  let y: int\n  let _x: int\n}\n```"}}
 
 Hover src/Hover.res 74:7
-{"contents": "```rescript\nmodule A = {\n  let x: int\n}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule A = {\n  let x: int\n}\n```"}}
 
 Hover src/Hover.res 77:7
-{"contents": "```rescript\nmodule A = {\n  let x: int\n}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule A = {\n  let x: int\n}\n```"}}
 
 Hover src/Hover.res 91:10
 Nothing at that position. Now trying to use completion.
@@ -69,46 +69,46 @@ JSX <Comp1:[95:3->95:8] > _children:95:8
 null
 
 Hover src/Hover.res 103:25
-{"contents": "```rescript\nfloat\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nfloat\n```"}}
 
 Hover src/Hover.res 106:21
-{"contents": "```rescript\nint\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
 Hover src/Hover.res 116:16
-{"contents": "```rescript\nAA.cond<[< #str(string)]> => AA.cond<[< #str(string)]>\n```\n\n\n```\n \n```\n```rescript\ntype AA.cond<'a> = 'a\n  constraint 'a = [< #str(string)]\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C110%2C2%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nAA.cond<[< #str(string)]> => AA.cond<[< #str(string)]>\n```\n\n---\n\n```\n \n```\n```rescript\ntype AA.cond<'a> = 'a\n  constraint 'a = [< #str(string)]\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C110%2C2%5D)\n"}}
 
 Hover src/Hover.res 119:25
-{"contents": "```rescript\nAA.cond<[< #str(string)]> => AA.cond<[< #str(string)]>\n```\n\n\n```\n \n```\n```rescript\ntype AA.cond<'a> = 'a\n  constraint 'a = [< #str(string)]\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C110%2C2%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nAA.cond<[< #str(string)]> => AA.cond<[< #str(string)]>\n```\n\n---\n\n```\n \n```\n```rescript\ntype AA.cond<'a> = 'a\n  constraint 'a = [< #str(string)]\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C110%2C2%5D)\n"}}
 
 Hover src/Hover.res 122:3
 Nothing at that position. Now trying to use completion.
 Attribute id:live:[122:0->122:5] label:live
 Completable: Cdecorator(live)
-{"contents": "The `@live` decorator is for reanalyze, a static analysis tool for ReScript that can do dead code analysis.\n\n`@live` tells the dead code analysis that the value should be considered live, even though it might appear to be dead. This is typically used in case of FFI where there are indirect ways to access values. It can be added to everything that could otherwise be considered unused by the dead code analysis - values, functions, arguments, records, individual record fields, and so on.\n\n[Read more and see examples in the documentation](https://rescript-lang.org/syntax-lookup#live-decorator).\n\nHint: Did you know you can run an interactive code analysis in your project by running the command `> ReScript: Start Code Analyzer`? Try it!"}
+{"contents": {"kind": "markdown", "value": "The `@live` decorator is for reanalyze, a static analysis tool for ReScript that can do dead code analysis.\n\n`@live` tells the dead code analysis that the value should be considered live, even though it might appear to be dead. This is typically used in case of FFI where there are indirect ways to access values. It can be added to everything that could otherwise be considered unused by the dead code analysis - values, functions, arguments, records, individual record fields, and so on.\n\n[Read more and see examples in the documentation](https://rescript-lang.org/syntax-lookup#live-decorator).\n\nHint: Did you know you can run an interactive code analysis in your project by running the command `> ReScript: Start Code Analyzer`? Try it!"}}
 
 Hover src/Hover.res 125:4
-{"contents": "```rescript\n(. ()) => unit => int\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(. ()) => unit => int\n```"}}
 
 Hover src/Hover.res 131:4
-{"contents": "```rescript\n(. ()) => (. ()) => int\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(. ()) => (. ()) => int\n```"}}
 
 Hover src/Hover.res 134:4
-{"contents": "```rescript\n(. unit, unit) => int\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(. unit, unit) => int\n```"}}
 
 Hover src/Hover.res 137:5
-{"contents": "```rescript\n(. ()) => unit => int\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(. ()) => unit => int\n```"}}
 
 Hover src/Hover.res 144:9
-{"contents": "```rescript\nint\n```\n\ndoc comment 1"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\ndoc comment 1"}}
 
 Hover src/Hover.res 148:6
-{"contents": "```rescript\nint\n```\n\n doc comment 2 "}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n doc comment 2 "}}
 
 Hover src/Hover.res 165:23
-{"contents": "```rescript\nfoo<bar>\n```\n\n\n```\n \n```\n```rescript\ntype foo<'a> = {content: 'a, zzz: string}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C161%2C2%5D)\n\n---\n\n\n\n```\n \n```\n```rescript\ntype bar = {age: int}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C162%2C2%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nfoo<bar>\n```\n\n---\n\n```\n \n```\n```rescript\ntype foo<'a> = {content: 'a, zzz: string}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C161%2C2%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype bar = {age: int}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C162%2C2%5D)\n"}}
 
 Hover src/Hover.res 167:22
-{"contents": "```rescript\nfoobar\n```\n\n\n```\n \n```\n```rescript\ntype foobar = foo<bar>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C163%2C2%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nfoobar\n```\n\n---\n\n```\n \n```\n```rescript\ntype foobar = foo<bar>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C163%2C2%5D)\n"}}
 
 Complete src/Hover.res 170:16
 posCursor:[170:16] posNoWhite:[170:15] Found expr:[170:5->170:16]
@@ -159,15 +159,15 @@ Completable: Cpath Value[y2].content.""
   }]
 
 Hover src/Hover.res 197:4
-{"contents": "```rescript\nCompV4.props<int, string> => React.element\n```\n\n\n```\n \n```\n```rescript\ntype CompV4.props<'n, 's> = {n?: 'n, s: 's}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C190%2C2%5D)\n\n---\n\n\n\n```\n \n```\n```rescript\ntype React.element = Jsx.element\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C0%2C0%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nCompV4.props<int, string> => React.element\n```\n\n---\n\n```\n \n```\n```rescript\ntype CompV4.props<'n, 's> = {n?: 'n, s: 's}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C190%2C2%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype React.element = Jsx.element\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C0%2C0%5D)\n"}}
 
 Hover src/Hover.res 202:16
-{"contents": "```rescript\nuseR\n```\n\n\n```\n \n```\n```rescript\ntype useR = {x: int, y: list<option<r<float>>>}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C200%2C0%5D)\n\n---\n\n\n\n```\n \n```\n```rescript\ntype r<'a> = {i: 'a, f: float}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C101%2C0%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nuseR\n```\n\n---\n\n```\n \n```\n```rescript\ntype useR = {x: int, y: list<option<r<float>>>}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C200%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype r<'a> = {i: 'a, f: float}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C101%2C0%5D)\n"}}
 
 Hover src/Hover.res 210:13
 Nothing at that position. Now trying to use completion.
 posCursor:[210:13] posNoWhite:[210:12] Found expr:[210:11->210:14]
 Pexp_ident usr:[210:11->210:14]
 Completable: Cpath Value[usr]
-{"contents": "```rescript\nuseR\n```\n\n\n```\n \n```\n```rescript\ntype useR = {x: int, y: list<option<r<float>>>}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C200%2C0%5D)\n\n---\n\n\n\n```\n \n```\n```rescript\ntype r<'a> = {i: 'a, f: float}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C101%2C0%5D)\n\n---\n"}
+{"contents": {"kind": "markdown", "value": "```rescript\nuseR\n```\n\n---\n\n```\n \n```\n```rescript\ntype useR = {x: int, y: list<option<r<float>>>}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C200%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype r<'a> = {i: 'a, f: float}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C101%2C0%5D)\n"}}
 

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -39,10 +39,10 @@ Hover src/Hover.res 46:10
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
 Hover src/Hover.res 49:13
-{"contents": {"kind": "markdown", "value": "```rescript\nmodule Logger = {\n  let log: string => unit\n}\n```"}}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule type Logger = {\n  let log: string => unit\n}\n```"}}
 
 Hover src/Hover.res 54:7
-{"contents": {"kind": "markdown", "value": "```rescript\nmodule Logger = {\n  let log: string => unit\n}\n```"}}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule type Logger = {\n  let log: string => unit\n}\n```"}}
 
 Definition src/Hover.res 60:14
 {"uri": "Hover.res", "range": {"start": {"line": 49, "character": 12}, "end": {"line": 49, "character": 18}}}
@@ -172,8 +172,8 @@ Completable: Cpath Value[usr]
 {"contents": {"kind": "markdown", "value": "```rescript\nuseR\n```\n\n---\n\n```\n \n```\n```rescript\ntype useR = {x: int, y: list<option<r<float>>>}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C200%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype r<'a> = {i: 'a, f: float}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C101%2C0%5D)\n"}}
 
 Hover src/Hover.res 230:20
-{"contents": "```rescript\nint\n```\n\n More Stuff "}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n More Stuff "}}
 
 Hover src/Hover.res 233:17
-{"contents": "```rescript\nint\n```\n\n More Stuff "}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n More Stuff "}}
 

--- a/analysis/tests/src/expected/Jsx2.res.txt
+++ b/analysis/tests/src/expected/Jsx2.res.txt
@@ -416,7 +416,7 @@ posCursor:[162:12] posNoWhite:[162:11] Found expr:[162:6->162:21]
 posCursor:[162:12] posNoWhite:[162:11] Found expr:[162:6->162:20]
 JSX <Comp:[162:6->162:10] age[162:11->162:14]=...[162:15->162:17]> _children:162:18
 Completable: Cjsx([Comp], age, [age])
-{"contents": "```rescript\nint\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
 Hover src/Jsx2.res 167:16
 Nothing at that position. Now trying to use completion.
@@ -429,5 +429,5 @@ posCursor:[167:16] posNoWhite:[167:15] Found expr:[167:10->167:25]
 posCursor:[167:16] posNoWhite:[167:15] Found expr:[167:10->167:24]
 JSX <Comp:[167:10->167:14] age[167:15->167:18]=...[167:19->167:21]> _children:167:22
 Completable: Cjsx([Comp], age, [age])
-{"contents": "```rescript\nint\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 

--- a/analysis/tests/src/expected/Jsx2.resi.txt
+++ b/analysis/tests/src/expected/Jsx2.resi.txt
@@ -1,10 +1,10 @@
 Hover src/Jsx2.resi 1:4
 getLocItem #1: heuristic for makeProps in interface files
 n1:componentLike n2:unit n3:string
-{"contents": "```rescript\n(~first: string, ~key: string=?, unit) => {\"first\": string}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\n(~first: string, ~key: string=?, unit) => {\"first\": string}\n```"}}
 
 Hover src/Jsx2.resi 4:4
-{"contents": "```rescript\nint\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
 Complete src/Jsx2.resi 7:19
 posCursor:[7:19] posNoWhite:[7:18] Found type:[7:12->7:19]

--- a/analysis/tests/src/expected/JsxV4.res.txt
+++ b/analysis/tests/src/expected/JsxV4.res.txt
@@ -14,5 +14,5 @@ Completable: Cjsx([M4], f, [first, f])
   }]
 
 Hover src/JsxV4.res 14:9
-{"contents": "```rescript\nReact.component<M4.props<string, string, string>>\n```\n\n\n```\n \n```\n```rescript\ntype React.component<'props> = Jsx.component<'props>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C12%2C0%5D)\n\n---\n\n\n\n```\n \n```\n```rescript\ntype M4.props<'first, 'fun, 'second> = {\n  first: 'first,\n  fun?: 'fun,\n  second?: 'second,\n}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22JsxV4.res%22%2C3%2C2%5D)\n\n---\n\n\n Doc Comment For M4 "}
+{"contents": {"kind": "markdown", "value": "```rescript\nReact.component<M4.props<string, string, string>>\n```\n\n---\n\n```\n \n```\n```rescript\ntype React.component<'props> = Jsx.component<'props>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22React.res%22%2C12%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype M4.props<'first, 'fun, 'second> = {\n  first: 'first,\n  fun?: 'fun,\n  second?: 'second,\n}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22JsxV4.res%22%2C3%2C2%5D)\n\n\n Doc Comment For M4 "}}
 

--- a/analysis/tests/src/expected/LongIdentTest.res.txt
+++ b/analysis/tests/src/expected/LongIdentTest.res.txt
@@ -1,3 +1,3 @@
 Hover src/LongIdentTest.res 2:13
-{"contents": "```rescript\nint\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 

--- a/analysis/tests/src/expected/RecModules.res.txt
+++ b/analysis/tests/src/expected/RecModules.res.txt
@@ -1,6 +1,6 @@
 Hover src/RecModules.res 18:12
-{"contents": "```rescript\nmodule C = {\n  type t\n  let createA: t => A.t\n}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule C = {\n  type t\n  let createA: t => A.t\n}\n```"}}
 
 Hover src/RecModules.res 20:12
-{"contents": "```rescript\nmodule A = {\n  type t\n  let child: t => B.t\n}\n```"}
+{"contents": {"kind": "markdown", "value": "```rescript\nmodule A = {\n  type t\n  let child: t => B.t\n}\n```"}}
 


### PR DESCRIPTION
**Before:**

Neovim LSP builtin:
![image](https://user-images.githubusercontent.com/16160544/198854273-37503792-48bd-43ae-acda-83c6544800ce.png)

VSCode:
![image](https://user-images.githubusercontent.com/16160544/198854361-41995fa1-62b6-44e2-9684-86af42b881b3.png)


**After:**

Neovim:
![image](https://user-images.githubusercontent.com/16160544/198854402-a5250c52-1470-44c4-8b11-1c82494ff430.png)

VSCode:
![image](https://user-images.githubusercontent.com/16160544/198854441-6a5b07e6-3213-4f2d-8473-8a953ff7b6a0.png)