### PR TITLE
Signature help - handle pipes

### DIFF
--- a/analysis/tests/src/SignatureHelp.res
+++ b/analysis/tests/src/SignatureHelp.res
@@ -50,3 +50,6 @@ let iAmSoSpecial = (iJustHaveOneArg: string) => {
 
 // let _ = iAmSoSpecial(
 //                      ^she
+
+// let _ = "hello"->otherFunc(1
+//                             ^she

--- a/analysis/tests/src/expected/SignatureHelp.res.txt
+++ b/analysis/tests/src/expected/SignatureHelp.res.txt
@@ -203,7 +203,7 @@ posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:20->53:31]
 Pexp_apply ...[53:20->53:29] (...[53:30->53:31])
 posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:20->53:29]
 Pexp_ident otherFunc:[53:20->53:29]
-argAtCursor: unlabelled<0>
+argAtCursor: unlabelled<1>
 extracted params: 
 [(string, int, float]
 {
@@ -212,6 +212,6 @@ extracted params:
     "parameters": [{"label": [15, 22], "documentation": {"kind": "markdown", "value": "```rescript\nstring\n```"}}, {"label": [24, 27], "documentation": {"kind": "markdown", "value": "```rescript\nstring\n```"}}, {"label": [29, 34], "documentation": {"kind": "markdown", "value": "```rescript\nstring\n```"}}]
   }],
   "activeSignature": 0,
-  "activeParameter": 0
+  "activeParameter": 1
 }
 

--- a/analysis/tests/src/expected/SignatureHelp.res.txt
+++ b/analysis/tests/src/expected/SignatureHelp.res.txt
@@ -182,7 +182,7 @@ extracted params:
 
 Signature help src/SignatureHelp.res 50:24
 posCursor:[50:23] posNoWhite:[50:22] Found expr:[50:11->50:24]
-Pexp_apply ...[50:11->50:23] (...[53:0->50:24])
+Pexp_apply ...[50:11->50:23] (...[56:0->50:24])
 posCursor:[50:23] posNoWhite:[50:22] Found expr:[50:11->50:23]
 Pexp_ident iAmSoSpecial:[50:11->50:23]
 argAtCursor: none
@@ -192,6 +192,24 @@ extracted params:
   "signatures": [{
     "label": "let iAmSoSpecial: string => unit",
     "parameters": [{"label": [18, 24], "documentation": {"kind": "markdown", "value": "```rescript\nstring\n```"}}]
+  }],
+  "activeSignature": 0,
+  "activeParameter": 0
+}
+
+Signature help src/SignatureHelp.res 53:31
+posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:11->53:31]
+posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:20->53:31]
+Pexp_apply ...[53:20->53:29] (...[53:30->53:31])
+posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:20->53:29]
+Pexp_ident otherFunc:[53:20->53:29]
+argAtCursor: unlabelled<0>
+extracted params: 
+[(string, int, float]
+{
+  "signatures": [{
+    "label": "let otherFunc: (string, int, float) => unit",
+    "parameters": [{"label": [15, 22], "documentation": {"kind": "markdown", "value": "```rescript\nstring\n```"}}, {"label": [24, 27], "documentation": {"kind": "markdown", "value": "```rescript\nstring\n```"}}, {"label": [29, 34], "documentation": {"kind": "markdown", "value": "```rescript\nstring\n```"}}]
   }],
   "activeSignature": 0,
   "activeParameter": 0


### PR DESCRIPTION
Previously, the signature help wouldn't understand pipes, meaning signature help for piped expressions would always be off by one when having unlabelled arguments. This diff fixes the signature help to account for pipes when present.

Closes https://github.com/rescript-lang/rescript-vscode/issues/618