### PR TITLE
complete JSX prop values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 #### :rocket: New Feature
 
 - Add autocomplete for function argument values (booleans, variants and options. More values coming), both labelled and unlabelled. https://github.com/rescript-lang/rescript-vscode/pull/665
+- Add autocomplete for JSX prop values. https://github.com/rescript-lang/rescript-vscode/pull/667
 
 #### :nail_care: Polish
 

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -9,8 +9,9 @@ let rec skipWhite text i =
 
 let extractCompletableArgValueInfo exp =
   match exp.Parsetree.pexp_desc with
-  | Pexp_ident {txt = Lident prefix} -> Some prefix
-  | Pexp_construct ({txt = Lident prefix}, _) -> Some prefix
+  | Pexp_ident {txt = Lident txt} -> Some txt
+  | Pexp_construct ({txt = Lident "()"}, _) -> Some ""
+  | Pexp_construct ({txt = Lident txt}, _) -> Some txt
   | _ -> None
 
 let isExprHole exp =
@@ -133,18 +134,6 @@ let extractJsxProps ~(compName : Longident.t Location.loc) ~args =
     | _ -> thisCaseShouldNotHappen
   in
   args |> processProps ~acc:[]
-
-let extractCompletableArgValueInfo exp =
-  match exp.Parsetree.pexp_desc with
-  | Pexp_ident {txt = Lident txt} -> Some txt
-  | Pexp_construct ({txt = Lident "()"}, _) -> Some ""
-  | Pexp_construct ({txt = Lident txt}, _) -> Some txt
-  | _ -> None
-
-let isExprHole exp =
-  match exp.Parsetree.pexp_desc with
-  | Pexp_extension ({txt = "rescript.exprhole"}, _) -> true
-  | _ -> false
 
 let findArgCompletables ~(args : arg list) ~endPos ~posBeforeCursor
     ~(contextPath : Completable.contextPath) ~posAfterFunExpr ~charBeforeCursor

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -537,6 +537,11 @@ module Completable = struct
         prefix: string;
       }
         (** e.g. someFunction(~someBoolArg=<com>), complete for the value of `someBoolArg` (true or false). *)
+    | CjsxPropValue of {
+        pathToComponent: string list;
+        propName: string;
+        prefix: string;
+      }
 
   (** An extracted type from a type expr *)
   type extractedType =
@@ -597,6 +602,9 @@ module Completable = struct
         | Optional name -> "~" ^ name ^ "=?")
       ^ (if prefix <> "" then "=" ^ prefix else "")
       ^ ")"
+    | CjsxPropValue {prefix; pathToComponent; propName} ->
+      "CjsxPropValue " ^ (pathToComponent |> list) ^ " " ^ propName ^ "="
+      ^ prefix
 end
 
 module CursorPosition = struct

--- a/analysis/tests/src/CompletionJsxProps.res
+++ b/analysis/tests/src/CompletionJsxProps.res
@@ -1,0 +1,9 @@
+// let _ = <CompletionSupport.TestComponent on=
+//                                             ^com
+
+// let _ = <CompletionSupport.TestComponent on=t
+//                                              ^com
+
+// let _ = <CompletionSupport.TestComponent test=T
+//                                                ^com
+

--- a/analysis/tests/src/CompletionSupport.res
+++ b/analysis/tests/src/CompletionSupport.res
@@ -4,3 +4,14 @@ module Test = {
   let addSelf = (ax: t) => {name: ax.name + 1}
   let make = (name: int): t => {name: name}
 }
+
+type testVariant = One | Two | Three(int)
+
+module TestComponent = {
+  @react.component
+  let make = (~on: bool, ~test: testVariant) => {
+    ignore(on)
+    ignore(test)
+    React.null
+  }
+}

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -463,9 +463,7 @@ Completable: Cpath Value[Js, Dict, u]
 Complete src/Completion.res 59:30
 posCursor:[59:30] posNoWhite:[59:29] Found expr:[59:15->59:30]
 JSX <O.Comp:[59:15->59:21] second[59:22->59:28]=...[59:29->59:30]> _children:None
-posCursor:[59:30] posNoWhite:[59:29] Found expr:[59:29->59:30]
-Pexp_ident z:[59:29->59:30]
-Completable: Cpath Value[z]
+Completable: CjsxPropValue [O, Comp] second=z
 [{
     "label": "zzz",
     "kind": 12,

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -1,0 +1,48 @@
+Complete src/CompletionJsxProps.res 0:47
+posCursor:[0:47] posNoWhite:[0:46] Found expr:[0:12->0:47]
+JSX <CompletionSupport.TestComponent:[0:12->0:43] on[0:44->0:46]=...__ghost__[0:-1->0:-1]> _children:None
+Completable: CjsxPropValue [CompletionSupport, TestComponent] on=
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionJsxProps.res 3:48
+posCursor:[3:48] posNoWhite:[3:47] Found expr:[3:12->3:48]
+JSX <CompletionSupport.TestComponent:[3:12->3:43] on[3:44->3:46]=...[3:47->3:48]> _children:None
+Completable: CjsxPropValue [CompletionSupport, TestComponent] on=t
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionJsxProps.res 6:50
+posCursor:[6:50] posNoWhite:[6:49] Found expr:[6:12->6:50]
+JSX <CompletionSupport.TestComponent:[6:12->6:43] test[6:44->6:48]=...[6:49->6:50]> _children:None
+Completable: CjsxPropValue [CompletionSupport, TestComponent] test=T
+[{
+    "label": "Two",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
+    "documentation": null
+  }, {
+    "label": "Three(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/Jsx2.res.txt
+++ b/analysis/tests/src/expected/Jsx2.res.txt
@@ -6,9 +6,7 @@ the type is not great but jump to definition works
 Complete src/Jsx2.res 8:15
 posCursor:[8:15] posNoWhite:[8:14] Found expr:[8:4->8:15]
 JSX <M:[8:4->8:5] second[8:6->8:12]=...[8:13->8:15]> _children:None
-posCursor:[8:15] posNoWhite:[8:14] Found expr:[8:13->8:15]
-Pexp_ident fi:[8:13->8:15]
-Completable: Cpath Value[fi]
+Completable: CjsxPropValue [M] second=fi
 []
 
 Complete src/Jsx2.res 11:20


### PR DESCRIPTION
This is ready for an initial review @cristianoc . A few things to consider:
* Can we figure out if we need to qualify variant constructors as we complete them? That's a typical issue with JSX props IIRC, that you almost always have to qualify them so the compiler can find them.
* How can we figure out if we need to expand options for JSX props? With fn arguments it was "easy" - optional label should expand option. How do we do it in JSX, do we need to look up the underlying make function? Maybe we already have access to what we need and I just need a gentle push in the right direction to connect the dots.

Closes https://github.com/rescript-lang/rescript-vscode/issues/322