### PR TITLE
Complete function argument values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## v1.10.0
 
+#### :rocket: New Feature
+
+- Add autocomplete for function argument values (booleans, variants and options. More values coming), both labelled and unlabelled. https://github.com/rescript-lang/rescript-vscode/pull/665
+
 #### :nail_care: Polish
 
 - Remove spacing between type definition in clients that do not support markdown links. https://github.com/rescript-lang/rescript-vscode/pull/619

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1542,6 +1542,22 @@ let completeTypedValue t ~env ~full ~prefix =
                     ~env))
     in
     items
+  | Some (Toption (env, t)) ->
+    let items =
+      [
+        Completion.create ~name:"None"
+          ~kind:(Label (t |> Shared.typeToString))
+          ~env;
+        Completion.create ~name:"Some(_)"
+          ~kind:(Label (t |> Shared.typeToString))
+          ~env;
+      ]
+    in
+    if prefix = "" then items
+    else
+      items
+      |> List.filter (fun (item : Completion.t) ->
+             Utils.startsWith item.name prefix)
   | _ -> []
 
 let processCompletable ~debug ~full ~scope ~env ~pos ~forHover

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1509,68 +1509,80 @@ let rec extractType ~env ~package (t : Types.type_expr) =
   | Ttuple expressions -> Some (Tuple (env, expressions))
   | _ -> None
 
-let rec completeTypedValue t ~env ~full ~prefix ~expandOption =
-  match t |> extractType ~env ~package:full.package with
-  | Some (Toption (env, typ)) when expandOption ->
-    typ |> completeTypedValue ~env ~full ~prefix ~expandOption:false
-  | Some (Tbool env) ->
+let completeTypedValue ~env ~full ~prefix ~expandOption =
+  let namesUsed = Hashtbl.create 10 in
+  let rec completeTypedValueInner t ~env ~full ~prefix ~expandOption =
     let items =
-      [
-        Completion.create ~name:"true"
-          ~kind:(Label (t |> Shared.typeToString))
-          ~env;
-        Completion.create ~name:"false"
-          ~kind:(Label (t |> Shared.typeToString))
-          ~env;
-      ]
+      match t |> extractType ~env ~package:full.package with
+      | Some (Toption (env, typ)) when expandOption ->
+        typ |> completeTypedValueInner ~env ~full ~prefix ~expandOption:false
+      | Some (Tbool env) ->
+        let items =
+          [
+            Completion.create ~name:"true"
+              ~kind:(Label (t |> Shared.typeToString))
+              ~env;
+            Completion.create ~name:"false"
+              ~kind:(Label (t |> Shared.typeToString))
+              ~env;
+          ]
+        in
+        if prefix = "" then items
+        else
+          items
+          |> List.filter (fun (item : Completion.t) ->
+                 Utils.startsWith item.name prefix)
+      | Some (Tvariant {env; constructors}) ->
+        let items =
+          constructors
+          |> List.filter_map (fun (constructor : Constructor.t) ->
+                 if
+                   prefix <> ""
+                   && not (Utils.startsWith constructor.cname.txt prefix)
+                 then None
+                 else
+                   Some
+                     (Completion.create
+                        ~name:
+                          (constructor.cname.txt
+                          ^
+                          if constructor.args |> List.length > 0 then
+                            "("
+                            ^ (constructor.args
+                              |> List.map (fun _ -> "_")
+                              |> String.concat ", ")
+                            ^ ")"
+                          else "")
+                        ~kind:(Constructor (constructor, "" (* TODO *)))
+                        ~env))
+        in
+        items
+      | Some (Toption (env, t)) ->
+        let items =
+          [
+            Completion.create ~name:"None"
+              ~kind:(Label (t |> Shared.typeToString))
+              ~env;
+            Completion.create ~name:"Some(_)"
+              ~kind:(Label (t |> Shared.typeToString))
+              ~env;
+          ]
+        in
+        if prefix = "" then items
+        else
+          items
+          |> List.filter (fun (item : Completion.t) ->
+                 Utils.startsWith item.name prefix)
+      | _ -> []
     in
+    (* Include all values and modules in completion if there's a prefix, not otherwise *)
     if prefix = "" then items
     else
       items
-      |> List.filter (fun (item : Completion.t) ->
-             Utils.startsWith item.name prefix)
-  | Some (Tvariant {env; constructors}) ->
-    let items =
-      constructors
-      |> List.filter_map (fun (constructor : Constructor.t) ->
-             if
-               prefix <> ""
-               && not (Utils.startsWith constructor.cname.txt prefix)
-             then None
-             else
-               Some
-                 (Completion.create
-                    ~name:
-                      (constructor.cname.txt
-                      ^
-                      if constructor.args |> List.length > 0 then
-                        "("
-                        ^ (constructor.args
-                          |> List.map (fun _ -> "_")
-                          |> String.concat ", ")
-                        ^ ")"
-                      else "")
-                    ~kind:(Constructor (constructor, "" (* TODO *)))
-                    ~env))
-    in
-    items
-  | Some (Toption (env, t)) ->
-    let items =
-      [
-        Completion.create ~name:"None"
-          ~kind:(Label (t |> Shared.typeToString))
-          ~env;
-        Completion.create ~name:"Some(_)"
-          ~kind:(Label (t |> Shared.typeToString))
-          ~env;
-      ]
-    in
-    if prefix = "" then items
-    else
-      items
-      |> List.filter (fun (item : Completion.t) ->
-             Utils.startsWith item.name prefix)
-  | _ -> []
+      @ completionForExportedValues ~env ~prefix ~exact:false ~namesUsed
+      @ completionForExportedModules ~env ~prefix ~exact:false ~namesUsed
+  in
+  completeTypedValueInner ~env ~full ~prefix ~expandOption
 
 let processCompletable ~debug ~full ~scope ~env ~pos ~forHover
     (completable : Completable.t) =

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1942,10 +1942,10 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
            in
            (dec2, doc))
     |> List.map mkDecorator
