### PR TITLE
Pipe completion unknown/type parameter return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,6 @@
 <p align="center">The Official VSCode plugin for ReScript</p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=chenglou92.rescript-vscode">
-    <img src="https://vsmarketplacebadge.apphb.com/version/chenglou92.rescript-vscode.svg"/>
-    <img src="https://vsmarketplacebadge.apphb.com/installs/chenglou92.rescript-vscode.svg"/>
-  </a>
-</p>
-
-<p align="center">
   <img src="https://user-images.githubusercontent.com/1909539/101266821-790b1400-3707-11eb-8e9f-fb7e36e660e6.gif"/>
 </p>
 

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -15,10 +15,10 @@ let getCompletions ~debug ~path ~pos ~currentFile ~forHover =
       (* Only perform expensive ast operations if there are completables *)
       match Cmt.loadFullCmtFromPath ~path with
       | None -> []
-      | Some {file; package} ->
-        let env = SharedTypes.QueryEnv.fromFile file in
+      | Some full ->
+        let env = SharedTypes.QueryEnv.fromFile full.file in
         completable
-        |> CompletionBackEnd.processCompletable ~debug ~package ~pos ~scope ~env
+        |> CompletionBackEnd.processCompletable ~debug ~full ~pos ~scope ~env
              ~forHover))
 
 let completion ~debug ~path ~pos ~currentFile =

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1275,7 +1275,7 @@ let rec getCompletionsForContextPath ~package ~opens ~rawOpens ~allFiles ~pos
                else None)
       | None -> [])
     | None -> [])
