### PR TITLE
Completion snippet support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Add autocomplete for function argument values (booleans, variants and options. More values coming), both labelled and unlabelled. https://github.com/rescript-lang/rescript-vscode/pull/665
 - Add autocomplete for JSX prop values. https://github.com/rescript-lang/rescript-vscode/pull/667
+- Add snippet support in completion items. https://github.com/rescript-lang/rescript-vscode/pull/668
 
 #### :nail_care: Polish
 

--- a/analysis/src/Cfg.ml
+++ b/analysis/src/Cfg.ml
@@ -1,0 +1,1 @@
+let supportsSnippets = ref false

--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -3,7 +3,7 @@ let help =
 **Private CLI For rescript-vscode usage only**
 
 API examples:
-  ./rescript-editor-analysis.exe completion src/MyFile.res 0 4 currentContent.res
+  ./rescript-editor-analysis.exe completion src/MyFile.res 0 4 currentContent.res true
   ./rescript-editor-analysis.exe definition src/MyFile.res 9 3
   ./rescript-editor-analysis.exe typeDefinition src/MyFile.res 9 3
   ./rescript-editor-analysis.exe documentSymbol src/Foo.res
@@ -86,7 +86,11 @@ Options:
 
 let main () =
   match Array.to_list Sys.argv with
-  | [_; "completion"; path; line; col; currentFile] ->
+  | [_; "completion"; path; line; col; currentFile; supportsSnippets] ->
+    (Cfg.supportsSnippets :=
+       match supportsSnippets with
+       | "true" -> true
+       | _ -> false);
     Commands.completion ~debug:false ~path
       ~pos:(int_of_string line, int_of_string col)
       ~currentFile
@@ -143,7 +147,9 @@ let main () =
       (Json.escape (CreateInterface.command ~path ~cmiFile))
   | [_; "format"; path] ->
     Printf.printf "\"%s\"" (Json.escape (Commands.format ~path))
-  | [_; "test"; path] -> Commands.test ~path
+  | [_; "test"; path] ->
+    Cfg.supportsSnippets := true;
+    Commands.test ~path
   | args when List.mem "-h" args || List.mem "--help" args -> prerr_endline help
   | _ ->
     prerr_endline help;

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1518,7 +1518,7 @@ let rec extractType ~env ~package (t : Types.type_expr) =
         (Tvariant
            {env; constructors; variantName = name.txt; variantDecl = decl})
     | _ -> None)
-  | Ttuple expressions -> Some (Tuple (env, expressions))
+  | Ttuple expressions -> Some (Tuple (env, expressions, t))
   | _ -> None
 
 let filterItems items ~prefix =
@@ -1585,6 +1585,14 @@ let completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
             ~env ~insertText:"Some(${1:_})" ();
         ]
         |> filterItems ~prefix
+      | Some (Tuple (env, exprs, typ)) ->
+        let numExprs = List.length exprs in
+        [
+          Completion.createWithSnippet
+            ~name:(printConstructorArgs numExprs ~asSnippet:false)
+            ~insertText:(printConstructorArgs numExprs ~asSnippet:true)
+            ~kind:(Value typ) ~env ();
+        ]
       | _ -> []
     in
     (* Include all values and modules in completion if there's a prefix, not otherwise *)

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -569,7 +569,7 @@ module Completable = struct
 
   (** An extracted type from a type expr *)
   type extractedType =
-    | Tuple of QueryEnv.t * Types.type_expr list
+    | Tuple of QueryEnv.t * Types.type_expr list * Types.type_expr
     | Toption of QueryEnv.t * Types.type_expr
     | Tbool of QueryEnv.t
     | Tvariant of {

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -292,6 +292,9 @@ module Completion = struct
 
   type t = {
     name: string;
+    sortText: string option;
+    insertText: string option;
+    insertTextFormat: Protocol.insertTextFormat option;
     env: QueryEnv.t;
     deprecated: string option;
     docstring: string list;
@@ -299,7 +302,28 @@ module Completion = struct
   }
 
   let create ~name ~kind ~env =
-    {name; env; deprecated = None; docstring = []; kind}
+    {
+      name;
+      env;
+      deprecated = None;
+      docstring = [];
+      kind;
+      sortText = None;
+      insertText = None;
+      insertTextFormat = None;
+    }
+
+  let createWithSnippet ~name ?insertText ~kind ~env ?sortText () =
+    {
+      name;
+      env;
+      deprecated = None;
+      docstring = [];
+      kind;
+      sortText;
+      insertText;
+      insertTextFormat = Some Protocol.Snippet;
+    }
 
   (* https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion *)
   (* https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemKind *)

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -69,3 +69,10 @@ let someFnTakingVariant = (
 
 // let _ = 1->someOtherFn(1, t)
 //                            ^com
+
+let fnTakingTuple = (arg: (int, int, float)) => {
+  ignore(arg)
+}
+
+// let _ = fnTakingTuple()
+//                       ^com

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -137,7 +137,9 @@ Completable: Cargument Value[someFnTakingVariant]($0=S)
     "kind": 4,
     "tags": [],
     "detail": "someVariant",
-    "documentation": null
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
   }]
 
 Complete src/CompletionFunctionArguments.res 60:44

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -84,6 +84,12 @@ Completable: Cargument Value[someOtherFn]($0=f)
     "tags": [],
     "detail": "bool",
     "documentation": null
+  }, {
+    "label": "fnTakingTuple",
+    "kind": 12,
+    "tags": [],
+    "detail": "((int, int, float)) => unit",
+    "documentation": null
   }]
 
 Complete src/CompletionFunctionArguments.res 51:39