-  | Cargument {contextPath; argumentLabel; prefix} -> (
+  | Cargument {functionContextPath; argumentLabel; prefix} -> (
     let labels =
       match
-        contextPath
+        functionContextPath
         |> getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos
              ~env ~exact:true ~scope
         |> completionsGetTypeEnv

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1483,23 +1483,12 @@ let getArgs ~env (t : Types.type_expr) ~full =
   in
   t |> getArgsLoop ~env ~full ~currentArgumentPosition:0
 
-type extractedType =
-  | Tuple of QueryEnv.t * Types.type_expr list
-  | Toption of QueryEnv.t * Types.type_expr
-  | Tbool of QueryEnv.t
-  | Tvariant of {
-      env: QueryEnv.t;
-      constructors: Constructor.t list;
-      variantDecl: Types.type_declaration;
-      variantName: string;
-    }
-
-(* This is a more general extraction function for pulling out the type of a type_expr. We already have other similar functions, but they are all specialized on something (variants, records, etc). *)
+(** Pulls out a type we can complete from a type expr. *)
 let rec extractType ~env ~package (t : Types.type_expr) =
   match t.desc with
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> extractType ~env ~package t1
   | Tconstr (Path.Pident {name = "option"}, [payloadTypeExpr], _) ->
-    Some (Toption (env, payloadTypeExpr))
+    Some (Completable.Toption (env, payloadTypeExpr))
   | Tconstr (Path.Pident {name = "bool"}, [], _) -> Some (Tbool env)
   | Tconstr (path, _, _) -> (
     match References.digConstructor ~env ~package path with

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1499,11 +1499,8 @@ let rec extractType ~env ~package (t : Types.type_expr) =
   match t.desc with
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> extractType ~env ~package t1
   | Tconstr (Path.Pident {name = "option"}, [payloadTypeExpr], _) ->
-    (* Handle option. TODO: Look up how the compiler does this and copy that behavior. *)
     Some (Toption (env, payloadTypeExpr))
-  | Tconstr (Path.Pident {name = "bool"}, [], _) ->
-    (* Handle bool. TODO: Look up how the compiler does this and copy that behavior. *)
-    Some (Tbool env)
+  | Tconstr (Path.Pident {name = "bool"}, [], _) -> Some (Tbool env)
   | Tconstr (path, _, _) -> (
     match References.digConstructor ~env ~package path with
     | Some (env, {item = {decl = {type_manifest = Some t1}}}) ->

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1817,6 +1817,7 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
            in
            (dec2, doc))
     |> List.map mkDecorator
+  | Cargument _ -> []
   | CnamedArg (cp, prefix, identsSeen) ->
     let labels =
       match

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1509,8 +1509,10 @@ let rec extractType ~env ~package (t : Types.type_expr) =
   | Ttuple expressions -> Some (Tuple (env, expressions))
   | _ -> None
 
-let completeTypedValue t ~env ~full ~prefix =
+let rec completeTypedValue t ~env ~full ~prefix ~expandOption =
   match t |> extractType ~env ~package:full.package with
+  | Some (Toption (env, typ)) when expandOption ->
+    typ |> completeTypedValue ~env ~full ~prefix ~expandOption:false
   | Some (Tbool env) ->
     let items =
       [
@@ -1938,7 +1940,10 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
     in
     match targetLabel with
     | None -> []
-    | Some (_, typ) -> typ |> completeTypedValue ~env ~full ~prefix)
+    | Some (Labelled _, typ) ->
+      typ |> completeTypedValue ~env ~full ~prefix ~expandOption:true
+    | Some (Unlabelled _, typ) ->
+      typ |> completeTypedValue ~env ~full ~prefix ~expandOption:false)
   | CnamedArg (cp, prefix, identsSeen) ->
     let labels =
       match

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1484,8 +1484,6 @@ let getArgs ~env (t : Types.type_expr) ~full =
   t |> getArgsLoop ~env ~full ~currentArgumentPosition:0
 
 type extractedType =
-  | Declared of QueryEnv.t * Type.t Declared.t
-  | Polyvariant of QueryEnv.t * SharedTypes.polyVariantConstructor list
   | Tuple of QueryEnv.t * Types.type_expr list
   | Toption of QueryEnv.t * Types.type_expr
   | Tbool of QueryEnv.t
@@ -1500,35 +1498,6 @@ let rec extractType ~env ~package (t : Types.type_expr) =
   | Tconstr (Path.Pident {name = "bool"}, [], _) ->
     (* Handle bool. TODO: Look up how the compiler does this and copy that behavior. *)
     Some (Tbool env)
-  | Tconstr (path, _, _) -> (
-    match References.digConstructor ~env ~package path with
-    | Some (env, {item = {decl = {type_manifest = Some t1}}}) ->
-      extractType ~env ~package t1
-    | Some (env, typ) -> Some (Declared (env, typ))
-    | None -> None)
-  | Tvariant {row_fields} ->
-    (* Since polyvariants are strutural, they're "inlined". So, we extract just
-       what we need for completion from that definition here. *)
-    let constructors =
-      row_fields
-      |> List.map (fun (label, field) ->
-             {
-               name = label;
-               payload =
-                 (match field with
-                 | Types.Rpresent maybeTypeExpr -> maybeTypeExpr
-                 | _ -> None);
-               args =
-                 (* Multiple arguments are represented as a Ttuple, while a single argument is just the type expression itself. *)
-                 (match field with
-                 | Types.Rpresent (Some typeExpr) -> (
-                   match typeExpr.desc with
-                   | Ttuple args -> args
-                   | _ -> [typeExpr])
-                 | _ -> []);
-             })
-    in
-    Some (Polyvariant (env, constructors))
   | Ttuple expressions -> Some (Tuple (env, expressions))
   | _ -> None
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1539,7 +1539,17 @@ let rec completeTypedValue t ~env ~full ~prefix ~expandOption =
              then None
              else
                Some
-                 (Completion.create ~name:constructor.cname.txt
+                 (Completion.create
+                    ~name:
+                      (constructor.cname.txt
+                      ^
+                      if constructor.args |> List.length > 0 then
+                        "("
+                        ^ (constructor.args
+                          |> List.map (fun _ -> "_")
+                          |> String.concat ", ")
+                        ^ ")"
+                      else "")
                     ~kind:(Constructor (constructor, "" (* TODO *)))
                     ~env))
     in

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -142,11 +142,19 @@ let findArgCompletables ~(args : arg list) ~endPos ~posBeforeCursor
         | Some prefix ->
           Some
             (Cargument
-               {contextPath; argumentLabel = Labelled labelled.name; prefix})
+               {
+                 functionContextPath = contextPath;
+                 argumentLabel = Labelled labelled.name;
+                 prefix;
+               })
       else if isExprHole exp then
         Some
           (Cargument
-             {contextPath; argumentLabel = Labelled labelled.name; prefix = ""})
+             {
+               functionContextPath = contextPath;
+               argumentLabel = Labelled labelled.name;
+               prefix = "";
+             })
       else loop rest
     | {label = None; exp} :: rest ->
       if Res_parsetree_viewer.isTemplateLiteral exp then None
