### PR TITLE
fix: document symbol path location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - Fix issue where pipes were not taken into account in the signature help, resulting in the highlighted argument in signature help always being off by one for unlabelled arguments in piped expressions https://github.com/rescript-lang/rescript-vscode/issues/618
 
+- Fix file location in Document Symbols response. https://github.com/rescript-lang/rescript-vscode/issues/629
+
 ## v1.8.2
 
 #### :rocket: New Feature

--- a/analysis/src/DocumentSymbol.ml
+++ b/analysis/src/DocumentSymbol.ml
@@ -137,16 +137,9 @@ let command ~path =
   let result =
     !symbols
     |> List.rev_map (fun (name, loc, kind) ->
+           let range = Utils.cmtLocToRange loc in
            Protocol.stringifyDocumentSymbolItem
-             {
-               name;
-               location =
-                 {
-                   uri = Uri.toString (Uri.fromPath path);
-                   range = Utils.cmtLocToRange loc;
-                 };
-               kind = kindNumber kind;
-             })
+             {name; range; selectionRange = range; kind = kindNumber kind})
     |> String.concat ",\n"
   in
   print_endline ("[\n" ^ result ^ "\n]")

--- a/analysis/src/Protocol.ml
+++ b/analysis/src/Protocol.ml
@@ -42,7 +42,12 @@ type completionItem = {
 }
 
 type location = {uri: string; range: range}
-type documentSymbolItem = {name: string; kind: int; location: location}
+type documentSymbolItem = {
+  name: string;
+  kind: int;
+  range: range;
+  selectionRange: range;
+}
 type renameFile = {oldUri: string; newUri: string}
 type textEdit = {range: range; newText: string}
 
@@ -103,15 +108,16 @@ let stringifyLocation (h : location) =
   Printf.sprintf {|{"uri": "%s", "range": %s}|} (Json.escape h.uri)
     (stringifyRange h.range)
 
-let stringifyDocumentSymbolItem i =
+let stringifyDocumentSymbolItem (i : documentSymbolItem) =
+  let range = stringifyRange i.range in
   Printf.sprintf
     {|{
         "name": "%s",
         "kind": %i,
-        "location": %s
+        "range": %s,
+        "selectionRange": %s
 }|}
-    (Json.escape i.name) i.kind
-    (stringifyLocation i.location)
+    (Json.escape i.name) i.kind range range
 
 let stringifyRenameFile {oldUri; newUri} =
   Printf.sprintf {|{

--- a/analysis/tests/src/expected/DocumentSymbol.res.txt
+++ b/analysis/tests/src/expected/DocumentSymbol.res.txt
@@ -3,82 +3,98 @@ DocumentSymbol src/DocumentSymbol.res
 {
         "name": "MyList",
         "kind": 2,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 0, "character": 7}, "end": {"line": 0, "character": 25}}}
+        "range": {"start": {"line": 0, "character": 7}, "end": {"line": 0, "character": 25}},
+        "selectionRange": {"start": {"line": 0, "character": 7}, "end": {"line": 0, "character": 25}}
 },
 {
         "name": "Dep",
         "kind": 2,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 2, "character": 7}, "end": {"line": 7, "character": 1}}}
+        "range": {"start": {"line": 2, "character": 7}, "end": {"line": 7, "character": 1}},
+        "selectionRange": {"start": {"line": 2, "character": 7}, "end": {"line": 7, "character": 1}}
 },
 {
         "name": "customDouble",
         "kind": 12,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 6, "character": 2}, "end": {"line": 6, "character": 35}}}
+        "range": {"start": {"line": 6, "character": 2}, "end": {"line": 6, "character": 35}},
+        "selectionRange": {"start": {"line": 6, "character": 2}, "end": {"line": 6, "character": 35}}
 },
 {
         "name": "Lib",
         "kind": 2,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 9, "character": 7}, "end": {"line": 12, "character": 1}}}
+        "range": {"start": {"line": 9, "character": 7}, "end": {"line": 12, "character": 1}},
+        "selectionRange": {"start": {"line": 9, "character": 7}, "end": {"line": 12, "character": 1}}
 },
 {
         "name": "foo",
         "kind": 12,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 10, "character": 2}, "end": {"line": 10, "character": 55}}}