-  | CPPipe (cp, funNamePrefix) -> (
+  | CPPipe {contextPath = cp; id = funNamePrefix} -> (
     match
       cp
       |> getCompletionsForContextPath ~package ~opens ~rawOpens ~allFiles ~pos

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1157,7 +1157,7 @@ let completionsGetTypeEnv = function
   | {Completion.kind = Field ({typ}, _); env} :: _ -> Some (typ, env)
   | _ -> None
 
-let findTypeAtLoc loc ~(env : QueryEnv.t) ~package ~debug =
+let findReturnTypeOfFunctionAtLoc loc ~(env : QueryEnv.t) ~package ~debug =
   match Cmt.loadFullCmtFromPath ~path:(env.file.uri |> Uri.toPath) with
   | None -> None
   | Some full -> (
@@ -1301,7 +1301,9 @@ let rec getCompletionsForContextPath ~package ~opens ~rawOpens ~allFiles ~pos
       let typ =
         match typ with
         | {Types.desc = Tvar _} -> (
-          match findTypeAtLoc lhsLoc ~env ~package ~debug:false with
+          match
+            findReturnTypeOfFunctionAtLoc lhsLoc ~env ~package ~debug:false
+          with
           | None -> typ
           | Some typFromLoc -> typFromLoc)
         | _ -> typ

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -180,6 +180,7 @@ let completePipeChain ~(lhs : Parsetree.expression) =
         pexp_loc;
         pexp_attributes;
       }
+    |> Option.map (fun ctxPath -> (ctxPath, d.pexp_loc))
     (* When the left side of the pipe we're completing is an identifier application.
        Example: someArray->filterAllTheGoodStuff-> *)
   | Pexp_apply
@@ -195,6 +196,7 @@ let completePipeChain ~(lhs : Parsetree.expression) =
         pexp_loc;
         pexp_attributes;
       }
+    |> Option.map (fun ctxPath -> (ctxPath, pexp_loc))
   | _ -> None
 
 let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
@@ -436,11 +438,12 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       | None -> (
         match exprToContextPath lhs with
         | Some pipe ->
-          setResult (Cpath (CPPipe {contextPath = pipe; id}));
+          setResult
+            (Cpath (CPPipe {contextPath = pipe; id; lhsLoc = lhs.pexp_loc}));
           true
         | None -> false)
-      | Some pipe ->
-        setResult (Cpath (CPPipe {contextPath = pipe; id}));
+      | Some (pipe, lhsLoc) ->
+        setResult (Cpath (CPPipe {contextPath = pipe; id; lhsLoc}));
         true
     in
     match expr.pexp_desc with

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -436,11 +436,11 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       | None -> (
         match exprToContextPath lhs with
         | Some pipe ->
-          setResult (Cpath (CPPipe (pipe, id)));
+          setResult (Cpath (CPPipe {contextPath = pipe; id}));
           true
         | None -> false)
       | Some pipe ->
-        setResult (Cpath (CPPipe (pipe, id)));
+        setResult (Cpath (CPPipe {contextPath = pipe; id}));
         true
     in
     match expr.pexp_desc with

--- a/analysis/src/Hover.ml
+++ b/analysis/src/Hover.ml
@@ -136,12 +136,13 @@ let getHoverViaCompletions ~debug ~path ~pos ~currentFile ~forHover
       (* Only perform expensive ast operations if there are completables *)
       match Cmt.loadFullCmtFromPath ~path with
       | None -> None
-      | Some {file; package} -> (
+      | Some full -> (
+        let {file; package} = full in
         let env = SharedTypes.QueryEnv.fromFile file in
         let completions =
           completable
-          |> CompletionBackEnd.processCompletable ~debug ~package ~pos ~scope
-               ~env ~forHover
+          |> CompletionBackEnd.processCompletable ~debug ~full ~pos ~scope ~env
+               ~forHover
         in
         match completions with
         | {kind = Label typString; docstring} :: _ ->

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -479,7 +479,12 @@ module Completable = struct
     | CPId of string list * completionContext
     | CPField of contextPath * string
     | CPObj of contextPath * string
-    | CPPipe of {contextPath: contextPath; id: string; lhsLoc: Warnings.loc}
+    | CPPipe of {
+        contextPath: contextPath;
+        id: string;
+        lhsLoc: Location.t;
+            (** The loc item for the left hand side of the pipe. *)
+      }
 
   type t =
     | Cdecorator of string  (** e.g. @module *)

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -479,7 +479,7 @@ module Completable = struct
     | CPId of string list * completionContext
     | CPField of contextPath * string
     | CPObj of contextPath * string
-    | CPPipe of contextPath * string
+    | CPPipe of {contextPath: contextPath; id: string}
 
   type t =
     | Cdecorator of string  (** e.g. @module *)
@@ -513,7 +513,7 @@ module Completable = struct
         completionContextToString completionContext ^ list sl
       | CPField (cp, s) -> contextPathToString cp ^ "." ^ str s
       | CPObj (cp, s) -> contextPathToString cp ^ "[\"" ^ s ^ "\"]"
-      | CPPipe (cp, s) -> contextPathToString cp ^ "->" ^ s
+      | CPPipe {contextPath; id} -> contextPathToString contextPath ^ "->" ^ id
     in
     function
     | Cpath cp -> "Cpath " ^ contextPathToString cp

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -479,7 +479,7 @@ module Completable = struct
     | CPId of string list * completionContext
     | CPField of contextPath * string
     | CPObj of contextPath * string
-    | CPPipe of {contextPath: contextPath; id: string}
+    | CPPipe of {contextPath: contextPath; id: string; lhsLoc: Warnings.loc}
 
   type t =
     | Cdecorator of string  (** e.g. @module *)

--- a/analysis/src/SignatureHelp.ml
+++ b/analysis/src/SignatureHelp.ml
@@ -18,12 +18,13 @@ let findFunctionType ~currentFile ~debug ~path ~pos =
       | Some (completable, scope) -> (
         match Cmt.loadFullCmtFromPath ~path with
         | None -> None
-        | Some {file; package} ->
+        | Some full ->
+          let {file; package} = full in
           let env = QueryEnv.fromFile file in
           Some
             ( completable
-              |> CompletionBackEnd.processCompletable ~debug ~package ~pos
-                   ~scope ~env ~forHover:true,
+              |> CompletionBackEnd.processCompletable ~debug ~full ~pos ~scope
+                   ~env ~forHover:true,
               env,
               package,
               file )))

--- a/analysis/tests/src/CompletionPipeChain.res
+++ b/analysis/tests/src/CompletionPipeChain.res
@@ -58,3 +58,7 @@ let f = int->Integer.increment(2)
 let _ = [123]->Js.Array2.forEach(v => Js.log(v))
 // ->
 //   ^com
+
+let _ = [123]->Belt.Array.reduce(0, (acc, curr) => acc + curr)
+// ->
+//   ^com

--- a/analysis/tests/src/CompletionPipeChain.res
+++ b/analysis/tests/src/CompletionPipeChain.res
@@ -60,5 +60,5 @@ let _ = [123]->Js.Array2.forEach(v => Js.log(v))
 //   ^com
 
 let _ = [123]->Belt.Array.reduce(0, (acc, curr) => acc + curr)
-// ->
-//   ^com
+// ->t
+//    ^com

--- a/analysis/tests/src/expected/CompletionPipeChain.res.txt
+++ b/analysis/tests/src/expected/CompletionPipeChain.res.txt
@@ -242,5 +242,53 @@ Completable: Cpath Value[Js, Array2, forEach](Nolabel, Nolabel)->
 Complete src/CompletionPipeChain.res 62:5
 posCursor:[62:5] posNoWhite:[62:4] Found expr:[61:8->0:-1]
 Completable: Cpath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)->
-[]
+[{
+    "label": "Belt.Int.fromString",
+    "kind": 12,
+    "tags": [],
+    "detail": "string => option<int>",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `string` to an `int`. Returns `Some(int)` when the input is a number, `None` otherwise.\n\n  ```res example\n  Js.log(Belt.Int.fromString(\"1\") === Some(1)) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.*",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Multiplication of two `int` values. Same as the multiplication from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 * 2 === 4) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int./",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Division of two `int` values. Same as the division from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(4 / 2 === 2); /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n  ```res example\n  Js.log(Belt.Int.toString(1) === \"1\") /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.toFloat",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => float",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `int` to a `float`.\n\n  ```res example\n  Js.log(Belt.Int.toFloat(1) === 1.0) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.fromFloat",
+    "kind": 12,
+    "tags": [],
+    "detail": "float => int",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `float` to an `int`.\n\n  ```res example\n  Js.log(Belt.Int.fromFloat(1.0) === 1) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.-",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Subtraction of two `int` values. Same as the subtraction from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 - 1 === 1) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.+",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Addition of two `int` values. Same as the addition from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 + 2 === 4) /* true */\n  ```\n"}
+  }]
 

--- a/analysis/tests/src/expected/CompletionPipeChain.res.txt
+++ b/analysis/tests/src/expected/CompletionPipeChain.res.txt
@@ -239,28 +239,10 @@ posCursor:[58:5] posNoWhite:[58:4] Found expr:[57:8->0:-1]
 Completable: Cpath Value[Js, Array2, forEach](Nolabel, Nolabel)->
 []
 
-Complete src/CompletionPipeChain.res 62:5
-posCursor:[62:5] posNoWhite:[62:4] Found expr:[61:8->0:-1]
-Completable: Cpath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)->
+Complete src/CompletionPipeChain.res 62:6
+posCursor:[62:6] posNoWhite:[62:5] Found expr:[61:8->62:6]
+Completable: Cpath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)->t
 [{
-    "label": "Belt.Int.fromString",
-    "kind": 12,
-    "tags": [],
-    "detail": "string => option<int>",
-    "documentation": {"kind": "markdown", "value": "\n  Converts a given `string` to an `int`. Returns `Some(int)` when the input is a number, `None` otherwise.\n\n  ```res example\n  Js.log(Belt.Int.fromString(\"1\") === Some(1)) /* true */\n  ```\n"}
-  }, {
-    "label": "Belt.Int.*",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n  Multiplication of two `int` values. Same as the multiplication from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 * 2 === 4) /* true */\n  ```\n"}
-  }, {
-    "label": "Belt.Int./",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n  Division of two `int` values. Same as the division from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(4 / 2 === 2); /* true */\n  ```\n"}
-  }, {
     "label": "Belt.Int.toString",
     "kind": 12,
     "tags": [],
@@ -272,23 +254,5 @@ Completable: Cpath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)->
     "tags": [],
     "detail": "int => float",
     "documentation": {"kind": "markdown", "value": "\n  Converts a given `int` to a `float`.\n\n  ```res example\n  Js.log(Belt.Int.toFloat(1) === 1.0) /* true */\n  ```\n"}
