### PR TITLE
Fix issue with references to elements defined in an interface file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 
 - Fix issue where code analysis would not track types in inner modules across implementations and interfaces https://github.com/rescript-association/reanalyze/issues/186
 
+- Fix issue with references to elements defined in an interface file https://github.com/rescript-lang/rescript-vscode/issues/645
+
 ## v1.8.2
 
 #### :rocket: New Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 - Fix issue where code analysis would not track types in inner modules across implementations and interfaces https://github.com/rescript-association/reanalyze/issues/186
 
-- Fix issue with references to elements defined in an interface file https://github.com/rescript-lang/rescript-vscode/issues/645
+- Fix issue with references to elements defined in an interface file https://github.com/rescript-lang/rescript-vscode/pull/646
 
 ## v1.8.2
 

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -172,9 +172,11 @@ let references ~path ~pos ~debug =
                  | Some loc -> loc
                  | None -> Uri.toTopLevelLoc uri2
                in
-               Protocol.stringifyLocation
-                 {uri = Uri.toString uri2; range = Utils.cmtLocToRange loc}
-               :: acc)
+               if loc.loc_ghost then acc
+               else
+                 Protocol.stringifyLocation
+                   {uri = Uri.toString uri2; range = Utils.cmtLocToRange loc}
+                 :: acc)
              [])
   in
   print_endline

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -172,11 +172,9 @@ let references ~path ~pos ~debug =
                  | Some loc -> loc
                  | None -> Uri.toTopLevelLoc uri2
                in
-               if loc.loc_ghost then acc
-               else
-                 Protocol.stringifyLocation
-                   {uri = Uri.toString uri2; range = Utils.cmtLocToRange loc}
-                 :: acc)
+               Protocol.stringifyLocation
+                 {uri = Uri.toString uri2; range = Utils.cmtLocToRange loc}
+               :: acc)
              [])
   in
   print_endline

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -19,7 +19,7 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
     let oldDeclared = Stamps.findValue env.stamps stamp in
     let declared =
       addDeclared
-        ~name:(Location.mknoloc (Ident.name ident))
+        ~name:(Location.mkloc (Ident.name ident) loc)
         ~extent:loc ~stamp ~env ~item val_attributes
         (Exported.add exported Exported.Value)
         Stamps.addValue
@@ -107,7 +107,7 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
     let declared =
       addDeclared ~extent:md_loc
         ~item:(forTypeModule env md_type)
-        ~name:(Location.mknoloc (Ident.name ident))
+        ~name:(Location.mkloc (Ident.name ident) md_loc)
         ~stamp:(Ident.binding_time ident) ~env md_attributes
         (Exported.add exported Exported.Module)
         Stamps.addModule

--- a/analysis/tests/src/References.res
+++ b/analysis/tests/src/References.res
@@ -9,3 +9,14 @@ let c = x
 
 let foo = (~xx) => xx + 1
 //                 ^ref
+
+module M: {
+  let aa: int
+} = {
+  let aa = 10
+}
+
+let bb = M.aa
+let cc = bb
+let dd = M.aa
+//          ^ref

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -14,6 +14,8 @@ Hover src/Hover.res 22:11
 {"contents": {"kind": "markdown", "value": "```rescript\nint => int\n```\n\nSome doc comment"}}
 
 Hover src/Hover.res 26:6
+getLocItem #8: heuristic for JSX with at most one child
+heuristic for: [makeProps, make, createElement], give the loc of `make` 
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
 Hover src/Hover.res 33:4

--- a/analysis/tests/src/expected/References.res.txt
+++ b/analysis/tests/src/expected/References.res.txt
@@ -14,3 +14,9 @@ References src/References.res 9:19
 {"uri": "References.res", "range": {"start": {"line": 9, "character": 19}, "end": {"line": 9, "character": 21}}}
 ]
 
+References src/References.res 20:12
+[
+{"uri": "References.res", "range": {"start": {"line": 18, "character": 11}, "end": {"line": 18, "character": 13}}},
+{"uri": "References.res", "range": {"start": {"line": 20, "character": 11}, "end": {"line": 20, "character": 13}}}
+]
+

--- a/analysis/tests/src/expected/References.res.txt
+++ b/analysis/tests/src/expected/References.res.txt
@@ -16,6 +16,7 @@ References src/References.res 9:19
 
 References src/References.res 20:12
 [
+{"uri": "References.res", "range": {"start": {"line": 13, "character": 2}, "end": {"line": 13, "character": 13}}},
 {"uri": "References.res", "range": {"start": {"line": 18, "character": 11}, "end": {"line": 18, "character": 13}}},
 {"uri": "References.res", "range": {"start": {"line": 20, "character": 11}, "end": {"line": 20, "character": 13}}}
 ]


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/645

References to elements defined in an interface file are not working. E.g.
```res
module M: {
  let aa: int
} = {
  let aa = 10
}

let bb = M.aa
let cc = bb
let dd = M.aa
//          ^ref
```

The observed issue is that the locations of the references are fine, but the location of the definition in the module type is reported as being a ghost location (line -1).

This PR simply removes the ghost location from the results. Still need to look at why such ghost location is produced (go to definitions goes to the correct location in the module type).

For components, the JSX ppx produces 2 values called `make` shadowing one another, which triggers the compiler to generate a module constraint with a module type having only one `make`, and the same issue appears.