+        "range": {"start": {"line": 10, "character": 2}, "end": {"line": 10, "character": 55}},
+        "selectionRange": {"start": {"line": 10, "character": 2}, "end": {"line": 10, "character": 55}}
 },
 {
         "name": "next",
         "kind": 12,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 11, "character": 2}, "end": {"line": 11, "character": 48}}}
+        "range": {"start": {"line": 11, "character": 2}, "end": {"line": 11, "character": 48}},
+        "selectionRange": {"start": {"line": 11, "character": 2}, "end": {"line": 11, "character": 48}}
 },
 {
         "name": "op",
         "kind": 13,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 14, "character": 0}, "end": {"line": 14, "character": 16}}}
+        "range": {"start": {"line": 14, "character": 0}, "end": {"line": 14, "character": 16}},
+        "selectionRange": {"start": {"line": 14, "character": 0}, "end": {"line": 14, "character": 16}}
 },
 {
         "name": "ForAuto",
         "kind": 2,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 16, "character": 7}, "end": {"line": 20, "character": 1}}}
+        "range": {"start": {"line": 16, "character": 7}, "end": {"line": 20, "character": 1}},
+        "selectionRange": {"start": {"line": 16, "character": 7}, "end": {"line": 20, "character": 1}}
 },
 {
         "name": "t",
         "kind": 26,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 17, "character": 2}, "end": {"line": 17, "character": 14}}}
+        "range": {"start": {"line": 17, "character": 2}, "end": {"line": 17, "character": 14}},
+        "selectionRange": {"start": {"line": 17, "character": 2}, "end": {"line": 17, "character": 14}}
 },
 {
         "name": "abc",
         "kind": 12,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 18, "character": 2}, "end": {"line": 18, "character": 32}}}
+        "range": {"start": {"line": 18, "character": 2}, "end": {"line": 18, "character": 32}},
+        "selectionRange": {"start": {"line": 18, "character": 2}, "end": {"line": 18, "character": 32}}
 },
 {
         "name": "abd",
         "kind": 12,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 19, "character": 2}, "end": {"line": 19, "character": 32}}}
+        "range": {"start": {"line": 19, "character": 2}, "end": {"line": 19, "character": 32}},
+        "selectionRange": {"start": {"line": 19, "character": 2}, "end": {"line": 19, "character": 32}}
 },
 {
         "name": "fa",
         "kind": 16,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 22, "character": 0}, "end": {"line": 22, "character": 22}}}
+        "range": {"start": {"line": 22, "character": 0}, "end": {"line": 22, "character": 22}},
+        "selectionRange": {"start": {"line": 22, "character": 0}, "end": {"line": 22, "character": 22}}
 },
 {
         "name": "O",
         "kind": 2,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 24, "character": 7}, "end": {"line": 29, "character": 1}}}
+        "range": {"start": {"line": 24, "character": 7}, "end": {"line": 29, "character": 1}},
+        "selectionRange": {"start": {"line": 24, "character": 7}, "end": {"line": 29, "character": 1}}
 },
 {
         "name": "Comp",
         "kind": 2,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 25, "character": 9}, "end": {"line": 28, "character": 3}}}
+        "range": {"start": {"line": 25, "character": 9}, "end": {"line": 28, "character": 3}},
+        "selectionRange": {"start": {"line": 25, "character": 9}, "end": {"line": 28, "character": 3}}
 },
 {
         "name": "make",
         "kind": 12,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 27, "character": 4}, "end": {"line": 27, "character": 98}}}
+        "range": {"start": {"line": 27, "character": 4}, "end": {"line": 27, "character": 98}},
+        "selectionRange": {"start": {"line": 27, "character": 4}, "end": {"line": 27, "character": 98}}
 },
 {
         "name": "zzz",
         "kind": 16,
-        "location": {"uri": "DocumentSymbol.res", "range": {"start": {"line": 31, "character": 0}, "end": {"line": 31, "character": 12}}}
+        "range": {"start": {"line": 31, "character": 0}, "end": {"line": 31, "character": 12}},
+        "selectionRange": {"start": {"line": 31, "character": 0}, "end": {"line": 31, "character": 12}}
 }
 ]
 


### PR DESCRIPTION
Change response format to [documentSymbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol). [symbolInformation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolInformation) are deprecated.

Close #628 