-  }, {
-    "label": "Belt.Int.fromFloat",
-    "kind": 12,
-    "tags": [],
-    "detail": "float => int",
-    "documentation": {"kind": "markdown", "value": "\n  Converts a given `float` to an `int`.\n\n  ```res example\n  Js.log(Belt.Int.fromFloat(1.0) === 1) /* true */\n  ```\n"}
-  }, {
-    "label": "Belt.Int.-",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n  Subtraction of two `int` values. Same as the subtraction from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 - 1 === 1) /* true */\n  ```\n"}
-  }, {
-    "label": "Belt.Int.+",
-    "kind": 12,
-    "tags": [],
-    "detail": "(int, int) => int",
-    "documentation": {"kind": "markdown", "value": "\n  Addition of two `int` values. Same as the addition from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 + 2 === 4) /* true */\n  ```\n"}
   }]
 

--- a/analysis/tests/src/expected/CompletionPipeChain.res.txt
+++ b/analysis/tests/src/expected/CompletionPipeChain.res.txt
@@ -239,3 +239,8 @@ posCursor:[58:5] posNoWhite:[58:4] Found expr:[57:8->0:-1]
 Completable: Cpath Value[Js, Array2, forEach](Nolabel, Nolabel)->
 []
 
+Complete src/CompletionPipeChain.res 62:5
+posCursor:[62:5] posNoWhite:[62:4] Found expr:[61:8->0:-1]
+Completable: Cpath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)->
+[]
+


### PR DESCRIPTION
This fixes pipe completion for functions returning a type not known until the code has compiled. `Array.reduce` being an example, which has the signature `('a, ('a, 'b) => 'a) => 'a`. It returns `'a` but we don't know what `'a` is unless it has compiled.

This makes it so that this now completes as `int` (after saving):
```
let _ = [123]->Belt.Array.reduce(0, (acc, curr) => acc + curr)->
```

Again, note this only has effect _after saving_ (compiling so that the type parameter is instantiated). But it at least enables pipe completion in this scenario, even if it requires saving, which used to not work at all.