### PR TITLE
polish: move `prepareRename` to analysis binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Rename custom LSP methods names. https://github.com/rescript-lang/rescript-vscode/pull/611
 - Better performance for Inlay Hints and Codelens.
 - Accept both `@ns.doc` and the new `@res.doc` for the internal representation of doc comments. And both `@ns.optional` and `@res.optional` for the optional fields. https://github.com/rescript-lang/rescript-vscode/pull/642
+- Migrate `prepareRename` to analysis
 
 #### :bug: Bug Fix
 

--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -10,6 +10,7 @@ API examples:
   ./rescript-editor-analysis.exe hover src/MyFile.res 10 2 true
   ./rescript-editor-analysis.exe references src/MyFile.res 10 2
   ./rescript-editor-analysis.exe rename src/MyFile.res 10 2 foo
+  ./rescript-editor-analysis.exe prepareRename src/MyFile.res 10 2
   ./rescript-editor-analysis.exe diagnosticSyntax src/MyFile.res
   ./rescript-editor-analysis.exe inlayHint src/MyFile.res 0 3 25
   ./rescript-editor-analysis.exe codeLens src/MyFile.res
@@ -50,6 +51,10 @@ Options:
   rename: rename all appearances of item in MyFile.res at line 10 column 2 with foo:
 
     ./rescript-editor-analysis.exe rename src/MyFile.res 10 2 foo
+
+  prepareRename: Validity of a rename operation at a given location.
+
+    ./rescript-editor-analysis.exe prepareRename src/MyFile.res 10 2
 
   semanticTokens: return token semantic highlighting info for MyFile.res
 
@@ -136,6 +141,10 @@ let main () =
     Commands.rename ~path
       ~pos:(int_of_string line, int_of_string col)
       ~newName ~debug:false
+  | [_; "prepareRename"; path; line; col] ->
+    Commands.prepareRename ~path
+      ~pos:(int_of_string line, int_of_string col)
+      ~debug:false
   | [_; "semanticTokens"; currentFile] ->
     SemanticTokens.semanticTokens ~currentFile
   | [_; "createInterface"; path; cmiFile] ->

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -253,6 +253,20 @@ let rename ~path ~pos ~newName ~debug =
   in
   print_endline result
 
+let prepareRename ~path ~pos ~debug =
+  let currentLoc =
+    match Cmt.loadFullCmtFromPath ~path with
+    | None -> None
+    | Some full -> (
+      match References.getLocItem ~full ~pos ~debug with
+      | None -> None
+      | Some {loc} -> Some (Utils.cmtLocToRange loc))
+  in
+  (match currentLoc with
+  | None -> Protocol.null
+  | Some range -> range |> Protocol.stringifyRange)
+  |> print_endline
+
 let format ~path =
   if Filename.check_suffix path ".res" then
     let {Res_driver.parsetree = structure; comments; diagnostics} =
@@ -382,6 +396,13 @@ let test ~path =
                ^ string_of_int col ^ " " ^ newName)
             in
             rename ~path ~pos:(line, col) ~newName ~debug:true
+          | "pre" ->
+              let () =
+                print_endline
+                  ("PrepareRename " ^ path ^ " " ^ string_of_int line ^ ":"
+                 ^ string_of_int col)
+              in
+              prepareRename ~path ~pos:(line, col) ~debug:true
           | "typ" ->
             print_endline
               ("TypeDefinition " ^ path ^ " " ^ string_of_int line ^ ":"

--- a/analysis/tests/src/PrepareRename.res
+++ b/analysis/tests/src/PrepareRename.res
@@ -1,0 +1,5 @@
+let a = 1
+//  ^pre
+
+let b = 2 and c = 3
+//                 ^pre      

--- a/analysis/tests/src/expected/PrepareRename.res.txt
+++ b/analysis/tests/src/expected/PrepareRename.res.txt
@@ -1,0 +1,6 @@
+PrepareRename src/PrepareRename.res 0:4
+{"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 5}}
+
+PrepareRename src/PrepareRename.res 3:19
+{"start": {"line": 3, "character": 18}, "end": {"line": 3, "character": 19}}
+

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -556,30 +556,14 @@ function prepareRename(msg: p.RequestMessage): p.ResponseMessage {
   // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareRename
   let params = msg.params as p.PrepareRenameParams;
   let filePath = fileURLToPath(params.textDocument.uri);
-  let locations: null | p.Location[] = utils.getReferencesForPosition(
+
+  let result = utils.runAnalysisAfterSanityCheck(filePath, [
+    "prepareRename",
     filePath,
-    params.position
-  );
-  let result: p.Range | null = null;
-  if (locations !== null) {
-    locations.forEach((loc) => {
-      if (
-        path.normalize(fileURLToPath(loc.uri)) ===
-        path.normalize(fileURLToPath(params.textDocument.uri))
-      ) {
-        let { start, end } = loc.range;
-        let pos = params.position;
-        if (
-          start.character <= pos.character &&
-          start.line <= pos.line &&
-          end.character >= pos.character &&
-          end.line >= pos.line
-        ) {
-          result = loc.range;
-        }
-      }
-    });
-  }
+    params.position.line,
+    params.position.character,
+  ]);
+
   return {
     jsonrpc: c.jsonrpcVersion,
     id: msg.id,


### PR DESCRIPTION
Previously it fetched all the references `references` and iterated over them to find the location under the cursor. With this change, go directly to the location and validate.