@@ -221,5 +227,19 @@ Completable: Cargument Value[someOtherFn]($2=t)
     "tags": [],
     "detail": "bool",
     "documentation": null
+  }]
+
+Complete src/CompletionFunctionArguments.res 76:25
+posCursor:[76:25] posNoWhite:[76:24] Found expr:[76:11->76:26]
+Pexp_apply ...[76:11->76:24] (...[76:25->76:26])
+Completable: Cargument Value[fnTakingTuple]($0)
+[{
+    "label": "(_, _, _)",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int, float)",
+    "documentation": null,
+    "insertText": "(${1:_}, ${2:_}, ${3:_})",
+    "insertTextFormat": 2
   }]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -95,19 +95,25 @@ Completable: Cargument Value[someFnTakingVariant](~config)
     "kind": 4,
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
   }, {
     "label": "Two",
     "kind": 4,
     "tags": [],
     "detail": "Two\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null
+    "documentation": null,
+    "insertText": "Two",
+    "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
     "detail": "Three(int, string)\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null
+    "documentation": null,
+    "insertText": "Three(${1:_}, ${2:_})",
+    "insertTextFormat": 2
   }]
 
 Complete src/CompletionFunctionArguments.res 54:40
@@ -119,7 +125,9 @@ Completable: Cargument Value[someFnTakingVariant](~config=O)
     "kind": 4,
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
   }, {
     "label": "OIncludeMeInCompletions",
     "kind": 9,
@@ -151,7 +159,9 @@ Completable: Cargument Value[someFnTakingVariant](~configOpt2=O)
     "kind": 4,
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
   }, {
     "label": "OIncludeMeInCompletions",
     "kind": 9,

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -37,12 +37,16 @@ Completable: CjsxPropValue [CompletionSupport, TestComponent] test=T
     "kind": 4,
     "tags": [],
     "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
-    "documentation": null
+    "documentation": null,
+    "insertText": "Two",
+    "insertTextFormat": 2
   }, {
     "label": "Three(_)",
     "kind": 4,
     "tags": [],
     "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
-    "documentation": null
+    "documentation": null,
+    "insertText": "Three(${1:_})",
+    "insertTextFormat": 2
   }]
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -947,7 +947,7 @@ function createInterface(msg: p.RequestMessage): p.Message {
       jsonrpc: c.jsonrpcVersion,
       id: msg.id,
       result: {
-        uri: utils.pathToURI(resiPath),
+        uri: utils.pathToURI(resiPath)
       },
     };
     return response;
@@ -1014,7 +1014,7 @@ function openCompiledFile(msg: p.RequestMessage): p.Message {
     id: msg.id,
     result: {
       uri: utils.pathToURI(compiledFilePath.result),
-    },
+    }
   };
 
   return response;
@@ -1112,9 +1112,7 @@ function onMessage(msg: p.Message) {
           codeActionProvider: true,
           renameProvider: { prepareProvider: true },
           documentSymbolProvider: true,
-          completionProvider: {
-            triggerCharacters: [".", ">", "@", "~", '"', "="],
-          },
+          completionProvider: { triggerCharacters: [".", ">", "@", "~", '"', "="] },
           semanticTokensProvider: {
             legend: {
               tokenTypes: [

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -680,6 +680,7 @@ function completion(msg: p.RequestMessage) {
       params.position.line,
       params.position.character,
       tmpname,
+      "true",
     ],
     msg
   );
@@ -946,7 +947,7 @@ function createInterface(msg: p.RequestMessage): p.Message {
       jsonrpc: c.jsonrpcVersion,
       id: msg.id,
       result: {
-        uri: utils.pathToURI(resiPath)
+        uri: utils.pathToURI(resiPath),
       },
     };
     return response;
@@ -1013,7 +1014,7 @@ function openCompiledFile(msg: p.RequestMessage): p.Message {
     id: msg.id,
     result: {
       uri: utils.pathToURI(compiledFilePath.result),
-    }
+    },
   };
 
   return response;
@@ -1111,7 +1112,9 @@ function onMessage(msg: p.Message) {
           codeActionProvider: true,
           renameProvider: { prepareProvider: true },
           documentSymbolProvider: true,
-          completionProvider: { triggerCharacters: [".", ">", "@", "~", '"', "="] },
+          completionProvider: {
+            triggerCharacters: [".", ">", "@", "~", '"', "="],
+          },
           semanticTokensProvider: {
             legend: {
               tokenTypes: [


### PR DESCRIPTION
This adds support for snippets in completion. Snippets lets us tell the editor where we want the cursor to move as the user tabs its way through the newly inserted text.
* Add snippet support
* Implement snippets for a few existing things like completion options, variant constructor arguments, etc
* Implement very basic completion for tuples, including with snippet support