@@ -158,7 +166,7 @@ let findArgCompletables ~(args : arg list) ~endPos ~posBeforeCursor
           Some
             (Cargument
                {
-                 contextPath;
+                 functionContextPath = contextPath;
                  argumentLabel =
                    Unlabelled {argumentPosition = !unlabelledCount};
                  prefix;
@@ -167,7 +175,7 @@ let findArgCompletables ~(args : arg list) ~endPos ~posBeforeCursor
         Some
           (Cargument
              {
-               contextPath;
+               functionContextPath = contextPath;
                argumentLabel = Unlabelled {argumentPosition = !unlabelledCount};
                prefix = "";
              })

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -108,8 +108,8 @@ let extractJsxProps ~(compName : Longident.t Location.loc) ~args =
 
 let extractCompletableArgValueInfo exp =
   match exp.Parsetree.pexp_desc with
-  | Pexp_ident {txt} -> Some (Utils.flattenLongIdent txt |> List.hd)
-  | Pexp_construct ({txt}, _) -> Some (Utils.flattenLongIdent txt |> List.hd)
+  | Pexp_ident {txt = Lident txt} -> Some txt
+  | Pexp_construct ({txt = Lident txt}, _) -> Some txt
   | _ -> None
 
 let isExprHole exp =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -109,6 +109,7 @@ let extractJsxProps ~(compName : Longident.t Location.loc) ~args =
 let extractCompletableArgValueInfo exp =
   match exp.Parsetree.pexp_desc with
   | Pexp_ident {txt} -> Some (Utils.flattenLongIdent txt |> List.hd)
+  | Pexp_construct ({txt}, _) -> Some (Utils.flattenLongIdent txt |> List.hd)
   | _ -> None
 
 let isExprHole exp =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -149,8 +149,6 @@ let findArgCompletables ~(args : arg list) ~endPos ~posBeforeCursor
              {contextPath; argumentLabel = Labelled labelled.name; prefix = ""})
       else loop rest
     | {label = None; exp} :: rest ->
-      (* TODO: Better guard for this... This is so completion does not trigger
-         inside of template string calls, which are regular calls *)
       if Res_parsetree_viewer.isTemplateLiteral exp then None
       else if exp.pexp_loc |> Loc.hasPos ~pos:posBeforeCursor then
         (* Completing in an unlabelled argument *)

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -531,10 +531,11 @@ module Completable = struct
     | Cjsx of string list * string * string list
         (** E.g. (["M", "Comp"], "id", ["id1", "id2"]) for <M.Comp id1=... id2=... ... id *)
     | Cargument of {
-        contextPath: contextPath;
+        functionContextPath: contextPath;
         argumentLabel: argumentLabel;
         prefix: string;
       }
+        (** e.g. someFunction(~someBoolArg=<com>), complete for the value of `someBoolArg` (true or false). *)
 
   (** An extracted type from a type expr *)
   type extractedType =
@@ -585,8 +586,8 @@ module Completable = struct
     | Cnone -> "Cnone"
     | Cjsx (sl1, s, sl2) ->
       "Cjsx(" ^ (sl1 |> list) ^ ", " ^ str s ^ ", " ^ (sl2 |> list) ^ ")"
-    | Cargument {contextPath; argumentLabel; prefix} ->
-      contextPathToString contextPath
+    | Cargument {functionContextPath; argumentLabel; prefix} ->
+      contextPathToString functionContextPath
       ^ "("
       ^ (match argumentLabel with
         | Unlabelled {argumentPosition} -> "$" ^ string_of_int argumentPosition

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -587,7 +587,8 @@ module Completable = struct
     | Cjsx (sl1, s, sl2) ->
       "Cjsx(" ^ (sl1 |> list) ^ ", " ^ str s ^ ", " ^ (sl2 |> list) ^ ")"
     | Cargument {functionContextPath; argumentLabel; prefix} ->
-      contextPathToString functionContextPath
+      "Cargument "
+      ^ contextPathToString functionContextPath
       ^ "("
       ^ (match argumentLabel with
         | Unlabelled {argumentPosition} -> "$" ^ string_of_int argumentPosition

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -502,6 +502,10 @@ module Completable = struct
   (* Completion context *)
   type completionContext = Type | Value | Module | Field
 
+  type argumentLabel =
+    | Unlabelled of {argumentPosition: int}
+    | Labelled of string
+
   type contextPath =
     | CPString
     | CPArray
@@ -526,6 +530,11 @@ module Completable = struct
     | Cpath of contextPath
     | Cjsx of string list * string * string list
         (** E.g. (["M", "Comp"], "id", ["id1", "id2"]) for <M.Comp id1=... id2=... ... id *)
+    | Cargument of {
+        contextPath: contextPath;
+        argumentLabel: argumentLabel;
+        prefix: string;
+      }
 
   let toString =
     let completionContextToString = function
@@ -564,6 +573,14 @@ module Completable = struct
     | Cnone -> "Cnone"
     | Cjsx (sl1, s, sl2) ->
       "Cjsx(" ^ (sl1 |> list) ^ ", " ^ str s ^ ", " ^ (sl2 |> list) ^ ")"
+    | Cargument {contextPath; argumentLabel; prefix} ->
+      contextPathToString contextPath
+      ^ "("
+      ^ (match argumentLabel with
+        | Unlabelled {argumentPosition} -> "$" ^ string_of_int argumentPosition
+        | Labelled name -> "~" ^ name)
+      ^ (if prefix <> "" then "=" ^ prefix else "")
+      ^ ")"
 end
 
 module CursorPosition = struct

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -536,6 +536,18 @@ module Completable = struct
         prefix: string;
       }
 
+  (** An extracted type from a type expr *)
+  type extractedType =
+    | Tuple of QueryEnv.t * Types.type_expr list
+    | Toption of QueryEnv.t * Types.type_expr
+    | Tbool of QueryEnv.t
+    | Tvariant of {
+        env: QueryEnv.t;
+        constructors: Constructor.t list;
+        variantDecl: Types.type_declaration;
+        variantName: string;
+      }
+
   let toString =
     let completionContextToString = function
       | Value -> "Value"

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -498,12 +498,6 @@ let locItemToString {loc = {Location.loc_start; loc_end}; locType} =
 (* needed for debugging *)
 let _ = locItemToString
 
-type polyVariantConstructor = {
-  name: string;
-  payload: Types.type_expr option;
-  args: Types.type_expr list;
-}
-
 module Completable = struct
   (* Completion context *)
   type completionContext = Type | Value | Module | Field

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -505,6 +505,7 @@ module Completable = struct
   type argumentLabel =
     | Unlabelled of {argumentPosition: int}
     | Labelled of string
+    | Optional of string
 
   type contextPath =
     | CPString
@@ -592,7 +593,8 @@ module Completable = struct
       ^ "("
       ^ (match argumentLabel with
         | Unlabelled {argumentPosition} -> "$" ^ string_of_int argumentPosition
-        | Labelled name -> "~" ^ name)
+        | Labelled name -> "~" ^ name
+        | Optional name -> "~" ^ name ^ "=?")
       ^ (if prefix <> "" then "=" ^ prefix else "")
       ^ ")"
 end

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -498,6 +498,12 @@ let locItemToString {loc = {Location.loc_start; loc_end}; locType} =
 (* needed for debugging *)
 let _ = locItemToString
 
+type polyVariantConstructor = {
+  name: string;
+  payload: Types.type_expr option;
+  args: Types.type_expr list;
+}
+
 module Completable = struct
   (* Completion context *)
   type completionContext = Type | Value | Module | Field

--- a/analysis/tests/src/BrokenParserCases.res
+++ b/analysis/tests/src/BrokenParserCases.res
@@ -1,0 +1,5 @@
+// --- BROKEN PARSER CASES ---
+// This below demonstrates an issue when what you're completing is the _last_ labelled argument, and there's a unit application after it. The parser wrongly merges the unit argument as the expression of the labelled argument assignment, where is should really let the trailing unit argument be, and set a %rescript.exprhole as the expression of the assignment, just like it normally does.
+// let _ = someFn(~isOff=, ())
+//                       ^com
+

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -30,7 +30,7 @@ let someOtherFn = (includeName, age) => {
 // let _ = someOtherFn(f)
 //                      ^com
 
-type someVariant = One | Two | Three(int)
+type someVariant = One | Two | Three(int, string)
 
 let someFnTakingVariant = (
   configOpt: option<someVariant>,

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -53,3 +53,7 @@ let someFnTakingVariant = (
 
 // let _ = someFnTakingVariant(~configOpt2=O)
 //                                          ^com
+
+// This below demonstrates an issue when what you're completing is the _last_ labelled argument, and there's a unit application after it. The parser wrongly merges the unit argument as the expression of the labelled argument assignment, where is should really let the trailing unit argument be, and set a %rescript.exprhole as the expression of the assignment, just like it normally does.
+// let _ = someFn(~isOff=, ())
+//                       ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -26,3 +26,15 @@ let someOtherFn = (includeName, age) => {
 
 // let _ = someOtherFn(f)
 //                      ^com
+
+type someVariant = One | Two | Three(int)
+
+let someFnTakingVariant = (~config: someVariant) => {
+  ignore(config)
+}
+
+// let _ = someFnTakingVariant(~config=)
+//                                     ^com
+
+// let _ = someFnTakingVariant(~config=O)
+//                                      ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -1,0 +1,13 @@
+let someFn = (~isOn) => {
+  if isOn {
+    "on"
+  } else {
+    "off"
+  }
+}
+
+// let _ = someFn(~isOn=)
+//                      ^com
+
+// let _ = someFn(~isOn=t)
+//                       ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -67,6 +67,9 @@ let someFnTakingVariant = (
 // let _ = someOtherFn(1, 2, )
 //                          ^com
 
+// let _ = 1->someOtherFn(1, t)
+//                            ^com
+
 // --- BROKEN PARSER CASES ---
 // This below demonstrates an issue when what you're completing is the _last_ labelled argument, and there's a unit application after it. The parser wrongly merges the unit argument as the expression of the labelled argument assignment, where is should really let the trailing unit argument be, and set a %rescript.exprhole as the expression of the assignment, just like it normally does.
 // let _ = someFn(~isOff=, ())

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -11,3 +11,18 @@ let someFn = (~isOn) => {
 
 // let _ = someFn(~isOn=t)
 //                       ^com
+
+let _ = someFn(
+  ~isOn={
+    // switch someFn(~isOn=)
+    //                     ^com
+    true
+  },
+)
+
+let someOtherFn = (includeName, age) => {
+  "Hello" ++ (includeName ? " Some Name" : "") ++ ", you are age " ++ Belt.Int.toString(age)
+}
+
+// let _ = someOtherFn(t)
+//                      ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -24,5 +24,5 @@ let someOtherFn = (includeName, age) => {
   "Hello" ++ (includeName ? " Some Name" : "") ++ ", you are age " ++ Belt.Int.toString(age)
 }
 
-// let _ = someOtherFn(t)
+// let _ = someOtherFn(f)
 //                      ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -25,8 +25,11 @@ let _ = someFn(
   },
 )
 
-let someOtherFn = (includeName, age) => {
-  "Hello" ++ (includeName ? " Some Name" : "") ++ ", you are age " ++ Belt.Int.toString(age)
+let someOtherFn = (includeName, age, includeAge) => {
+  "Hello" ++
+  (includeName ? " Some Name" : "") ++
+  ", you are age " ++
+  Belt.Int.toString(includeAge ? age : 0)
 }
 
 // let _ = someOtherFn(f)
@@ -58,6 +61,14 @@ let someFnTakingVariant = (
 // let _ = someFnTakingVariant(~configOpt2=O)
 //                                          ^com
 
+// --- UNIMPLEMENTED CASES ---
+// The following two cases does not complete to a values because of ambiguity - should it complete for a value, or for a named argument? We don't know whether the function has args or not when deciding, since we're just in the AST at that point. Can potentially be fixed in the future.
+// let _ = someOtherFn()
+//                     ^com
+// let _ = someOtherFn(1, 2, )
+//                          ^com
+
+// --- BROKEN PARSER CASES ---
 // This below demonstrates an issue when what you're completing is the _last_ labelled argument, and there's a unit application after it. The parser wrongly merges the unit argument as the expression of the labelled argument assignment, where is should really let the trailing unit argument be, and set a %rescript.exprhole as the expression of the assignment, just like it normally does.
 // let _ = someFn(~isOff=, ())
 //                       ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -1,5 +1,5 @@
-let someFn = (~isOn) => {
-  if isOn {
+let someFn = (~isOn, ~isOff=false, ()) => {
+  if isOn && !isOff {
     "on"
   } else {
     "off"
@@ -10,6 +10,9 @@ let someFn = (~isOn) => {
 //                      ^com
 
 // let _ = someFn(~isOn=t)
+//                       ^com
+
+// let _ = someFn(~isOff=)
 //                       ^com
 
 let _ = someFn(
@@ -29,8 +32,14 @@ let someOtherFn = (includeName, age) => {
 
 type someVariant = One | Two | Three(int)
 
-let someFnTakingVariant = (~config: someVariant) => {
+let someFnTakingVariant = (
+  configOpt: option<someVariant>,
+  ~configOpt2=One,
+  ~config: someVariant,
+) => {
   ignore(config)
+  ignore(configOpt)
+  ignore(configOpt2)
 }
 
 // let _ = someFnTakingVariant(~config=)
@@ -38,3 +47,12 @@ let someFnTakingVariant = (~config: someVariant) => {
 
 // let _ = someFnTakingVariant(~config=O)
 //                                      ^com
+
+// let _ = someFnTakingVariant(S)
+//                              ^com
+
+// let _ = someFnTakingVariant(~configOpt=O)
+//                                         ^com
+
+// let _ = someFnTakingVariant(~configOpt2=O)
+//                                          ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -69,8 +69,3 @@ let someFnTakingVariant = (
 
 // let _ = 1->someOtherFn(1, t)
 //                            ^com
-
-// --- BROKEN PARSER CASES ---
-// This below demonstrates an issue when what you're completing is the _last_ labelled argument, and there's a unit application after it. The parser wrongly merges the unit argument as the expression of the labelled argument assignment, where is should really let the trailing unit argument be, and set a %rescript.exprhole as the expression of the assignment, just like it normally does.
-// let _ = someFn(~isOff=, ())
-//                       ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -61,10 +61,9 @@ let someFnTakingVariant = (
 // let _ = someFnTakingVariant(~configOpt2=O)
 //                                          ^com
 
-// --- UNIMPLEMENTED CASES ---
-// The following two cases does not complete to a values because of ambiguity - should it complete for a value, or for a named argument? We don't know whether the function has args or not when deciding, since we're just in the AST at that point. Can potentially be fixed in the future.
 // let _ = someOtherFn()
 //                     ^com
+
 // let _ = someOtherFn(1, 2, )
 //                          ^com
 

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -51,8 +51,5 @@ let someFnTakingVariant = (
 // let _ = someFnTakingVariant(S)
 //                              ^com
 
-// let _ = someFnTakingVariant(~configOpt=O)
-//                                         ^com
-
 // let _ = someFnTakingVariant(~configOpt2=O)
 //                                          ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -6,6 +6,8 @@ let someFn = (~isOn, ~isOff=false, ()) => {
   }
 }
 
+let tLocalVar = false
+
 // let _ = someFn(~isOn=)
 //                      ^com
 
@@ -29,6 +31,8 @@ let someOtherFn = (includeName, age) => {
 
 // let _ = someOtherFn(f)
 //                      ^com
+
+module OIncludeMeInCompletions = {}
 
 type someVariant = One | Two | Three(int, string)
 

--- a/analysis/tests/src/expected/BrokenParserCases.res.txt
+++ b/analysis/tests/src/expected/BrokenParserCases.res.txt
@@ -1,0 +1,6 @@
+Complete src/BrokenParserCases.res 2:25
+posCursor:[2:25] posNoWhite:[2:24] Found expr:[2:11->2:30]
+Pexp_apply ...[2:11->2:17] (~isOff2:19->2:24=...[2:27->2:29])
+Completable: Cargument Value[someFn]($0)
+[]
+

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -94,19 +94,19 @@ Completable: Value[someFnTakingVariant](~config)
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\n",
+    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null
   }, {
     "label": "Two",
     "kind": 4,
     "tags": [],
-    "detail": "Two\n\n",
+    "detail": "Two\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(int, string)\n\n",
+    "detail": "Three(int, string)\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null
   }]
 
@@ -118,7 +118,7 @@ Completable: Value[someFnTakingVariant](~config=O)
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\n",
+    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null
   }, {
     "label": "OIncludeMeInCompletions",
@@ -148,7 +148,7 @@ Completable: Value[someFnTakingVariant](~configOpt2=O)
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\n",
+    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null
   }, {
     "label": "OIncludeMeInCompletions",

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -32,7 +32,19 @@ Complete src/CompletionFunctionArguments.res 14:25
 posCursor:[14:25] posNoWhite:[14:24] Found expr:[14:11->14:26]
 Pexp_apply ...[14:11->14:17] (~isOff14:19->14:24=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOff)
-[]
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
 
 Complete src/CompletionFunctionArguments.res 19:27
 posCursor:[19:27] posNoWhite:[19:26] Found expr:[17:8->23:1]
@@ -108,7 +120,13 @@ Complete src/CompletionFunctionArguments.res 50:32
 posCursor:[50:32] posNoWhite:[50:31] Found expr:[50:11->50:33]
 Pexp_apply ...[50:11->50:30] (...[50:31->50:32])
 Completable: Value[someFnTakingVariant]($0=S)
-[]
+[{
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "someVariant",
+    "documentation": null
+  }]
 
 Complete src/CompletionFunctionArguments.res 53:43
 posCursor:[53:43] posNoWhite:[53:42] Found expr:[53:11->53:44]

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -1,15 +1,28 @@
 Complete src/CompletionFunctionArguments.res 8:24
 posCursor:[8:24] posNoWhite:[8:23] Found expr:[8:11->8:25]
 Pexp_apply ...[8:11->8:17] (~isOn8:19->8:23=...__ghost__[0:-1->0:-1])
-Completable: CnamedArg(Value[someFn], "", [isOn])
-Found type for function (~isOn: bool) => string
+Completable: Value[someFn](~isOn)
 []
 
 Complete src/CompletionFunctionArguments.res 11:25
 posCursor:[11:25] posNoWhite:[11:24] Found expr:[11:11->11:26]
 Pexp_apply ...[11:11->11:17] (~isOn11:19->11:23=...[11:24->11:25])
-posCursor:[11:25] posNoWhite:[11:24] Found expr:[11:24->11:25]
-Pexp_ident t:[11:24->11:25]
-Completable: Cpath Value[t]
+Completable: Value[someFn](~isOn=t)
+[]
+
+Complete src/CompletionFunctionArguments.res 16:27
+posCursor:[16:27] posNoWhite:[16:26] Found expr:[14:8->20:1]
+Pexp_apply ...[14:8->14:14] (~isOn15:3->15:7=...[16:7->18:8])
+posCursor:[16:27] posNoWhite:[16:26] Found expr:[16:7->18:8]
+posCursor:[16:27] posNoWhite:[16:26] Found expr:[16:7->16:28]
+posCursor:[16:27] posNoWhite:[16:26] Found expr:[16:14->16:28]
+Pexp_apply ...[16:14->16:20] (~isOn16:22->16:26=...__ghost__[0:-1->0:-1])
+Completable: Value[someFn](~isOn)
+[]
+
+Complete src/CompletionFunctionArguments.res 26:24
+posCursor:[26:24] posNoWhite:[26:23] Found expr:[26:11->26:25]
+Pexp_apply ...[26:11->26:22] (...[26:23->26:24])
+Completable: Value[someOtherFn]($0=t)
 []
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -194,9 +194,26 @@ Completable: Cargument Value[someOtherFn]($2)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 71:25
-posCursor:[71:25] posNoWhite:[71:24] Found expr:[71:11->71:30]
-Pexp_apply ...[71:11->71:17] (~isOff71:19->71:24=...[71:27->71:29])
+Complete src/CompletionFunctionArguments.res 69:30
+posCursor:[69:30] posNoWhite:[69:29] Found expr:[69:11->69:31]
+Completable: Cargument Value[someOtherFn]($2=t)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "tLocalVar",
+    "kind": 12,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionFunctionArguments.res 74:25
+posCursor:[74:25] posNoWhite:[74:24] Found expr:[74:11->74:30]
+Pexp_apply ...[74:11->74:17] (~isOff74:19->74:24=...[74:27->74:29])
 Completable: Cargument Value[someFn]($0)
 []
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -1,0 +1,15 @@
+Complete src/CompletionFunctionArguments.res 8:24
+posCursor:[8:24] posNoWhite:[8:23] Found expr:[8:11->8:25]
+Pexp_apply ...[8:11->8:17] (~isOn8:19->8:23=...__ghost__[0:-1->0:-1])
+Completable: CnamedArg(Value[someFn], "", [isOn])
+Found type for function (~isOn: bool) => string
+[]
+
+Complete src/CompletionFunctionArguments.res 11:25
+posCursor:[11:25] posNoWhite:[11:24] Found expr:[11:11->11:26]
+Pexp_apply ...[11:11->11:17] (~isOn11:19->11:23=...[11:24->11:25])
+posCursor:[11:25] posNoWhite:[11:24] Found expr:[11:24->11:25]
+Pexp_ident t:[11:24->11:25]
+Completable: Cpath Value[t]
+[]
+

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -1,7 +1,7 @@
 Complete src/CompletionFunctionArguments.res 10:24
 posCursor:[10:24] posNoWhite:[10:23] Found expr:[10:11->10:25]
 Pexp_apply ...[10:11->10:17] (~isOn10:19->10:23=...__ghost__[0:-1->0:-1])
-Completable: Value[someFn](~isOn)
+Completable: Cargument Value[someFn](~isOn)
 [{
     "label": "true",
     "kind": 4,
@@ -19,7 +19,7 @@ Completable: Value[someFn](~isOn)
 Complete src/CompletionFunctionArguments.res 13:25
 posCursor:[13:25] posNoWhite:[13:24] Found expr:[13:11->13:26]
 Pexp_apply ...[13:11->13:17] (~isOn13:19->13:23=...[13:24->13:25])
-Completable: Value[someFn](~isOn=t)
+Completable: Cargument Value[someFn](~isOn=t)
 [{
     "label": "true",
     "kind": 4,
@@ -37,7 +37,7 @@ Completable: Value[someFn](~isOn=t)
 Complete src/CompletionFunctionArguments.res 16:25
 posCursor:[16:25] posNoWhite:[16:24] Found expr:[16:11->16:26]
 Pexp_apply ...[16:11->16:17] (~isOff16:19->16:24=...__ghost__[0:-1->0:-1])
-Completable: Value[someFn](~isOff)
+Completable: Cargument Value[someFn](~isOff)
 [{
     "label": "true",
     "kind": 4,
@@ -59,7 +59,7 @@ posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:7->23:8]
 posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:7->21:28]
 posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:14->21:28]
 Pexp_apply ...[21:14->21:20] (~isOn21:22->21:26=...__ghost__[0:-1->0:-1])
-Completable: Value[someFn](~isOn)
+Completable: Cargument Value[someFn](~isOn)
 [{
     "label": "true",
     "kind": 4,
@@ -77,7 +77,7 @@ Completable: Value[someFn](~isOn)
 Complete src/CompletionFunctionArguments.res 34:24
 posCursor:[34:24] posNoWhite:[34:23] Found expr:[34:11->34:25]
 Pexp_apply ...[34:11->34:22] (...[34:23->34:24])
-Completable: Value[someOtherFn]($0=f)
+Completable: Cargument Value[someOtherFn]($0=f)
 [{
     "label": "false",
     "kind": 4,
@@ -89,7 +89,7 @@ Completable: Value[someOtherFn]($0=f)
 Complete src/CompletionFunctionArguments.res 51:39
 posCursor:[51:39] posNoWhite:[51:38] Found expr:[51:11->51:40]
 Pexp_apply ...[51:11->51:30] (~config51:32->51:38=...__ghost__[0:-1->0:-1])
-Completable: Value[someFnTakingVariant](~config)
+Completable: Cargument Value[someFnTakingVariant](~config)
 [{
     "label": "One",
     "kind": 4,
@@ -113,7 +113,7 @@ Completable: Value[someFnTakingVariant](~config)
 Complete src/CompletionFunctionArguments.res 54:40
 posCursor:[54:40] posNoWhite:[54:39] Found expr:[54:11->54:41]
 Pexp_apply ...[54:11->54:30] (~config54:32->54:38=...[54:39->54:40])
-Completable: Value[someFnTakingVariant](~config=O)
+Completable: Cargument Value[someFnTakingVariant](~config=O)
 [{
     "label": "One",
     "kind": 4,
@@ -131,7 +131,7 @@ Completable: Value[someFnTakingVariant](~config=O)
 Complete src/CompletionFunctionArguments.res 57:32
 posCursor:[57:32] posNoWhite:[57:31] Found expr:[57:11->57:33]
 Pexp_apply ...[57:11->57:30] (...[57:31->57:32])
-Completable: Value[someFnTakingVariant]($0=S)
+Completable: Cargument Value[someFnTakingVariant]($0=S)
 [{
     "label": "Some(_)",
     "kind": 4,
@@ -143,7 +143,7 @@ Completable: Value[someFnTakingVariant]($0=S)
 Complete src/CompletionFunctionArguments.res 60:44
 posCursor:[60:44] posNoWhite:[60:43] Found expr:[60:11->60:45]
 Pexp_apply ...[60:11->60:30] (~configOpt260:32->60:42=...[60:43->60:44])
-Completable: Value[someFnTakingVariant](~configOpt2=O)
+Completable: Cargument Value[someFnTakingVariant](~configOpt2=O)
 [{
     "label": "One",
     "kind": 4,

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -97,10 +97,10 @@ Completable: Value[someFnTakingVariant](~config)
     "detail": "Two\n\n",
     "documentation": null
   }, {
-    "label": "Three",
+    "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(int)\n\n",
+    "detail": "Three(int, string)\n\n",
     "documentation": null
   }]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -140,3 +140,16 @@ Completable: Value[someFnTakingVariant](~configOpt2=O)
     "documentation": null
   }]
 
+Complete src/CompletionFunctionArguments.res 57:25
+posCursor:[57:25] posNoWhite:[57:24] Found expr:[57:11->57:30]
+Pexp_apply ...[57:11->57:17] (~isOff57:19->57:24=...[57:27->57:29])
+Completable: CnamedArg(Value[someFn], "", [isOff])
+Found type for function (~isOn: bool, ~isOff: bool=?, unit) => string
+[{
+    "label": "isOn",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -1,6 +1,6 @@
-Complete src/CompletionFunctionArguments.res 10:24
-posCursor:[10:24] posNoWhite:[10:23] Found expr:[10:11->10:25]
-Pexp_apply ...[10:11->10:17] (~isOn10:19->10:23=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 8:24
+posCursor:[8:24] posNoWhite:[8:23] Found expr:[8:11->8:25]
+Pexp_apply ...[8:11->8:17] (~isOn8:19->8:23=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOn)
 [{
     "label": "true",
@@ -16,9 +16,9 @@ Completable: Value[someFn](~isOn)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 13:25
-posCursor:[13:25] posNoWhite:[13:24] Found expr:[13:11->13:26]
-Pexp_apply ...[13:11->13:17] (~isOn13:19->13:23=...[13:24->13:25])
+Complete src/CompletionFunctionArguments.res 11:25
+posCursor:[11:25] posNoWhite:[11:24] Found expr:[11:11->11:26]
+Pexp_apply ...[11:11->11:17] (~isOn11:19->11:23=...[11:24->11:25])
 Completable: Value[someFn](~isOn=t)
 [{
     "label": "true",
@@ -28,13 +28,19 @@ Completable: Value[someFn](~isOn=t)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 18:27
-posCursor:[18:27] posNoWhite:[18:26] Found expr:[16:8->22:1]
-Pexp_apply ...[16:8->16:14] (~isOn17:3->17:7=...[18:7->20:8])
-posCursor:[18:27] posNoWhite:[18:26] Found expr:[18:7->20:8]
-posCursor:[18:27] posNoWhite:[18:26] Found expr:[18:7->18:28]
-posCursor:[18:27] posNoWhite:[18:26] Found expr:[18:14->18:28]
-Pexp_apply ...[18:14->18:20] (~isOn18:22->18:26=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 14:25
+posCursor:[14:25] posNoWhite:[14:24] Found expr:[14:11->14:26]
+Pexp_apply ...[14:11->14:17] (~isOff14:19->14:24=...__ghost__[0:-1->0:-1])
+Completable: Value[someFn](~isOff)
+[]
+
+Complete src/CompletionFunctionArguments.res 19:27
+posCursor:[19:27] posNoWhite:[19:26] Found expr:[17:8->23:1]
+Pexp_apply ...[17:8->17:14] (~isOn18:3->18:7=...[19:7->21:8])
+posCursor:[19:27] posNoWhite:[19:26] Found expr:[19:7->21:8]
+posCursor:[19:27] posNoWhite:[19:26] Found expr:[19:7->19:28]
+posCursor:[19:27] posNoWhite:[19:26] Found expr:[19:14->19:28]
+Pexp_apply ...[19:14->19:20] (~isOn19:22->19:26=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOn)
 [{
     "label": "true",
@@ -50,9 +56,9 @@ Completable: Value[someFn](~isOn)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 28:24
-posCursor:[28:24] posNoWhite:[28:23] Found expr:[28:11->28:25]
-Pexp_apply ...[28:11->28:22] (...[28:23->28:24])
+Complete src/CompletionFunctionArguments.res 29:24
+posCursor:[29:24] posNoWhite:[29:23] Found expr:[29:11->29:25]
+Pexp_apply ...[29:11->29:22] (...[29:23->29:24])
 Completable: Value[someOtherFn]($0=f)
 [{
     "label": "false",
@@ -62,9 +68,9 @@ Completable: Value[someOtherFn]($0=f)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 37:39
-posCursor:[37:39] posNoWhite:[37:38] Found expr:[37:11->37:40]
-Pexp_apply ...[37:11->37:30] (~config37:32->37:38=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 44:39
+posCursor:[44:39] posNoWhite:[44:38] Found expr:[44:11->44:40]
+Pexp_apply ...[44:11->44:30] (~config44:32->44:38=...__ghost__[0:-1->0:-1])
 Completable: Value[someFnTakingVariant](~config)
 [{
     "label": "One",
@@ -86,9 +92,9 @@ Completable: Value[someFnTakingVariant](~config)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 40:40
-posCursor:[40:40] posNoWhite:[40:39] Found expr:[40:11->40:41]
-Pexp_apply ...[40:11->40:30] (~config40:32->40:38=...[40:39->40:40])
+Complete src/CompletionFunctionArguments.res 47:40
+posCursor:[47:40] posNoWhite:[47:39] Found expr:[47:11->47:41]
+Pexp_apply ...[47:11->47:30] (~config47:32->47:38=...[47:39->47:40])
 Completable: Value[someFnTakingVariant](~config=O)
 [{
     "label": "One",
@@ -97,4 +103,22 @@ Completable: Value[someFnTakingVariant](~config=O)
     "detail": "One\n\n",
     "documentation": null
   }]
+
+Complete src/CompletionFunctionArguments.res 50:32
+posCursor:[50:32] posNoWhite:[50:31] Found expr:[50:11->50:33]
+Pexp_apply ...[50:11->50:30] (...[50:31->50:32])
+Completable: Value[someFnTakingVariant]($0=S)
+[]
+
+Complete src/CompletionFunctionArguments.res 53:43
+posCursor:[53:43] posNoWhite:[53:42] Found expr:[53:11->53:44]
+Pexp_apply ...[53:11->53:30] (~configOpt53:32->53:41=...[53:42->53:43])
+Completable: Value[someFnTakingVariant](~configOpt=O)
+[]
+
+Complete src/CompletionFunctionArguments.res 56:44
+posCursor:[56:44] posNoWhite:[56:43] Found expr:[56:11->56:45]
+Pexp_apply ...[56:11->56:30] (~configOpt256:32->56:42=...[56:43->56:44])
+Completable: Value[someFnTakingVariant](~configOpt2=O)
+[]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -74,9 +74,9 @@ Completable: Value[someFn](~isOn)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 31:24
-posCursor:[31:24] posNoWhite:[31:23] Found expr:[31:11->31:25]
-Pexp_apply ...[31:11->31:22] (...[31:23->31:24])
+Complete src/CompletionFunctionArguments.res 34:24
+posCursor:[34:24] posNoWhite:[34:23] Found expr:[34:11->34:25]
+Pexp_apply ...[34:11->34:22] (...[34:23->34:24])
 Completable: Value[someOtherFn]($0=f)
 [{
     "label": "false",
@@ -86,9 +86,9 @@ Completable: Value[someOtherFn]($0=f)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 48:39
-posCursor:[48:39] posNoWhite:[48:38] Found expr:[48:11->48:40]
-Pexp_apply ...[48:11->48:30] (~config48:32->48:38=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 51:39
+posCursor:[51:39] posNoWhite:[51:38] Found expr:[51:11->51:40]
+Pexp_apply ...[51:11->51:30] (~config51:32->51:38=...__ghost__[0:-1->0:-1])
 Completable: Value[someFnTakingVariant](~config)
 [{
     "label": "One",
@@ -110,9 +110,9 @@ Completable: Value[someFnTakingVariant](~config)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 51:40
-posCursor:[51:40] posNoWhite:[51:39] Found expr:[51:11->51:41]
-Pexp_apply ...[51:11->51:30] (~config51:32->51:38=...[51:39->51:40])
+Complete src/CompletionFunctionArguments.res 54:40
+posCursor:[54:40] posNoWhite:[54:39] Found expr:[54:11->54:41]
+Pexp_apply ...[54:11->54:30] (~config54:32->54:38=...[54:39->54:40])
 Completable: Value[someFnTakingVariant](~config=O)
 [{
     "label": "One",
@@ -128,9 +128,9 @@ Completable: Value[someFnTakingVariant](~config=O)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 54:32
-posCursor:[54:32] posNoWhite:[54:31] Found expr:[54:11->54:33]
-Pexp_apply ...[54:11->54:30] (...[54:31->54:32])
+Complete src/CompletionFunctionArguments.res 57:32
+posCursor:[57:32] posNoWhite:[57:31] Found expr:[57:11->57:33]
+Pexp_apply ...[57:11->57:30] (...[57:31->57:32])
 Completable: Value[someFnTakingVariant]($0=S)
 [{
     "label": "Some(_)",
@@ -140,9 +140,9 @@ Completable: Value[someFnTakingVariant]($0=S)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 57:44
-posCursor:[57:44] posNoWhite:[57:43] Found expr:[57:11->57:45]
-Pexp_apply ...[57:11->57:30] (~configOpt257:32->57:42=...[57:43->57:44])
+Complete src/CompletionFunctionArguments.res 60:44
+posCursor:[60:44] posNoWhite:[60:43] Found expr:[60:11->60:45]
+Pexp_apply ...[60:11->60:30] (~configOpt260:32->60:42=...[60:43->60:44])
 Completable: Value[someFnTakingVariant](~configOpt2=O)
 [{
     "label": "One",
@@ -158,9 +158,23 @@ Completable: Value[someFnTakingVariant](~configOpt2=O)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 61:25
-posCursor:[61:25] posNoWhite:[61:24] Found expr:[61:11->61:30]
-Pexp_apply ...[61:11->61:17] (~isOff61:19->61:24=...[61:27->61:29])
+Complete src/CompletionFunctionArguments.res 65:23
+posCursor:[65:23] posNoWhite:[65:22] Found expr:[65:11->65:24]
+Pexp_apply ...[65:11->65:22] (...[65:23->65:24])
+Completable: CnamedArg(Value[someOtherFn], "", [])
+Found type for function (bool, int, bool) => string
+[]
+
+Complete src/CompletionFunctionArguments.res 67:28
+posCursor:[67:28] posNoWhite:[67:27] Found expr:[67:11->67:30]
+Pexp_apply ...[67:11->67:22] (...[67:23->67:24], ...[67:26->67:27])
+Completable: CnamedArg(Value[someOtherFn], "", [])
+Found type for function (bool, int, bool) => string
+[]
+
+Complete src/CompletionFunctionArguments.res 72:25
+posCursor:[72:25] posNoWhite:[72:24] Found expr:[72:11->72:30]
+Pexp_apply ...[72:11->72:17] (~isOff72:19->72:24=...[72:27->72:29])
 Completable: CnamedArg(Value[someFn], "", [isOff])
 Found type for function (~isOn: bool, ~isOff: bool=?, unit) => string
 [{

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -128,15 +128,9 @@ Completable: Value[someFnTakingVariant]($0=S)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 53:43
-posCursor:[53:43] posNoWhite:[53:42] Found expr:[53:11->53:44]
-Pexp_apply ...[53:11->53:30] (~configOpt53:32->53:41=...[53:42->53:43])
-Completable: Value[someFnTakingVariant](~configOpt=O)
-[]
-
-Complete src/CompletionFunctionArguments.res 56:44
-posCursor:[56:44] posNoWhite:[56:43] Found expr:[56:11->56:45]
-Pexp_apply ...[56:11->56:30] (~configOpt256:32->56:42=...[56:43->56:44])
+Complete src/CompletionFunctionArguments.res 53:44
+posCursor:[53:44] posNoWhite:[53:43] Found expr:[53:11->53:45]
+Pexp_apply ...[53:11->53:30] (~configOpt253:32->53:42=...[53:43->53:44])
 Completable: Value[someFnTakingVariant](~configOpt2=O)
 [{
     "label": "One",

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -1,6 +1,6 @@
-Complete src/CompletionFunctionArguments.res 8:24
-posCursor:[8:24] posNoWhite:[8:23] Found expr:[8:11->8:25]
-Pexp_apply ...[8:11->8:17] (~isOn8:19->8:23=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 10:24
+posCursor:[10:24] posNoWhite:[10:23] Found expr:[10:11->10:25]
+Pexp_apply ...[10:11->10:17] (~isOn10:19->10:23=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOn)
 [{
     "label": "true",
@@ -16,9 +16,9 @@ Completable: Value[someFn](~isOn)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 11:25
-posCursor:[11:25] posNoWhite:[11:24] Found expr:[11:11->11:26]
-Pexp_apply ...[11:11->11:17] (~isOn11:19->11:23=...[11:24->11:25])
+Complete src/CompletionFunctionArguments.res 13:25
+posCursor:[13:25] posNoWhite:[13:24] Found expr:[13:11->13:26]
+Pexp_apply ...[13:11->13:17] (~isOn13:19->13:23=...[13:24->13:25])
 Completable: Value[someFn](~isOn=t)
 [{
     "label": "true",
@@ -26,11 +26,17 @@ Completable: Value[someFn](~isOn=t)
     "tags": [],
     "detail": "bool",
     "documentation": null
+  }, {
+    "label": "tLocalVar",
+    "kind": 12,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 14:25
-posCursor:[14:25] posNoWhite:[14:24] Found expr:[14:11->14:26]
-Pexp_apply ...[14:11->14:17] (~isOff14:19->14:24=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 16:25
+posCursor:[16:25] posNoWhite:[16:24] Found expr:[16:11->16:26]
+Pexp_apply ...[16:11->16:17] (~isOff16:19->16:24=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOff)
 [{
     "label": "true",
@@ -46,13 +52,13 @@ Completable: Value[someFn](~isOff)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 19:27
-posCursor:[19:27] posNoWhite:[19:26] Found expr:[17:8->23:1]
-Pexp_apply ...[17:8->17:14] (~isOn18:3->18:7=...[19:7->21:8])
-posCursor:[19:27] posNoWhite:[19:26] Found expr:[19:7->21:8]
-posCursor:[19:27] posNoWhite:[19:26] Found expr:[19:7->19:28]
-posCursor:[19:27] posNoWhite:[19:26] Found expr:[19:14->19:28]
-Pexp_apply ...[19:14->19:20] (~isOn19:22->19:26=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 21:27
+posCursor:[21:27] posNoWhite:[21:26] Found expr:[19:8->25:1]
+Pexp_apply ...[19:8->19:14] (~isOn20:3->20:7=...[21:7->23:8])
+posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:7->23:8]
+posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:7->21:28]
+posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:14->21:28]
+Pexp_apply ...[21:14->21:20] (~isOn21:22->21:26=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOn)
 [{
     "label": "true",
@@ -68,9 +74,9 @@ Completable: Value[someFn](~isOn)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 29:24
-posCursor:[29:24] posNoWhite:[29:23] Found expr:[29:11->29:25]
-Pexp_apply ...[29:11->29:22] (...[29:23->29:24])
+Complete src/CompletionFunctionArguments.res 31:24
+posCursor:[31:24] posNoWhite:[31:23] Found expr:[31:11->31:25]
+Pexp_apply ...[31:11->31:22] (...[31:23->31:24])
 Completable: Value[someOtherFn]($0=f)
 [{
     "label": "false",
@@ -80,9 +86,9 @@ Completable: Value[someOtherFn]($0=f)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 44:39
-posCursor:[44:39] posNoWhite:[44:38] Found expr:[44:11->44:40]
-Pexp_apply ...[44:11->44:30] (~config44:32->44:38=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 48:39
+posCursor:[48:39] posNoWhite:[48:38] Found expr:[48:11->48:40]
+Pexp_apply ...[48:11->48:30] (~config48:32->48:38=...__ghost__[0:-1->0:-1])
 Completable: Value[someFnTakingVariant](~config)
 [{
     "label": "One",
@@ -104,9 +110,9 @@ Completable: Value[someFnTakingVariant](~config)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 47:40
-posCursor:[47:40] posNoWhite:[47:39] Found expr:[47:11->47:41]
-Pexp_apply ...[47:11->47:30] (~config47:32->47:38=...[47:39->47:40])
+Complete src/CompletionFunctionArguments.res 51:40
+posCursor:[51:40] posNoWhite:[51:39] Found expr:[51:11->51:41]
+Pexp_apply ...[51:11->51:30] (~config51:32->51:38=...[51:39->51:40])
 Completable: Value[someFnTakingVariant](~config=O)
 [{
     "label": "One",
@@ -114,11 +120,17 @@ Completable: Value[someFnTakingVariant](~config=O)
     "tags": [],
     "detail": "One\n\n",
     "documentation": null
+  }, {
+    "label": "OIncludeMeInCompletions",
+    "kind": 9,
+    "tags": [],
+    "detail": "module",
+    "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 50:32
-posCursor:[50:32] posNoWhite:[50:31] Found expr:[50:11->50:33]
-Pexp_apply ...[50:11->50:30] (...[50:31->50:32])
+Complete src/CompletionFunctionArguments.res 54:32
+posCursor:[54:32] posNoWhite:[54:31] Found expr:[54:11->54:33]
+Pexp_apply ...[54:11->54:30] (...[54:31->54:32])
 Completable: Value[someFnTakingVariant]($0=S)
 [{
     "label": "Some(_)",
@@ -128,9 +140,9 @@ Completable: Value[someFnTakingVariant]($0=S)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 53:44
-posCursor:[53:44] posNoWhite:[53:43] Found expr:[53:11->53:45]
-Pexp_apply ...[53:11->53:30] (~configOpt253:32->53:42=...[53:43->53:44])
+Complete src/CompletionFunctionArguments.res 57:44
+posCursor:[57:44] posNoWhite:[57:43] Found expr:[57:11->57:45]
+Pexp_apply ...[57:11->57:30] (~configOpt257:32->57:42=...[57:43->57:44])
 Completable: Value[someFnTakingVariant](~configOpt2=O)
 [{
     "label": "One",
@@ -138,11 +150,17 @@ Completable: Value[someFnTakingVariant](~configOpt2=O)
     "tags": [],
     "detail": "One\n\n",
     "documentation": null
+  }, {
+    "label": "OIncludeMeInCompletions",
+    "kind": 9,
+    "tags": [],
+    "detail": "module",
+    "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 57:25
-posCursor:[57:25] posNoWhite:[57:24] Found expr:[57:11->57:30]
-Pexp_apply ...[57:11->57:17] (~isOff57:19->57:24=...[57:27->57:29])
+Complete src/CompletionFunctionArguments.res 61:25
+posCursor:[61:25] posNoWhite:[61:24] Found expr:[61:11->61:30]
+Pexp_apply ...[61:11->61:17] (~isOff61:19->61:24=...[61:27->61:29])
 Completable: CnamedArg(Value[someFn], "", [isOff])
 Found type for function (~isOn: bool, ~isOff: bool=?, unit) => string
 [{

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -33,13 +33,13 @@ posCursor:[14:25] posNoWhite:[14:24] Found expr:[14:11->14:26]
 Pexp_apply ...[14:11->14:17] (~isOff14:19->14:24=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOff)
 [{
-    "label": "None",
+    "label": "true",
     "kind": 4,
     "tags": [],
     "detail": "bool",
     "documentation": null
   }, {
-    "label": "Some(_)",
+    "label": "false",
     "kind": 4,
     "tags": [],
     "detail": "bool",
@@ -138,5 +138,11 @@ Complete src/CompletionFunctionArguments.res 56:44
 posCursor:[56:44] posNoWhite:[56:43] Found expr:[56:11->56:45]
 Pexp_apply ...[56:11->56:30] (~configOpt256:32->56:42=...[56:43->56:44])
 Completable: Value[someFnTakingVariant](~configOpt2=O)
-[]
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\n",
+    "documentation": null
+  }]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -211,9 +211,3 @@ Completable: Cargument Value[someOtherFn]($2=t)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 74:25
-posCursor:[74:25] posNoWhite:[74:24] Found expr:[74:11->74:30]
-Pexp_apply ...[74:11->74:17] (~isOff74:19->74:24=...[74:27->74:29])
-Completable: Cargument Value[someFn]($0)
-[]
-

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -158,30 +158,45 @@ Completable: Cargument Value[someFnTakingVariant](~configOpt2=O)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 65:23
-posCursor:[65:23] posNoWhite:[65:22] Found expr:[65:11->65:24]
-Pexp_apply ...[65:11->65:22] (...[65:23->65:24])
-Completable: CnamedArg(Value[someOtherFn], "", [])
-Found type for function (bool, int, bool) => string
-[]
-
-Complete src/CompletionFunctionArguments.res 67:28
-posCursor:[67:28] posNoWhite:[67:27] Found expr:[67:11->67:30]
-Pexp_apply ...[67:11->67:22] (...[67:23->67:24], ...[67:26->67:27])
-Completable: CnamedArg(Value[someOtherFn], "", [])
-Found type for function (bool, int, bool) => string
-[]
-
-Complete src/CompletionFunctionArguments.res 72:25
-posCursor:[72:25] posNoWhite:[72:24] Found expr:[72:11->72:30]
-Pexp_apply ...[72:11->72:17] (~isOff72:19->72:24=...[72:27->72:29])
-Completable: CnamedArg(Value[someFn], "", [isOff])
-Found type for function (~isOn: bool, ~isOff: bool=?, unit) => string
+Complete src/CompletionFunctionArguments.res 63:23
+posCursor:[63:23] posNoWhite:[63:22] Found expr:[63:11->63:24]
+Pexp_apply ...[63:11->63:22] (...[63:23->63:24])
+Completable: Cargument Value[someOtherFn]($0)
 [{
-    "label": "isOn",
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
     "kind": 4,
     "tags": [],
     "detail": "bool",
     "documentation": null
   }]
+
+Complete src/CompletionFunctionArguments.res 66:28
+posCursor:[66:28] posNoWhite:[66:27] Found expr:[66:11->66:30]
+Pexp_apply ...[66:11->66:22] (...[66:23->66:24], ...[66:26->66:27])
+Completable: Cargument Value[someOtherFn]($2)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionFunctionArguments.res 71:25
+posCursor:[71:25] posNoWhite:[71:24] Found expr:[71:11->71:30]
+Pexp_apply ...[71:11->71:17] (~isOff71:19->71:24=...[71:27->71:29])
+Completable: Cargument Value[someFn]($0)
+[]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -1,6 +1,6 @@
-Complete src/CompletionFunctionArguments.res 8:24
-posCursor:[8:24] posNoWhite:[8:23] Found expr:[8:11->8:25]
-Pexp_apply ...[8:11->8:17] (~isOn8:19->8:23=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 10:24
+posCursor:[10:24] posNoWhite:[10:23] Found expr:[10:11->10:25]
+Pexp_apply ...[10:11->10:17] (~isOn10:19->10:23=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOn)
 [{
     "label": "true",
@@ -16,9 +16,9 @@ Completable: Value[someFn](~isOn)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 11:25
-posCursor:[11:25] posNoWhite:[11:24] Found expr:[11:11->11:26]
-Pexp_apply ...[11:11->11:17] (~isOn11:19->11:23=...[11:24->11:25])
+Complete src/CompletionFunctionArguments.res 13:25
+posCursor:[13:25] posNoWhite:[13:24] Found expr:[13:11->13:26]
+Pexp_apply ...[13:11->13:17] (~isOn13:19->13:23=...[13:24->13:25])
 Completable: Value[someFn](~isOn=t)
 [{
     "label": "true",
@@ -28,13 +28,13 @@ Completable: Value[someFn](~isOn=t)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 16:27
-posCursor:[16:27] posNoWhite:[16:26] Found expr:[14:8->20:1]
-Pexp_apply ...[14:8->14:14] (~isOn15:3->15:7=...[16:7->18:8])
-posCursor:[16:27] posNoWhite:[16:26] Found expr:[16:7->18:8]
-posCursor:[16:27] posNoWhite:[16:26] Found expr:[16:7->16:28]
-posCursor:[16:27] posNoWhite:[16:26] Found expr:[16:14->16:28]
-Pexp_apply ...[16:14->16:20] (~isOn16:22->16:26=...__ghost__[0:-1->0:-1])
+Complete src/CompletionFunctionArguments.res 18:27
+posCursor:[18:27] posNoWhite:[18:26] Found expr:[16:8->22:1]
+Pexp_apply ...[16:8->16:14] (~isOn17:3->17:7=...[18:7->20:8])
+posCursor:[18:27] posNoWhite:[18:26] Found expr:[18:7->20:8]
+posCursor:[18:27] posNoWhite:[18:26] Found expr:[18:7->18:28]
+posCursor:[18:27] posNoWhite:[18:26] Found expr:[18:14->18:28]
+Pexp_apply ...[18:14->18:20] (~isOn18:22->18:26=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOn)
 [{
     "label": "true",
@@ -50,15 +50,51 @@ Completable: Value[someFn](~isOn)
     "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 26:24
-posCursor:[26:24] posNoWhite:[26:23] Found expr:[26:11->26:25]
-Pexp_apply ...[26:11->26:22] (...[26:23->26:24])
+Complete src/CompletionFunctionArguments.res 28:24
+posCursor:[28:24] posNoWhite:[28:23] Found expr:[28:11->28:25]
+Pexp_apply ...[28:11->28:22] (...[28:23->28:24])
 Completable: Value[someOtherFn]($0=f)
 [{
     "label": "false",
     "kind": 4,
     "tags": [],
     "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionFunctionArguments.res 37:39
+posCursor:[37:39] posNoWhite:[37:38] Found expr:[37:11->37:40]
+Pexp_apply ...[37:11->37:30] (~config37:32->37:38=...__ghost__[0:-1->0:-1])
+Completable: Value[someFnTakingVariant](~config)
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\n",
+    "documentation": null
+  }, {
+    "label": "Two",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two\n\n",
+    "documentation": null
+  }, {
+    "label": "Three",
+    "kind": 4,
+    "tags": [],
+    "detail": "Three(int)\n\n",
+    "documentation": null
+  }]
+
+Complete src/CompletionFunctionArguments.res 40:40
+posCursor:[40:40] posNoWhite:[40:39] Found expr:[40:11->40:41]
+Pexp_apply ...[40:11->40:30] (~config40:32->40:38=...[40:39->40:40])
+Completable: Value[someFnTakingVariant](~config=O)
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\n",
     "documentation": null
   }]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -2,13 +2,31 @@ Complete src/CompletionFunctionArguments.res 8:24
 posCursor:[8:24] posNoWhite:[8:23] Found expr:[8:11->8:25]
 Pexp_apply ...[8:11->8:17] (~isOn8:19->8:23=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOn)
-[]
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
 
 Complete src/CompletionFunctionArguments.res 11:25
 posCursor:[11:25] posNoWhite:[11:24] Found expr:[11:11->11:26]
 Pexp_apply ...[11:11->11:17] (~isOn11:19->11:23=...[11:24->11:25])
 Completable: Value[someFn](~isOn=t)
-[]
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
 
 Complete src/CompletionFunctionArguments.res 16:27
 posCursor:[16:27] posNoWhite:[16:26] Found expr:[14:8->20:1]
@@ -18,11 +36,29 @@ posCursor:[16:27] posNoWhite:[16:26] Found expr:[16:7->16:28]
 posCursor:[16:27] posNoWhite:[16:26] Found expr:[16:14->16:28]
 Pexp_apply ...[16:14->16:20] (~isOn16:22->16:26=...__ghost__[0:-1->0:-1])
 Completable: Value[someFn](~isOn)
-[]
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
 
 Complete src/CompletionFunctionArguments.res 26:24
 posCursor:[26:24] posNoWhite:[26:23] Found expr:[26:11->26:25]
 Pexp_apply ...[26:11->26:22] (...[26:23->26:24])
-Completable: Value[someOtherFn]($0=t)
-[]
+Completable: Value[someOtherFn]($0=f)
+[{
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1111,7 +1111,7 @@ function onMessage(msg: p.Message) {
           codeActionProvider: true,
           renameProvider: { prepareProvider: true },
           documentSymbolProvider: true,
-          completionProvider: { triggerCharacters: [".", ">", "@", "~", '"'] },
+          completionProvider: { triggerCharacters: [".", ">", "@", "~", '"', "="] },
           semanticTokensProvider: {
             legend: {
               tokenTypes: [


### PR DESCRIPTION
The first in likely a long series of PRs bringing in and refining the work done in https://github.com/rescript-lang/rescript-vscode/pull/493, but little bit by bit.

This PR does the following:
- Completes the expressions of labelled arguments or unlabelled arguments in function applications.
- Currently completes booleans, options and variants. The rest of the relevant types (polyvariants, records, tuples, etc) will be completable as well in due time.

There are caveats that I've added comments for in the PR.

The next step will be getting support for snippets in completion items in, so we can intelligently move the cursor for the user into payloads of constructors etc. That'll come in a separate PR.
After that, completing polyvariants. 
Then the same work as in this PR, but for JSX props.