### PR TITLE
Fix issue where jump to definition would go to the wrong place when there are aliased identifiers in submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 - Fix issue with references from implementation files which also happen to have interface files https://github.com/rescript-lang/rescript-vscode/issues/645
 
+- Fix issue where jump to definition would go to the wrong place when there are aliased identifiers in submodules https://github.com/rescript-lang/rescript-vscode/pull/653
+
 ## v1.8.2
 
 #### :rocket: New Feature

--- a/analysis/src/Hover.ml
+++ b/analysis/src/Hover.ml
@@ -184,24 +184,21 @@ let newHover ~full:{file; package} ~supportsMarkdownLinks locItem =
     | None -> None
     | Some file -> (
       let env = QueryEnv.fromFile file in
-      match ResolvePath.resolvePath ~env ~path ~package with
+      match References.exportedForTip ~env ~path ~package ~tip with
       | None -> None
-      | Some (env, name) -> (
-        match References.exportedForTip ~env ~name tip with
+      | Some (_env, _name, stamp) -> (
+        match Stamps.findModule file.stamps stamp with
         | None -> None
-        | Some stamp -> (
-          match Stamps.findModule file.stamps stamp with
+        | Some md -> (
+          match References.resolveModuleReference ~file ~package md with
           | None -> None
-          | Some md -> (
-            match References.resolveModuleReference ~file ~package md with
-            | None -> None
-            | Some (file, declared) ->
-              let name, docstring =
-                match declared with
-                | Some d -> (d.name.txt, d.docstring)
-                | None -> (file.moduleName, file.structure.docstring)
-              in
-              showModule ~docstring ~name ~file declared)))))
+          | Some (file, declared) ->
+            let name, docstring =
+              match declared with
+              | Some d -> (d.name.txt, d.docstring)
+              | None -> (file.moduleName, file.structure.docstring)
+            in
+            showModule ~docstring ~name ~file declared))))
   | LModule NotFound -> None
   | TopLevelModule name -> (
     match ProcessCmt.fileForModule ~package name with

--- a/analysis/src/Hover.ml
+++ b/analysis/src/Hover.ml
@@ -106,7 +106,8 @@ let hoverWithExpandedTypes ~docstring ~file ~package ~supportsMarkdownLinks typ
                Markdown.goToDefinitionText ~env ~pos:loc.Warnings.loc_start
              else ""
            in
-           Markdown.divider ^ (if supportsMarkdownLinks then Markdown.spacing else "")
+           Markdown.divider
+           ^ (if supportsMarkdownLinks then Markdown.spacing else "")
            ^ Markdown.codeBlock
                (decl
                |> Shared.declToString ~printNameAsIs:true
@@ -186,7 +187,7 @@ let newHover ~full:{file; package} ~supportsMarkdownLinks locItem =
       match ResolvePath.resolvePath ~env ~path ~package with
       | None -> None
       | Some (env, name) -> (
-        match References.exportedForTip ~env name tip with
+        match References.exportedForTip ~env ~name tip with
         | None -> None
         | Some stamp -> (
           match Stamps.findModule file.stamps stamp with

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -249,7 +249,17 @@ let rec forSignatureItem ~env ~(exported : Exported.t)
            decl |> forTypeDeclaration ~env ~exported ~recStatus)
   | Tsig_module
       {md_id; md_attributes; md_loc; md_name = name; md_type = {mty_type}} ->
-    let item = forTypeModule env mty_type in
+    let item =
+      let env =
+        {
+          env with
+          modulePath =
+            ExportedModule
+              {name = name.txt; modulePath = env.modulePath; isType = false};
+        }
+      in
+      forTypeModule env mty_type
+    in
     let declared =
       addDeclared ~item ~name ~extent:md_loc ~stamp:(Ident.binding_time md_id)
         ~env md_attributes

--- a/analysis/src/ResolvePath.ml
+++ b/analysis/src/ResolvePath.ml
@@ -133,7 +133,7 @@ let resolveFromCompilerPath ~env ~package path =
   | NotFound -> NotFound
   | Exported (env, name) -> Exported (env, name)
 
-let rec getSourceUri ~(env : QueryEnv.t) ~package path =
+let rec getSourceUri ~(env : QueryEnv.t) ~package (path : ModulePath.t) =
   match path with
   | File (uri, _moduleName) -> uri
   | NotVisible -> env.file.uri

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -274,6 +274,13 @@ end
 
 module Env = struct
   type t = {stamps: Stamps.t; modulePath: ModulePath.t}
+  let addExportedModule ~name ~isType env =
+    {
+      env with
+      modulePath = ExportedModule {name; modulePath = env.modulePath; isType};
+    }
+  let addModule ~name env = env |> addExportedModule ~name ~isType:false
+  let addModuleType ~name env = env |> addExportedModule ~name ~isType:true
 end
 
 type filePath = string

--- a/analysis/tests/src/Cross.res
+++ b/analysis/tests/src/Cross.res
@@ -36,3 +36,6 @@ type defT2 = DefinitionWithInterface.t
 
 // DefinitionWithInterface.a
 //                          ^com
+
+let yy = DefinitionWithInterface.Inner.y
+//                                     ^def

--- a/analysis/tests/src/DefinitionWithInterface.res
+++ b/analysis/tests/src/DefinitionWithInterface.res
@@ -5,3 +5,7 @@ type t = int
 
 let aabbcc = 3
 let _ = aabbcc
+
+module Inner = {
+  let y = 100
+}

--- a/analysis/tests/src/DefinitionWithInterface.res
+++ b/analysis/tests/src/DefinitionWithInterface.res
@@ -8,4 +8,5 @@ let _ = aabbcc
 
 module Inner = {
   let y = 100
+  //  ^def
 }

--- a/analysis/tests/src/DefinitionWithInterface.resi
+++ b/analysis/tests/src/DefinitionWithInterface.resi
@@ -2,3 +2,7 @@ let y: int
 //  ^def
 
 type t
+
+module Inner: {
+  let y: int
+}

--- a/analysis/tests/src/DefinitionWithInterface.resi
+++ b/analysis/tests/src/DefinitionWithInterface.resi
@@ -5,4 +5,5 @@ type t
 
 module Inner: {
   let y: int
+  //  ^def
 }

--- a/analysis/tests/src/expected/Cross.res.txt
+++ b/analysis/tests/src/expected/Cross.res.txt
@@ -99,3 +99,6 @@ Pexp_ident DefinitionWithInterface.a:[36:3->36:28]
 Completable: Cpath Value[DefinitionWithInterface, a]
 []
 
+Definition src/Cross.res 39:39
+{"uri": "DefinitionWithInterface.res", "range": {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 5}}}
+

--- a/analysis/tests/src/expected/Cross.res.txt
+++ b/analysis/tests/src/expected/Cross.res.txt
@@ -100,5 +100,5 @@ Completable: Cpath Value[DefinitionWithInterface, a]
 []
 
 Definition src/Cross.res 39:39
-{"uri": "DefinitionWithInterface.res", "range": {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 5}}}
+{"uri": "DefinitionWithInterface.res", "range": {"start": {"line": 9, "character": 6}, "end": {"line": 9, "character": 7}}}
 

--- a/analysis/tests/src/expected/DefinitionWithInterface.res.txt
+++ b/analysis/tests/src/expected/DefinitionWithInterface.res.txt
@@ -1,3 +1,6 @@
 Definition src/DefinitionWithInterface.res 0:4
 {"uri": "DefinitionWithInterface.resi", "range": {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 5}}}
 
+Definition src/DefinitionWithInterface.res 9:6
+{"uri": "DefinitionWithInterface.resi", "range": {"start": {"line": 6, "character": 2}, "end": {"line": 6, "character": 12}}}
+

--- a/analysis/tests/src/expected/DefinitionWithInterface.resi.txt
+++ b/analysis/tests/src/expected/DefinitionWithInterface.resi.txt
@@ -1,3 +1,6 @@
 Definition src/DefinitionWithInterface.resi 0:4
 {"uri": "DefinitionWithInterface.res", "range": {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 5}}}
 
+Definition src/DefinitionWithInterface.resi 6:6
+{"uri": "DefinitionWithInterface.res", "range": {"start": {"line": 9, "character": 6}, "end": {"line": 9, "character": 7}}}
+


### PR DESCRIPTION
In the example, the reference to `DefinitionWithInterface.Inner.y` leads to `DefinitionWithInterface.y` instead. This seems to happen only when there is an interface file, and the outer module has the same value named `y` as the inner module.

See https://github.com/rescript-lang/rescript-vscode/issues/652