### PR TITLE
Initial pattern completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add autocomplete for JSX prop values. https://github.com/rescript-lang/rescript-vscode/pull/667
 - Add snippet support in completion items. https://github.com/rescript-lang/rescript-vscode/pull/668
 - Add support from completing polyvariants as values. https://github.com/rescript-lang/rescript-vscode/pull/669
+- Add support for completion in patterns. https://github.com/rescript-lang/rescript-vscode/pull/670
 
 #### :nail_care: Polish
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1770,6 +1770,18 @@ let rec resolveNestedPattern typ ~env ~package ~nested =
       | Some {typ} -> typ |> resolveNestedPattern ~env ~package ~nested)
     | PRecordBody {seenFields}, Some (Trecord {env; typeExpr}) ->
       Some (typeExpr, env, Some (Completable.RecordField {seenFields}))
+    | ( PVariantPayload {constructorName; payloadNum},
+        Some (Tvariant {env; constructors}) ) -> (
+      match
+        constructors
+        |> List.find_opt (fun (c : Constructor.t) ->
+               c.cname.txt = constructorName)
+      with
+      | None -> None
+      | Some constructor -> (
+        match List.nth_opt constructor.args payloadNum with
+        | None -> None
+        | Some (typ, _) -> typ |> resolveNestedPattern ~env ~package ~nested))
     | _ -> None)
 
 let processCompletable ~debug ~full ~scope ~env ~pos ~forHover

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1568,7 +1568,7 @@ let printConstructorArgs argsLen ~asSnippet =
   else ""
 
 let completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
-    ~expandOption ~includeLocalValues =
+    ~expandOption ~includeLocalValues ~completionContext =
   let namesUsed = Hashtbl.create 10 in
   let rec completeTypedValueInner t ~env ~full ~prefix ~expandOption =
     let items =
@@ -1643,13 +1643,21 @@ let completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
             ~insertText:(printConstructorArgs numExprs ~asSnippet:true)
             ~kind:(Value typ) ~env ();
         ]
-      | Some (Trecord {env; fields; typeExpr}) ->
-        fields
-        |> List.map (fun (field : field) ->
-               Completion.create ~name:field.fname.txt
-                 ~kind:(Field (field, typeExpr |> Shared.typeToString))
-                 ~env)
-        |> filterItems ~prefix
+      | Some (Trecord {env; fields; typeExpr}) -> (
+        match completionContext with
+        | Some Completable.RecordField ->
+          fields
+          |> List.map (fun (field : field) ->
+                 Completion.create ~name:field.fname.txt
+                   ~kind:(Field (field, typeExpr |> Shared.typeToString))
+                   ~env)
+          |> filterItems ~prefix
+        | None ->
+          [
+            Completion.createWithSnippet ~name:"{}"
+              ~insertText:(if !Cfg.supportsSnippets then "{$0}" else "{}")
+              ~sortText:"a" ~kind:(Value typeExpr) ~env ();
+          ])
       | _ -> []
     in
     (* Include all values and modules in completion if there's a prefix, not otherwise *)
@@ -1740,20 +1748,22 @@ let getJsxLabels ~componentPath ~findTypeOfValue ~package =
 
 let rec resolveNestedPattern typ ~env ~package ~nested =
   match nested with
-  | [] -> Some (typ, env)
+  | [] -> Some (typ, env, None)
   | patternPath :: nested -> (
     match (patternPath, typ |> extractType ~env ~package) with
     | Completable.PTupleItem {itemNum}, Some (Tuple (env, tupleItems, _)) -> (
       match List.nth_opt tupleItems itemNum with
       | None -> None
       | Some typ -> typ |> resolveNestedPattern ~env ~package ~nested)
-    | Completable.PRecordField {fieldName}, Some (Trecord {env; fields}) -> (
+    | PFollowRecordField {fieldName}, Some (Trecord {env; fields}) -> (
       match
         fields
         |> List.find_opt (fun (field : field) -> field.fname.txt = fieldName)
       with
       | None -> None
       | Some {typ} -> typ |> resolveNestedPattern ~env ~package ~nested)
+    | PRecordBody _, Some (Trecord {env; typeExpr}) ->
+      Some (typeExpr, env, Some Completable.RecordField)
     | _ -> None)
 
 let processCompletable ~debug ~full ~scope ~env ~pos ~forHover
@@ -1819,7 +1829,7 @@ let processCompletable ~debug ~full ~scope ~env ~pos ~forHover
     | Some (_, typ, env) ->
       typ
       |> completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
-           ~expandOption:true ~includeLocalValues:true)
+           ~expandOption:true ~includeLocalValues:true ~completionContext:None)
   | Cdecorator prefix ->
     let mkDecorator (name, docstring) =
       {(Completion.create ~name ~kind:(Label "") ~env) with docstring}
@@ -2084,11 +2094,11 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
     | Some (Optional _, typ) ->
       typ
       |> completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
-           ~expandOption:true ~includeLocalValues:true
+           ~expandOption:true ~includeLocalValues:true ~completionContext:None
     | Some ((Unlabelled _ | Labelled _), typ) ->
       typ
       |> completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
-           ~expandOption:false ~includeLocalValues:true)
+           ~expandOption:false ~includeLocalValues:true ~completionContext:None)
   | CnamedArg (cp, prefix, identsSeen) ->
     let labels =
       match
@@ -2129,7 +2139,7 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
     | Some (typ, env) ->
       typ
       |> completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
-           ~expandOption:false ~includeLocalValues:false
+           ~expandOption:false ~includeLocalValues:false ~completionContext:None
     | None -> [])
   | Cpattern {typ; prefix; nested = Some nested} -> (
     let envWhereCompletionStarted = env in
@@ -2142,8 +2152,8 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
     | Some (typ, env) -> (
       match typ |> resolveNestedPattern ~env ~package:full.package ~nested with
       | None -> []
-      | Some (typ, env) ->
+      | Some (typ, env, completionContext) ->
         typ
         |> completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
-             ~expandOption:false ~includeLocalValues:false)
+             ~expandOption:false ~includeLocalValues:false ~completionContext)
     | None -> [])

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1778,7 +1778,7 @@ let rec resolveNestedPattern typ ~env ~package ~nested =
       | Some {typ} -> typ |> resolveNestedPattern ~env ~package ~nested)
     | PRecordBody {seenFields}, Some (Trecord {env; typeExpr}) ->
       Some (typeExpr, env, Some (Completable.RecordField {seenFields}))
-    | PVariantPayload {constructorName}, Some (Tvariant {env; constructors})
+    | PVariantPayload {constructorName; itemNum}, Some (Tvariant {env; constructors})
       -> (
       match
         constructors
@@ -1787,15 +1787,10 @@ let rec resolveNestedPattern typ ~env ~package ~nested =
       with
       | None -> None
       | Some constructor -> (
-        let payloadNum, nested =
-          match nested with
-          | PTupleItem {itemNum} :: nested -> (itemNum, nested)
-          | _ -> (0, nested)
-        in
-        match List.nth_opt constructor.args payloadNum with
+        match List.nth_opt constructor.args itemNum with
         | None -> None
         | Some (typ, _) -> typ |> resolveNestedPattern ~env ~package ~nested))
-    | ( PPolyvariantPayload {constructorName},
+    | ( PPolyvariantPayload {constructorName; itemNum},
         Some (Tpolyvariant {env; constructors}) ) -> (
       match
         constructors
@@ -1804,12 +1799,7 @@ let rec resolveNestedPattern typ ~env ~package ~nested =
       with
       | None -> None
       | Some constructor -> (
-        let payloadNum, nested =
-          match nested with
-          | PTupleItem {itemNum} :: nested -> (itemNum, nested)
-          | _ -> (0, nested)
-        in
-        match List.nth_opt constructor.args payloadNum with
+        match List.nth_opt constructor.args itemNum with
         | None -> None
         | Some typ -> typ |> resolveNestedPattern ~env ~package ~nested))
     | PArray, Some (Tarray (env, typ)) ->

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1644,6 +1644,9 @@ let completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
             ~kind:(Value typ) ~env ();
         ]
       | Some (Trecord {env; fields; typeExpr}) -> (
+        (* As we're completing for a record, we'll need a hint (completionContext)
+           here to figure out whether we should complete for a record field, or
+           the record body itself. *)
         match completionContext with
         | Some (Completable.RecordField {seenFields}) ->
           fields
@@ -1748,6 +1751,7 @@ let getJsxLabels ~componentPath ~findTypeOfValue ~package =
     typ |> getLabels
   | None -> []
 
+(** This moves through a pattern via a set of instructions, trying to resolve the type at the end of the pattern. *)
 let rec resolveNestedPattern typ ~env ~package ~nested =
   match nested with
   | [] -> Some (typ, env, None)

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1519,6 +1519,8 @@ let rec extractType ~env ~package (t : Types.type_expr) =
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> extractType ~env ~package t1
   | Tconstr (Path.Pident {name = "option"}, [payloadTypeExpr], _) ->
     Some (Completable.Toption (env, payloadTypeExpr))
+  | Tconstr (Path.Pident {name = "array"}, [payloadTypeExpr], _) ->
+    Some (Tarray (env, payloadTypeExpr))
   | Tconstr (Path.Pident {name = "bool"}, [], _) -> Some (Tbool env)
   | Tconstr (path, _, _) -> (
     match References.digConstructor ~env ~package path with
@@ -1663,6 +1665,12 @@ let completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
               ~insertText:(if !Cfg.supportsSnippets then "{$0}" else "{}")
               ~sortText:"a" ~kind:(Value typeExpr) ~env ();
           ])
+      | Some (Tarray (env, typeExpr)) ->
+        [
+          Completion.createWithSnippet ~name:"[]"
+            ~insertText:(if !Cfg.supportsSnippets then "[$0]" else "[]")
+            ~sortText:"a" ~kind:(Value typeExpr) ~env ();
+        ]
       | _ -> []
     in
     (* Include all values and modules in completion if there's a prefix, not otherwise *)
@@ -1794,6 +1802,8 @@ let rec resolveNestedPattern typ ~env ~package ~nested =
         match List.nth_opt constructor.args payloadNum with
         | None -> None
         | Some typ -> typ |> resolveNestedPattern ~env ~package ~nested))
+    | PArray, Some (Tarray (env, typ)) ->
+      typ |> resolveNestedPattern ~env ~package ~nested
     | _ -> None)
 
 let processCompletable ~debug ~full ~scope ~env ~pos ~forHover

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1778,8 +1778,11 @@ let rec resolveNestedPattern typ ~env ~package ~nested =
       | Some {typ} -> typ |> resolveNestedPattern ~env ~package ~nested)
     | PRecordBody {seenFields}, Some (Trecord {env; typeExpr}) ->
       Some (typeExpr, env, Some (Completable.RecordField {seenFields}))
-    | PVariantPayload {constructorName; itemNum}, Some (Tvariant {env; constructors})
-      -> (
+    | ( PVariantPayload {constructorName = "Some"; itemNum = 0},
+        Some (Toption (env, typ)) ) ->
+      typ |> resolveNestedPattern ~env ~package ~nested
+    | ( PVariantPayload {constructorName; itemNum},
+        Some (Tvariant {env; constructors}) ) -> (
       match
         constructors
         |> List.find_opt (fun (c : Constructor.t) ->

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -2171,7 +2171,7 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
            Utils.startsWith name prefix
            && (forHover || not (List.mem name identsSeen)))
     |> List.map mkLabel
-  | Cpattern {typ; prefix; nested = None} -> (
+  | Cpattern {typ; prefix; nested = []} -> (
     let envWhereCompletionStarted = env in
     match
       typ
@@ -2184,7 +2184,7 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
       |> completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
            ~expandOption:false ~includeLocalValues:false ~completionContext:None
     | None -> [])
-  | Cpattern {typ; prefix; nested = Some nested} -> (
+  | Cpattern {typ; prefix; nested} -> (
     let envWhereCompletionStarted = env in
     match
       typ

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -2171,27 +2171,14 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
            Utils.startsWith name prefix
            && (forHover || not (List.mem name identsSeen)))
     |> List.map mkLabel
-  | Cpattern {typ; prefix; nested = []; fallback} -> (
-    let envWhereCompletionStarted = env in
-    match
-      typ
-      |> getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
-           ~exact:true ~scope
-      |> completionsGetTypeEnv
-    with
-    | Some (typ, env) -> (
-      let items =
-        typ
-        |> completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
-             ~expandOption:false ~includeLocalValues:false
-             ~completionContext:None
-      in
-      match (items, fallback) with
-      | [], Some fallback ->
-        fallback |> processCompletable ~debug ~full ~scope ~env ~pos ~forHover
-      | items, _ -> items)
-    | None -> [])
   | Cpattern {typ; prefix; nested; fallback} -> (
+    let fallbackOrEmpty ?items () =
+      match (fallback, items) with
+      | Some fallback, (None | Some []) ->
+        fallback |> processCompletable ~debug ~full ~scope ~env ~pos ~forHover
+      | _, Some items -> items
+      | None, None -> []
+    in
     let envWhereCompletionStarted = env in
     match
       typ
@@ -2201,15 +2188,12 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
     with
     | Some (typ, env) -> (
       match typ |> resolveNestedPattern ~env ~package:full.package ~nested with
-      | None -> []
-      | Some (typ, env, completionContext) -> (
+      | None -> fallbackOrEmpty ()
+      | Some (typ, env, completionContext) ->
         let items =
           typ
           |> completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
                ~expandOption:false ~includeLocalValues:false ~completionContext
         in
-        match (items, fallback) with
-        | [], Some fallback ->
-          fallback |> processCompletable ~debug ~full ~scope ~env ~pos ~forHover
-        | items, _ -> items))
-    | None -> [])
+        fallbackOrEmpty ~items ())
+    | None -> fallbackOrEmpty ())

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1782,6 +1782,18 @@ let rec resolveNestedPattern typ ~env ~package ~nested =
         match List.nth_opt constructor.args payloadNum with
         | None -> None
         | Some (typ, _) -> typ |> resolveNestedPattern ~env ~package ~nested))
+    | ( PPolyvariantPayload {constructorName; payloadNum},
+        Some (Tpolyvariant {env; constructors}) ) -> (
+      match
+        constructors
+        |> List.find_opt (fun (c : polyVariantConstructor) ->
+               c.name = constructorName)
+      with
+      | None -> None
+      | Some constructor -> (
+        match List.nth_opt constructor.args payloadNum with
+        | None -> None
+        | Some typ -> typ |> resolveNestedPattern ~env ~package ~nested))
     | _ -> None)
 
 let processCompletable ~debug ~full ~scope ~env ~pos ~forHover

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1645,8 +1645,10 @@ let completeTypedValue ~env ~envWhereCompletionStarted ~full ~prefix
         ]
       | Some (Trecord {env; fields; typeExpr}) -> (
         match completionContext with
-        | Some Completable.RecordField ->
+        | Some (Completable.RecordField {seenFields}) ->
           fields
+          |> List.filter (fun (field : field) ->
+                 List.mem field.fname.txt seenFields = false)
           |> List.map (fun (field : field) ->
                  Completion.create ~name:field.fname.txt
                    ~kind:(Field (field, typeExpr |> Shared.typeToString))
@@ -1762,8 +1764,8 @@ let rec resolveNestedPattern typ ~env ~package ~nested =
       with
       | None -> None
       | Some {typ} -> typ |> resolveNestedPattern ~env ~package ~nested)
-    | PRecordBody _, Some (Trecord {env; typeExpr}) ->
-      Some (typeExpr, env, Some Completable.RecordField)
+    | PRecordBody {seenFields}, Some (Trecord {env; typeExpr}) ->
+      Some (typeExpr, env, Some (Completable.RecordField {seenFields}))
     | _ -> None)
 
 let processCompletable ~debug ~full ~scope ~env ~pos ~forHover

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -435,7 +435,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
     match !lookingForPat with
     | Some (Completable.Cpattern ({nested = None} as p)) ->
       lookingForPat := Some (Cpattern {p with nested = Some [patternPat]})
-    | Some (Completable.Cpattern ({nested = Some nested} as p)) ->
+    | Some (Cpattern ({nested = Some nested} as p)) ->
       lookingForPat :=
         Some (Cpattern {p with nested = Some (nested @ [patternPat])})
     | _ -> ()
@@ -451,7 +451,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       setResult cpattern
     | _ -> ()
   in
-
+  (* Identifies expressions where we can do typed pattern or expr completion. *)
   let typedCompletionExpr (exp : Parsetree.expression) =
     if
       exp.pexp_loc
@@ -485,7 +485,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         | Some ctxPath -> setLookingForPat ctxPath)
       | _ -> unsetLookingForPat
   in
-
+  (* Tracks the path through a pattern for where the cursor is. *)
   let typedCompletionPat (pat : Parsetree.pattern) =
     if
       pat.ppat_loc
@@ -495,7 +495,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       match pat.ppat_desc with
       | Ppat_var {txt} -> commitFoundPat ~prefix:txt ()
       | Ppat_tuple patterns -> (
-        let patCount = ref (-1) in
+        let patCount = ref None in
         let patCountWithPatHole = ref None in
         patterns
         |> List.iteri (fun index p ->
@@ -503,13 +503,13 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
                  p.Parsetree.ppat_loc
                  |> CursorPosition.classifyLoc ~pos:posBeforeCursor
                with
-               | HasCursor -> patCount := index
+               | HasCursor -> patCount := Some index
                | EmptyLoc -> patCountWithPatHole := Some index
                | _ -> ());
         match (!patCount, !patCountWithPatHole) with
-        | patCount, _ when patCount > -1 ->
+        | Some patCount, _ ->
           appendNestedPat (Completable.PTupleItem {itemNum = patCount})
-        | _, Some patHoleCount ->
+        | None, Some patHoleCount ->
           appendNestedPat (Completable.PTupleItem {itemNum = patHoleCount})
         | _ -> ())
       | Ppat_record ([], _) ->

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -548,17 +548,6 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
               {constructorName = getUnqualifiedName txt; itemNum = 1};
           ]
           @ patternPath )
-    | Ppat_construct ({txt}, Some pat)
-      when locHasCursor pat.ppat_loc && isPatternTuple pat = false ->
-      (* Single payload *)
-      pat
-      |> traversePattern
-           ~patternPath:
-             ([
-                Completable.PVariantPayload
-                  {constructorName = getUnqualifiedName txt; itemNum = 0};
-              ]
-             @ patternPath)
     | Ppat_construct ({txt}, Some {ppat_loc; ppat_desc = Ppat_tuple tupleItems})
       when locHasCursor ppat_loc ->
       tupleItems
@@ -577,6 +566,15 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
                    itemNum = itemNum + 1;
                  };
              ]
+             @ patternPath)
+    | Ppat_construct ({txt}, Some p) when locHasCursor pat.ppat_loc ->
+      p
+      |> traversePattern
+           ~patternPath:
+             ([
+                Completable.PVariantPayload
+                  {constructorName = getUnqualifiedName txt; itemNum = 0};
+              ]
              @ patternPath)
     | Ppat_variant
         ( txt,
@@ -597,17 +595,6 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         ( "",
           [Completable.PPolyvariantPayload {constructorName = txt; itemNum = 1}]
           @ patternPath )
-    | Ppat_variant (txt, Some pat)
-      when locHasCursor pat.ppat_loc && isPatternTuple pat = false ->
-      (* Single payload *)
-      pat
-      |> traversePattern
-           ~patternPath:
-             ([
-                Completable.PPolyvariantPayload
-                  {constructorName = txt; itemNum = 0};
-              ]
-             @ patternPath)
     | Ppat_variant (txt, Some {ppat_loc; ppat_desc = Ppat_tuple tupleItems})
       when locHasCursor ppat_loc ->
       tupleItems
@@ -620,6 +607,15 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
                Completable.PPolyvariantPayload
                  {constructorName = txt; itemNum = itemNum + 1};
              ]
+             @ patternPath)
+    | Ppat_variant (txt, Some p) when locHasCursor pat.ppat_loc ->
+      p
+      |> traversePattern
+           ~patternPath:
+             ([
+                Completable.PPolyvariantPayload
+                  {constructorName = txt; itemNum = 0};
+              ]
              @ patternPath)
     | _ -> None
   in

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -516,6 +516,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       | Ppat_var {txt} -> commitFoundPat ~prefix:txt ()
       | Ppat_construct ({txt = Lident prefix}, None) ->
         commitFoundPat ~prefix ()
+      | Ppat_variant (prefix, None) -> commitFoundPat ~prefix:("#" ^ prefix) ()
       | Ppat_tuple patterns -> (
         match patterns |> findPatTupleItemWithCursor ~pos:posBeforeCursor with
         | Some itemNum -> appendNestedPat (Completable.PTupleItem {itemNum})
@@ -611,6 +612,45 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
           appendNestedPat
             (Completable.PVariantPayload
                {constructorName = getUnqualifiedName txt; payloadNum}))
+      | Ppat_variant
+          ( txt,
+            Some {ppat_loc; ppat_desc = Ppat_construct ({txt = Lident "()"}, _)}
+          )
+        when ppat_loc
+             |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+             = HasCursor ->
+        (* Empty payload *)
+        appendNestedPat
+          (Completable.PPolyvariantPayload
+             {constructorName = txt; payloadNum = 0});
+        commitFoundPat ~prefix:"" ()
+      | Ppat_variant
+          ( txt,
+            Some
+              {
+                ppat_loc;
+                ppat_desc =
+                  Ppat_var _ | Ppat_record _ | Ppat_construct _ | Ppat_variant _;
+              } )
+        when ppat_loc
+             |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+             = HasCursor ->
+        (* Single payload *)
+        appendNestedPat
+          (Completable.PPolyvariantPayload
+             {constructorName = txt; payloadNum = 0})
+      | Ppat_variant (txt, Some {ppat_loc; ppat_desc = Ppat_tuple tupleItems})
+        when ppat_loc
+             |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+             = HasCursor -> (
+        (* Multiple payloads with cursor in item *)
+        (* TODO: New item with comma *)
+        match tupleItems |> findPatTupleItemWithCursor ~pos:posBeforeCursor with
+        | None -> ()
+        | Some payloadNum ->
+          appendNestedPat
+            (Completable.PPolyvariantPayload {constructorName = txt; payloadNum})
+        )
       | _ -> ()
   in
   let case (iterator : Ast_iterator.iterator) (case : Parsetree.case) =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -517,6 +517,9 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       | Ppat_construct ({txt = Lident prefix}, None) ->
         commitFoundPat ~prefix ()
       | Ppat_variant (prefix, None) -> commitFoundPat ~prefix:("#" ^ prefix) ()
+      | Ppat_array arrayPatterns ->
+        appendNestedPat Completable.PArray;
+        if List.length arrayPatterns = 0 then commitFoundPat ~prefix:"" ()
       | Ppat_tuple patterns -> (
         match patterns |> findPatTupleItemWithCursor ~pos:posBeforeCursor with
         | Some itemNum -> appendNestedPat (Completable.PTupleItem {itemNum})

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -264,6 +264,12 @@ let rec exprToContextPath (e : Parsetree.expression) =
     | Some contexPath -> Some (CPApply (contexPath, args |> List.map fst)))
   | _ -> None
 
+let rec getUnqualifiedName txt =
+  match txt with
+  | Longident.Lident fieldName -> fieldName
+  | Ldot (t, _) -> getUnqualifiedName t
+  | _ -> ""
+
 let completePipeChain ~(lhs : Parsetree.expression) =
   (* Complete the end of pipe chains by reconstructing the pipe chain as a single pipe,
      so it can be completed.
@@ -304,6 +310,20 @@ let completePipeChain ~(lhs : Parsetree.expression) =
         pexp_attributes;
       }
     |> Option.map (fun ctxPath -> (ctxPath, pexp_loc))
+  | _ -> None
+
+let findPatTupleItemWithCursor patterns ~pos =
+  let patCount = ref None in
+  let patCountWithPatHole = ref None in
+  patterns
+  |> List.iteri (fun index p ->
+         match p.Parsetree.ppat_loc |> CursorPosition.classifyLoc ~pos with
+         | HasCursor -> patCount := Some index
+         | EmptyLoc -> patCountWithPatHole := Some index
+         | _ -> ());
+  match (!patCount, !patCountWithPatHole) with
+  | Some patCount, _ -> Some patCount
+  | None, Some patHoleCount -> Some patHoleCount
   | _ -> None
 
 let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
@@ -494,23 +514,11 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
     then
       match pat.ppat_desc with
       | Ppat_var {txt} -> commitFoundPat ~prefix:txt ()
+      | Ppat_construct ({txt = Lident prefix}, None) ->
+        commitFoundPat ~prefix ()
       | Ppat_tuple patterns -> (
-        let patCount = ref None in
-        let patCountWithPatHole = ref None in
-        patterns
-        |> List.iteri (fun index p ->
-               match
-                 p.Parsetree.ppat_loc
-                 |> CursorPosition.classifyLoc ~pos:posBeforeCursor
-               with
-               | HasCursor -> patCount := Some index
-               | EmptyLoc -> patCountWithPatHole := Some index
-               | _ -> ());
-        match (!patCount, !patCountWithPatHole) with
-        | Some patCount, _ ->
-          appendNestedPat (Completable.PTupleItem {itemNum = patCount})
-        | None, Some patHoleCount ->
-          appendNestedPat (Completable.PTupleItem {itemNum = patHoleCount})
+        match patterns |> findPatTupleItemWithCursor ~pos:posBeforeCursor with
+        | Some itemNum -> appendNestedPat (Completable.PTupleItem {itemNum})
         | _ -> ())
       | Ppat_record ([], _) ->
         (* Empty fields means we're in a record body `{}`. Complete for the fields. *)
@@ -563,6 +571,46 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
             appendNestedPat (Completable.PRecordBody {seenFields});
             commitFoundPat ~prefix:"" ()
           | _ -> ()))
+      | Ppat_construct
+          ( {txt},
+            Some {ppat_loc; ppat_desc = Ppat_construct ({txt = Lident "()"}, _)}
+          )
+        when ppat_loc
+             |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+             = HasCursor ->
+        (* Empty payload *)
+        appendNestedPat
+          (Completable.PVariantPayload
+             {constructorName = getUnqualifiedName txt; payloadNum = 0});
+        commitFoundPat ~prefix:"" ()
+      | Ppat_construct
+          ( {txt},
+            Some
+              {
+                ppat_loc;
+                ppat_desc =
+                  Ppat_var _ | Ppat_record _ | Ppat_construct _ | Ppat_variant _;
+              } )
+        when ppat_loc
+             |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+             = HasCursor ->
+        (* Single payload *)
+        appendNestedPat
+          (Completable.PVariantPayload
+             {constructorName = getUnqualifiedName txt; payloadNum = 0})
+      | Ppat_construct
+          ({txt}, Some {ppat_loc; ppat_desc = Ppat_tuple tupleItems})
+        when ppat_loc
+             |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+             = HasCursor -> (
+        (* Multiple payloads with cursor in item *)
+        (* TODO: New item with comma *)
+        match tupleItems |> findPatTupleItemWithCursor ~pos:posBeforeCursor with
+        | None -> ()
+        | Some payloadNum ->
+          appendNestedPat
+            (Completable.PVariantPayload
+               {constructorName = getUnqualifiedName txt; payloadNum}))
       | _ -> ()
   in
   let case (iterator : Ast_iterator.iterator) (case : Parsetree.case) =
@@ -958,12 +1006,19 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
   let pat (iterator : Ast_iterator.iterator) (pat : Parsetree.pattern) =
     if pat.ppat_loc |> Loc.hasPos ~pos:posNoWhite then (
       found := true;
+      let oldLookingForPat = !lookingForPat in
+      typedCompletionPat pat;
       if debug then
         Printf.printf "posCursor:[%s] posNoWhite:[%s] Found pattern:%s\n"
           (Pos.toString posCursor) (Pos.toString posNoWhite)
           (Loc.toString pat.ppat_loc);
-      (match pat.ppat_desc with
-      | Ppat_construct (lid, _) ->
+      (* TODO:
+          This change breaks old behavior of completing constructors in scope.
+          Either be fine with it, fix it somehow, or incorporate completing
+          constructors in scope when regular completion for variants can't
+          be done. *)
+      (match (!lookingForPat, pat.ppat_desc) with
+      | None, Ppat_construct (lid, _) ->
         let lidPath = flattenLidCheckDot lid in
         if debug then
           Printf.printf "Ppat_construct %s:%s\n"
@@ -971,8 +1026,6 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
             (Loc.toString lid.loc);
         setResult (Cpath (CPId (lidPath, Value)))
       | _ -> ());
-      let oldLookingForPat = !lookingForPat in
-      typedCompletionPat pat;
       Ast_iterator.default_iterator.pat iterator pat;
       lookingForPat := oldLookingForPat)
   in

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -441,6 +441,9 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       | Ppat_or (p1, p2) ->
         [p1; p2] |> List.find_map (fun p -> p |> traversePattern ~patternPath)
       | Ppat_var {txt} -> Some (txt, patternPath)
+      | Ppat_construct ({txt = Lident "()"}, None) ->
+        (* switch s { | (<com>) }*)
+        Some ("", patternPath @ [Completable.PTupleItem {itemNum = 0}])
       | Ppat_construct ({txt = Lident prefix}, None) ->
         Some (prefix, patternPath)
       | Ppat_variant (prefix, None) -> Some ("#" ^ prefix, patternPath)
@@ -451,16 +454,31 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
           arrayPatterns
           |> List.find_map (fun pat ->
                  pat |> traversePattern ~patternPath:nextPatternPath)
-      | Ppat_tuple patterns ->
+      | Ppat_tuple tupleItems -> (
         let itemNum = ref (-1) in
-        patterns
-        |> List.find_map (fun pat ->
-               itemNum := !itemNum + 1;
-               pat
-               |> traversePattern
-                    ~patternPath:
-                      ([Completable.PTupleItem {itemNum = !itemNum}]
-                      @ patternPath))
+        let itemWithCursor =
+          tupleItems
+          |> List.find_map (fun pat ->
+                 itemNum := !itemNum + 1;
+                 pat
+                 |> traversePattern
+                      ~patternPath:
+                        ([Completable.PTupleItem {itemNum = !itemNum}]
+                        @ patternPath))
+        in
+        match (itemWithCursor, firstCharBeforeCursorNoWhite) with
+        | None, Some ',' -> (
+          (* No tuple item has the cursor, but there's a comma before the cursor.
+             Figure out what arg we're trying to complete. Example: #test(true, <com>, None) *)
+          let locs = tupleItems |> List.map (fun p -> p.Parsetree.ppat_loc) in
+          match locs |> lastLocIndexBeforePos ~pos:posBeforeCursor with
+          | None -> None
+          | Some itemNum ->
+            Some
+              ( "",
+                [Completable.PTupleItem {itemNum = itemNum + 1}] @ patternPath
+              ))
+        | v, _ -> v)
       | Ppat_record ([], _) ->
         (* Empty fields means we're in a record body `{}`. Complete for the fields. *)
         Some ("", [Completable.PRecordBody {seenFields = []}] @ patternPath)

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -430,7 +430,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
     if debug then
       Printf.printf "looking for: %s \n" (Completable.toString (Cpath ctxPath))
   in
-  let unsetLookingForPat = lookingForPat := None in
+  let unsetLookingForPat () = lookingForPat := None in
   let appendNestedPat patternPat =
     match !lookingForPat with
     | Some (Completable.Cpattern ({nested = None} as p)) ->
@@ -483,7 +483,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         match exp |> exprToContextPath with
         | None -> ()
         | Some ctxPath -> setLookingForPat ctxPath)
-      | _ -> unsetLookingForPat
+      | _ -> unsetLookingForPat ()
   in
   (* Tracks the path through a pattern for where the cursor is. *)
   let typedCompletionPat (pat : Parsetree.pattern) =
@@ -579,7 +579,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
   in
   let structure_item (iterator : Ast_iterator.iterator)
       (item : Parsetree.structure_item) =
-    unsetLookingForPat;
+    unsetLookingForPat ();
     let processed = ref false in
     (match item.pstr_desc with
     | Pstr_open {popen_lid} ->

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -718,26 +718,28 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         match exp |> exprToContextPath with
         | None -> ()
         | Some ctxPath -> (
-          let caseWithCursor =
+          let hasCaseWithCursor =
             cases
             |> List.find_opt (fun case ->
                    case.Parsetree.pc_lhs.ppat_loc
                    |> CursorPosition.classifyLoc ~pos:posBeforeCursor
                    = HasCursor)
+            |> Option.is_some
           in
-          let caseWithPatHole =
+          let hasCaseWithPatHole =
             cases
             |> List.find_opt (fun case -> isPatternHole case.Parsetree.pc_lhs)
+            |> Option.is_some
           in
-          match (caseWithPatHole, caseWithCursor) with
-          | _, Some _ ->
+          match (hasCaseWithPatHole, hasCaseWithCursor) with
+          | _, true ->
             (* Always continue if there's a case with the cursor *)
             setLookingForPat ctxPath
-          | Some _, None ->
+          | true, false ->
             (* If there's no case with the cursor, but a broken parser case, complete for the top level. *)
             setResult
               (Completable.Cpattern {typ = ctxPath; nested = []; prefix = ""})
-          | None, None -> ()))
+          | false, false -> ()))
       | _ -> unsetLookingForPat ()
   in
 

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -423,15 +423,14 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
     scope :=
       !scope |> Scope.addModule ~name:md.pmd_name.txt ~loc:md.pmd_name.loc
   in
-
   let lookingForPat = ref None in
-
   let setLookingForPat ctxPath =
     lookingForPat :=
       Some (Completable.Cpattern {typ = ctxPath; prefix = ""; nested = None});
     if debug then
       Printf.printf "looking for: %s \n" (Completable.toString (Cpath ctxPath))
   in
+  let unsetLookingForPat = lookingForPat := None in
   let appendNestedPat patternPat =
     match !lookingForPat with
     | Some (Completable.Cpattern ({nested = None} as p)) ->
@@ -484,7 +483,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         match exp |> exprToContextPath with
         | None -> ()
         | Some ctxPath -> setLookingForPat ctxPath)
-      | _ -> ()
+      | _ -> unsetLookingForPat
   in
 
   let typedCompletionPat (pat : Parsetree.pattern) =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -323,20 +323,6 @@ let completePipeChain ~(lhs : Parsetree.expression) =
     |> Option.map (fun ctxPath -> (ctxPath, pexp_loc))
   | _ -> None
 
-let findPatTupleItemWithCursor patterns ~pos =
-  let patCount = ref None in
-  let patCountWithPatHole = ref None in
-  patterns
-  |> List.iteri (fun index p ->
-         match p.Parsetree.ppat_loc |> CursorPosition.classifyLoc ~pos with
-         | HasCursor -> patCount := Some index
-         | EmptyLoc -> patCountWithPatHole := Some index
-         | _ -> ());
-  match (!patCount, !patCountWithPatHole) with
-  | Some patCount, _ -> Some patCount
-  | None, Some patHoleCount -> Some patHoleCount
-  | _ -> None
-
 let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
   let offsetNoWhite = skipWhite text (offset - 1) in
   let posNoWhite =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -420,7 +420,8 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
   let setLookingForPat ctxPath =
     lookingForPat :=
       Some (Completable.Cpattern {typ = ctxPath; prefix = ""; nested = None});
-    Printf.printf "looking for: %s \n" (Completable.toString (Cpath ctxPath))
+    if debug then
+      Printf.printf "looking for: %s \n" (Completable.toString (Cpath ctxPath))
   in
   let appendNestedPat patternPat =
     match !lookingForPat with
@@ -443,7 +444,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
     | _ -> ()
   in
 
-  let rec typedCompletionExpr (exp : Parsetree.expression) =
+  let typedCompletionExpr (exp : Parsetree.expression) =
     if
       exp.pexp_loc
       |> CursorPosition.classifyLoc ~pos:posBeforeCursor
@@ -477,7 +478,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       | _ -> ()
   in
 
-  let rec typedCompletionPat (pat : Parsetree.pattern) =
+  let typedCompletionPat (pat : Parsetree.pattern) =
     if
       pat.ppat_loc
       |> CursorPosition.classifyLoc ~pos:posBeforeCursor
@@ -502,6 +503,35 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
           appendNestedPat (Completable.PTupleItem {itemNum = patCount})
         | _, Some patHoleCount ->
           appendNestedPat (Completable.PTupleItem {itemNum = patHoleCount})
+        | _ -> ())
+      | Ppat_record ([], _) -> commitFoundPat ~prefix:"" ()
+      | Ppat_record (fields, _) -> (
+        let fieldWithCursor = ref None in
+        let fieldWithPatHole = ref None in
+        fields
+        |> List.filter (fun (_, f) ->
+               (* Ensure we only include fields with patterns we can continue into. *)
+               match f.Parsetree.ppat_desc with
+               | Ppat_tuple _ | Ppat_construct _ | Ppat_variant _
+               | Ppat_record _ ->
+                 true
+               | _ -> false)
+        |> List.iter (fun (fname, f) ->
+               match
+                 ( fname.Location.txt,
+                   f.Parsetree.ppat_loc
+                   |> CursorPosition.classifyLoc ~pos:posBeforeCursor )
+               with
+               | Longident.Lident fname, HasCursor ->
+                 fieldWithCursor := Some fname
+               | Lident fname, EmptyLoc when isPatternHole f ->
+                 fieldWithPatHole := Some fname
+               | _ -> ());
+        match (!fieldWithCursor, !fieldWithPatHole) with
+        | Some fname, _ ->
+          appendNestedPat (Completable.PRecordField {fieldName = fname})
+        | None, Some fname ->
+          appendNestedPat (Completable.PRecordField {fieldName = fname})
         | _ -> ())
       | _ -> ()
   in

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -641,11 +641,10 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
   in
   let completePattern (pat : Parsetree.pattern) =
     match (pat |> traversePattern ~patternPath:[], !lookingForPat) with
-    | Some (prefix, []), Some (Completable.Cpattern p) ->
-      setResult (Completable.Cpattern {p with prefix; nested = None})
-    | Some (prefix, nestedPattern), Some (Cpattern p) ->
+    | Some (prefix, nestedPattern), Some ctxPath ->
       setResult
-        (Cpattern {p with prefix; nested = Some (List.rev nestedPattern)})
+        (Completable.Cpattern
+           {typ = ctxPath; prefix; nested = List.rev nestedPattern})
     | _ -> ()
   in
   let scopeValueBinding (vb : Parsetree.value_binding) =
@@ -681,8 +680,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       !scope |> Scope.addModule ~name:md.pmd_name.txt ~loc:md.pmd_name.loc
   in
   let setLookingForPat ctxPath =
-    lookingForPat :=
-      Some (Completable.Cpattern {typ = ctxPath; prefix = ""; nested = None});
+    lookingForPat := Some ctxPath;
     if debug then
       Printf.printf "looking for: %s \n" (Completable.toString (Cpath ctxPath))
   in
@@ -713,7 +711,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         | None -> ()
         | Some ctxPath ->
           setResult
-            (Completable.Cpattern {typ = ctxPath; nested = None; prefix = ""}))
+            (Completable.Cpattern {typ = ctxPath; nested = []; prefix = ""}))
       | Pexp_match (exp, _cases) -> (
         (* If there's more than one case, or the case isn't a pattern hole, set that we're looking for this path currently. *)
         match exp |> exprToContextPath with

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -664,11 +664,8 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
     scope :=
       !scope |> Scope.addModule ~name:md.pmd_name.txt ~loc:md.pmd_name.loc
   in
-  let setLookingForPat ctxPath =
-    lookingForPat := Some ctxPath;
-    if debug then
-      Printf.printf "looking for: %s \n" (Completable.toString (Cpath ctxPath))
-  in
+  let setLookingForPat ctxPath = lookingForPat := Some ctxPath in
+
   let unsetLookingForPat () = lookingForPat := None in
   (* Identifies expressions where we can do typed pattern or expr completion. *)
   let typedCompletionExpr (exp : Parsetree.expression) =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -585,7 +585,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         (* Empty payload *)
         appendNestedPat
           (Completable.PVariantPayload
-             {constructorName = getUnqualifiedName txt; payloadNum = 0});
+             {constructorName = getUnqualifiedName txt});
         commitFoundPat ~prefix:"" ()
       | Ppat_construct
           ( {txt},
@@ -601,7 +601,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         (* Single payload *)
         appendNestedPat
           (Completable.PVariantPayload
-             {constructorName = getUnqualifiedName txt; payloadNum = 0})
+             {constructorName = getUnqualifiedName txt})
       | Ppat_construct
           ({txt}, Some {ppat_loc; ppat_desc = Ppat_tuple tupleItems})
         when ppat_loc
@@ -611,10 +611,10 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         (* TODO: New item with comma *)
         match tupleItems |> findPatTupleItemWithCursor ~pos:posBeforeCursor with
         | None -> ()
-        | Some payloadNum ->
+        | Some _ ->
           appendNestedPat
             (Completable.PVariantPayload
-               {constructorName = getUnqualifiedName txt; payloadNum}))
+               {constructorName = getUnqualifiedName txt}))
       | Ppat_variant
           ( txt,
             Some {ppat_loc; ppat_desc = Ppat_construct ({txt = Lident "()"}, _)}
@@ -624,8 +624,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
              = HasCursor ->
         (* Empty payload *)
         appendNestedPat
-          (Completable.PPolyvariantPayload
-             {constructorName = txt; payloadNum = 0});
+          (Completable.PPolyvariantPayload {constructorName = txt});
         commitFoundPat ~prefix:"" ()
       | Ppat_variant
           ( txt,
@@ -640,8 +639,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
              = HasCursor ->
         (* Single payload *)
         appendNestedPat
-          (Completable.PPolyvariantPayload
-             {constructorName = txt; payloadNum = 0})
+          (Completable.PPolyvariantPayload {constructorName = txt})
       | Ppat_variant (txt, Some {ppat_loc; ppat_desc = Ppat_tuple tupleItems})
         when ppat_loc
              |> CursorPosition.classifyLoc ~pos:posBeforeCursor
@@ -650,10 +648,9 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         (* TODO: New item with comma *)
         match tupleItems |> findPatTupleItemWithCursor ~pos:posBeforeCursor with
         | None -> ()
-        | Some payloadNum ->
+        | Some _ ->
           appendNestedPat
-            (Completable.PPolyvariantPayload {constructorName = txt; payloadNum})
-        )
+            (Completable.PPolyvariantPayload {constructorName = txt}))
       | _ -> ()
   in
   let case (iterator : Ast_iterator.iterator) (case : Parsetree.case) =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -20,6 +20,11 @@ let isExprHole exp =
   | Pexp_extension ({txt = "rescript.exprhole"}, _) -> true
   | _ -> false
 
+let isPatternHole pat =
+  match pat.Parsetree.ppat_desc with
+  | Ppat_extension ({txt = "rescript.patternhole"}, _) -> true
+  | _ -> false
+
 type prop = {
   name: string;
   posStart: int * int;
@@ -410,6 +415,96 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       !scope |> Scope.addModule ~name:md.pmd_name.txt ~loc:md.pmd_name.loc
   in
 
+  let lookingForPat = ref None in
+
+  let setLookingForPat ctxPath =
+    lookingForPat :=
+      Some (Completable.Cpattern {typ = ctxPath; prefix = ""; nested = None});
+    Printf.printf "looking for: %s \n" (Completable.toString (Cpath ctxPath))
+  in
+  let appendNestedPat patternPat =
+    match !lookingForPat with
+    | Some (Completable.Cpattern ({nested = None} as p)) ->
+      lookingForPat := Some (Cpattern {p with nested = Some [patternPat]})
+    | Some (Completable.Cpattern ({nested = Some nested} as p)) ->
+      lookingForPat :=
+        Some (Cpattern {p with nested = Some (nested @ [patternPat])})
+    | _ -> ()
+  in
+  let commitFoundPat ?prefix () =
+    match !lookingForPat with
+    | Some (Completable.Cpattern p as cpattern) ->
+      let cpattern =
+        match prefix with
+        | None -> cpattern
+        | Some prefix -> Cpattern {p with prefix}
+      in
+      setResult cpattern
+    | _ -> ()
+  in
+
+  let rec typedCompletionExpr (exp : Parsetree.expression) =
+    if
+      exp.pexp_loc
+      |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+      = HasCursor
+    then
+      match exp.pexp_desc with
+      | Pexp_match (_exp, []) ->
+        (* No cases means there's no `|` yet in the switch *) ()
+      | Pexp_match
+          ( exp,
+            [
+              {
+                pc_lhs =
+                  {
+                    ppat_desc =
+                      Ppat_extension ({txt = "rescript.patternhole"}, _);
+                  };
+              };
+            ] ) -> (
+        (* A single case that's a pattern hole typically means `switch x { | }`. Complete as the pattern itself with nothing nested. *)
+        match exprToContextPath exp with
+        | None -> ()
+        | Some ctxPath ->
+          setResult
+            (Completable.Cpattern {typ = ctxPath; nested = None; prefix = ""}))
+      | Pexp_match (exp, _cases) -> (
+        (* If there's more than one case, or the case isn't a pattern hole, set that we're looking for this path currently. *)
+        match exp |> exprToContextPath with
+        | None -> ()
+        | Some ctxPath -> setLookingForPat ctxPath)
+      | _ -> ()
+  in
+
+  let rec typedCompletionPat (pat : Parsetree.pattern) =
+    if
+      pat.ppat_loc
+      |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+      = HasCursor
+    then
+      match pat.ppat_desc with
+      | Ppat_var {txt} -> commitFoundPat ~prefix:txt ()
+      | Ppat_tuple patterns -> (
+        let patCount = ref (-1) in
+        let patCountWithPatHole = ref None in
+        patterns
+        |> List.iteri (fun index p ->
+               match
+                 p.Parsetree.ppat_loc
+                 |> CursorPosition.classifyLoc ~pos:posBeforeCursor
+               with
+               | HasCursor -> patCount := index
+               | EmptyLoc -> patCountWithPatHole := Some index
+               | _ -> ());
+        match (!patCount, !patCountWithPatHole) with
+        | patCount, _ when patCount > -1 ->
+          appendNestedPat (Completable.PTupleItem {itemNum = patCount})
+        | _, Some patHoleCount ->
+          appendNestedPat (Completable.PTupleItem {itemNum = patHoleCount})
+        | _ -> ())
+      | _ -> ()
+  in
   let case (iterator : Ast_iterator.iterator) (case : Parsetree.case) =
     let oldScope = !scope in
     scopePattern case.pc_lhs;
@@ -548,6 +643,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
         setResult (Cpath (CPPipe {contextPath = pipe; id; lhsLoc}));
         true
     in
+    typedCompletionExpr expr;
     match expr.pexp_desc with
     | Pexp_apply
         ( {pexp_desc = Pexp_ident {txt = Lident "|."; loc = opLoc}},
@@ -807,7 +903,10 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
             (Loc.toString lid.loc);
         setResult (Cpath (CPId (lidPath, Value)))
       | _ -> ());
-      Ast_iterator.default_iterator.pat iterator pat)
+      let oldLookingForPat = !lookingForPat in
+      typedCompletionPat pat;
+      Ast_iterator.default_iterator.pat iterator pat;
+      lookingForPat := oldLookingForPat)
   in
   let module_expr (iterator : Ast_iterator.iterator)
       (me : Parsetree.module_expr) =

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -312,6 +312,15 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
     let line, col = posCursor in
     (line, max 0 col - offset + offsetNoWhite)
   in
+  (* Identifies the first character before the cursor that's not white space.
+     Should be used very sparingly, but can be used to drive completion triggering
+     in scenarios where the parser eats things we'd need to complete.
+     Example: let {whatever,     <cursor>}, char is ','. *)
+  let firstCharBeforeCursorNoWhite =
+    if offsetNoWhite < String.length text && offsetNoWhite >= 0 then
+      Some text.[offsetNoWhite]
+    else None
+  in
   let posBeforeCursor = Pos.posBeforeCursor posCursor in
   let charBeforeCursor, blankAfterCursor =
     match Pos.positionToOffset text posCursor with
@@ -505,10 +514,10 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
           appendNestedPat (Completable.PTupleItem {itemNum = patHoleCount})
         | _ -> ())
       | Ppat_record ([], _) ->
+        (* Empty fields means we're in a record body `{}`. Complete for the fields. *)
         appendNestedPat (Completable.PRecordBody {seenFields = []});
         commitFoundPat ~prefix:"" ()
       | Ppat_record (fields, _) -> (
-        (* TODO: Identify seen fields. *)
         let fieldWithCursor = ref None in
         let fieldWithPatHole = ref None in
         fields
@@ -523,6 +532,13 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
                | Lident fname, _ when isPatternHole f ->
                  fieldWithPatHole := Some (fname, f)
                | _ -> ());
+        let seenFields =
+          fields
+          |> List.filter_map (fun (fieldName, _f) ->
+                 match fieldName with
+                 | {Location.txt = Longident.Lident fieldName} -> Some fieldName
+                 | _ -> None)
+        in
         match (!fieldWithCursor, !fieldWithPatHole) with
         | Some (fname, f), _ | None, Some (fname, f) -> (
           match f.ppat_desc with
@@ -535,10 +551,19 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
             commitFoundPat ~prefix:"" ()
           | Ppat_var {txt} ->
             (* A var means `{s}` or similar. Complete for fields. *)
-            appendNestedPat (Completable.PRecordBody {seenFields = []});
+            appendNestedPat (Completable.PRecordBody {seenFields});
             commitFoundPat ~prefix:txt ()
           | _ -> ())
-        | _ -> ())
+        | None, None -> (
+          (* Figure out if we're completing for a new field.
+             If the cursor is inside of the record body, but no field has the cursor,
+             and there's no pattern hole. Check the first char to the left of the cursor,
+             ignoring white space. If that's a comma, we assume you're completing for a new field. *)
+          match firstCharBeforeCursorNoWhite with
+          | Some ',' ->
+            appendNestedPat (Completable.PRecordBody {seenFields});
+            commitFoundPat ~prefix:"" ()
+          | _ -> ()))
       | _ -> ()
   in
   let case (iterator : Ast_iterator.iterator) (case : Parsetree.case) =

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -558,6 +558,7 @@ module Completable = struct
     | PFollowRecordField of {fieldName: string}
     | PRecordBody of {seenFields: string list}
     | PVariantPayload of {constructorName: string; payloadNum: int}
+    | PPolyvariantPayload of {constructorName: string; payloadNum: int}
 
   let patternPathToString p =
     match p with
@@ -566,6 +567,9 @@ module Completable = struct
     | PRecordBody _ -> "recordBody"
     | PVariantPayload {constructorName; payloadNum} ->
       "variantPayload::" ^ constructorName ^ "($" ^ string_of_int payloadNum
+      ^ ")"
+    | PPolyvariantPayload {constructorName; payloadNum} ->
+      "polyvariantPayload::" ^ constructorName ^ "($" ^ string_of_int payloadNum
       ^ ")"
 
   type t =

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -592,11 +592,7 @@ module Completable = struct
         propName: string;
         prefix: string;
       }
-    | Cpattern of {
-        typ: contextPath;
-        nested: patternPath list option;
-        prefix: string;
-      }
+    | Cpattern of {typ: contextPath; nested: patternPath list; prefix: string}
 
   (** An extracted type from a type expr *)
   type extractedType =
@@ -677,8 +673,8 @@ module Completable = struct
       ^ (if prefix = "" then "" else "=" ^ prefix)
       ^
       match nested with
-      | None -> ""
-      | Some patternPaths ->
+      | [] -> ""
+      | patternPaths ->
         "->"
         ^ (patternPaths
           |> List.map (fun patternPath -> patternPathToString patternPath)

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -551,7 +551,7 @@ module Completable = struct
       }
 
   (** Additional context for a pattern completion where needed. *)
-  type patternContext = RecordField
+  type patternContext = RecordField of {seenFields: string list}
 
   type patternPath =
     | PTupleItem of {itemNum: int}

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -550,14 +550,19 @@ module Completable = struct
             (** The loc item for the left hand side of the pipe. *)
       }
 
+  (** Additional context for a pattern completion where needed. *)
+  type patternContext = RecordField
+
   type patternPath =
     | PTupleItem of {itemNum: int}
-    | PRecordField of {fieldName: string}
+    | PFollowRecordField of {fieldName: string}
+    | PRecordBody of {seenFields: string list}
 
   let patternPathToString p =
     match p with
     | PTupleItem {itemNum} -> "tuple($" ^ string_of_int itemNum ^ ")"
-    | PRecordField {fieldName} -> "recordField(" ^ fieldName ^ ")"
+    | PFollowRecordField {fieldName} -> "recordField(" ^ fieldName ^ ")"
+    | PRecordBody _ -> "recordBody"
 
   type t =
     | Cdecorator of string  (** e.g. @module *)

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -557,8 +557,8 @@ module Completable = struct
     | PTupleItem of {itemNum: int}
     | PFollowRecordField of {fieldName: string}
     | PRecordBody of {seenFields: string list}
-    | PVariantPayload of {constructorName: string; payloadNum: int}
-    | PPolyvariantPayload of {constructorName: string; payloadNum: int}
+    | PVariantPayload of {constructorName: string}
+    | PPolyvariantPayload of {constructorName: string}
     | PArray
 
   let patternPathToString p =
@@ -566,12 +566,10 @@ module Completable = struct
     | PTupleItem {itemNum} -> "tuple($" ^ string_of_int itemNum ^ ")"
     | PFollowRecordField {fieldName} -> "recordField(" ^ fieldName ^ ")"
     | PRecordBody _ -> "recordBody"
-    | PVariantPayload {constructorName; payloadNum} ->
-      "variantPayload::" ^ constructorName ^ "($" ^ string_of_int payloadNum
-      ^ ")"
-    | PPolyvariantPayload {constructorName; payloadNum} ->
-      "polyvariantPayload::" ^ constructorName ^ "($" ^ string_of_int payloadNum
-      ^ ")"
+    | PVariantPayload {constructorName} ->
+      "variantPayload(" ^ constructorName ^ ")"
+    | PPolyvariantPayload {constructorName} ->
+      "polyvariantPayload(" ^ constructorName ^ ")"
     | PArray -> "array"
 
   type t =

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -592,7 +592,12 @@ module Completable = struct
         propName: string;
         prefix: string;
       }
-    | Cpattern of {typ: contextPath; nested: patternPath list; prefix: string}
+    | Cpattern of {
+        typ: contextPath;
+        nested: patternPath list;
+        prefix: string;
+        fallback: t option;
+      }
 
   (** An extracted type from a type expr *)
   type extractedType =

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -550,11 +550,14 @@ module Completable = struct
             (** The loc item for the left hand side of the pipe. *)
       }
 
-  type patternPath = PTupleItem of {itemNum: int}
+  type patternPath =
+    | PTupleItem of {itemNum: int}
+    | PRecordField of {fieldName: string}
 
   let patternPathToString p =
     match p with
     | PTupleItem {itemNum} -> "tuple($" ^ string_of_int itemNum ^ ")"
+    | PRecordField {fieldName} -> "recordField(" ^ fieldName ^ ")"
 
   type t =
     | Cdecorator of string  (** e.g. @module *)
@@ -595,6 +598,11 @@ module Completable = struct
     | Tpolyvariant of {
         env: QueryEnv.t;
         constructors: polyVariantConstructor list;
+        typeExpr: Types.type_expr;
+      }
+    | Trecord of {
+        env: QueryEnv.t;
+        fields: field list;
         typeExpr: Types.type_expr;
       }
 

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -557,8 +557,8 @@ module Completable = struct
     | PTupleItem of {itemNum: int}
     | PFollowRecordField of {fieldName: string}
     | PRecordBody of {seenFields: string list}
-    | PVariantPayload of {constructorName: string}
-    | PPolyvariantPayload of {constructorName: string}
+    | PVariantPayload of {constructorName: string; itemNum: int}
+    | PPolyvariantPayload of {constructorName: string; itemNum: int}
     | PArray
 
   let patternPathToString p =
@@ -566,10 +566,11 @@ module Completable = struct
     | PTupleItem {itemNum} -> "tuple($" ^ string_of_int itemNum ^ ")"
     | PFollowRecordField {fieldName} -> "recordField(" ^ fieldName ^ ")"
     | PRecordBody _ -> "recordBody"
-    | PVariantPayload {constructorName} ->
-      "variantPayload(" ^ constructorName ^ ")"
-    | PPolyvariantPayload {constructorName} ->
-      "polyvariantPayload(" ^ constructorName ^ ")"
+    | PVariantPayload {constructorName; itemNum} ->
+      "variantPayload::" ^ constructorName ^ "($" ^ string_of_int itemNum ^ ")"
+    | PPolyvariantPayload {constructorName; itemNum} ->
+      "polyvariantPayload::" ^ constructorName ^ "($" ^ string_of_int itemNum
+      ^ ")"
     | PArray -> "array"
 
   type t =

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -557,12 +557,16 @@ module Completable = struct
     | PTupleItem of {itemNum: int}
     | PFollowRecordField of {fieldName: string}
     | PRecordBody of {seenFields: string list}
+    | PVariantPayload of {constructorName: string; payloadNum: int}
 
   let patternPathToString p =
     match p with
     | PTupleItem {itemNum} -> "tuple($" ^ string_of_int itemNum ^ ")"
     | PFollowRecordField {fieldName} -> "recordField(" ^ fieldName ^ ")"
     | PRecordBody _ -> "recordBody"
+    | PVariantPayload {constructorName; payloadNum} ->
+      "variantPayload::" ^ constructorName ^ "($" ^ string_of_int payloadNum
+      ^ ")"
 
   type t =
     | Cdecorator of string  (** e.g. @module *)

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -559,6 +559,7 @@ module Completable = struct
     | PRecordBody of {seenFields: string list}
     | PVariantPayload of {constructorName: string; payloadNum: int}
     | PPolyvariantPayload of {constructorName: string; payloadNum: int}
+    | PArray
 
   let patternPathToString p =
     match p with
@@ -571,6 +572,7 @@ module Completable = struct
     | PPolyvariantPayload {constructorName; payloadNum} ->
       "polyvariantPayload::" ^ constructorName ^ "($" ^ string_of_int payloadNum
       ^ ")"
+    | PArray -> "array"
 
   type t =
     | Cdecorator of string  (** e.g. @module *)
@@ -602,6 +604,7 @@ module Completable = struct
     | Tuple of QueryEnv.t * Types.type_expr list * Types.type_expr
     | Toption of QueryEnv.t * Types.type_expr
     | Tbool of QueryEnv.t
+    | Tarray of QueryEnv.t * Types.type_expr
     | Tvariant of {
         env: QueryEnv.t;
         constructors: Constructor.t list;

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -699,6 +699,10 @@ module CursorPosition = struct
     if posStart <= pos && pos <= posEnd then HasCursor
     else if posEnd = (Location.none |> Loc.end_) then EmptyLoc
     else NoCursor
+
+  let locHasCursor loc ~pos = loc |> classifyLoc ~pos = HasCursor
+
+  let locIsEmpty loc ~pos = loc |> classifyLoc ~pos = EmptyLoc
 end
 
 type labelled = {

--- a/analysis/tests/src/BrokenParserCases.res
+++ b/analysis/tests/src/BrokenParserCases.res
@@ -3,3 +3,7 @@
 // let _ = someFn(~isOff=, ())
 //                       ^com
 
+// This should parse as a single item tuple when in a pattern?
+// switch s { | (t) }
+//                ^com
+

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -105,3 +105,12 @@ ignore(b)
 
 // switch b { | #three({})}
 //                      ^com
+
+let c: array<bool> = []
+ignore(c)
+
+// switch c { | }
+//             ^com
+
+// switch c { | [] }
+//               ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -121,3 +121,9 @@ ignore(c)
 
 // switch c { | [] }
 //               ^com
+
+let o = Some(true)
+ignore(o)
+
+// switch o { | Some() }
+//                   ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -63,3 +63,12 @@ let z = (f, true)
 
 // switch f { | {nest: {}}}
 //                      ^com
+
+let _ = switch f {
+| {first: 123, nest} =>
+  ()
+  // switch nest { | {}}
+  //                  ^com
+  nest.nested
+| _ => false
+}

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -92,3 +92,16 @@ ignore(z)
 
 // switch z { | Three({})}
 //                     ^com
+
+type somePolyVariant = [#one | #two(bool) | #three(someRecord, bool)]
+let b: somePolyVariant = #two(true)
+ignore(b)
+
+// switch b { | #two()}
+//                   ^com
+
+// switch b { | #two(t)}
+//                    ^com
+
+// switch b { | #three({})}
+//                      ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -75,3 +75,6 @@ let _ = switch f {
 
 // let {} = f
 //      ^com
+
+// let {nest: {n}}} = f
+//              ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -1,0 +1,18 @@
+let v = (true, Some(false))
+
+// switch v {
+//           ^com
+
+// switch v { | }
+//             ^com
+
+// switch v { | (t, _) }
+//                ^com
+
+let x = true
+
+// switch x { |
+//              ^com
+
+// switch x { | t
+//               ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -78,3 +78,17 @@ let _ = switch f {
 
 // let {nest: {n}}} = f
 //              ^com
+
+type someVariant = One | Two(bool) | Three(someRecord, bool)
+
+let z = Two(true)
+ignore(z)
+
+// switch z { | Two()}
+//                  ^com
+
+// switch z { | Two(t)}
+//                   ^com
+
+// switch z { | Three({})}
+//                     ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -159,3 +159,14 @@ let v: multiPayloadPolyVariant = #test(1, true, Some(false), [])
 
 // switch v { | #test(1, true, None, )}
 //                                  ^com
+
+let s = (true, Some(true), [false])
+
+// switch s { | () }
+//               ^com
+
+// switch s { | (true, ) }
+//                     ^com
+
+// switch s { | (true, , []) }
+//                    ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -1,4 +1,9 @@
-let v = (true, Some(false))
+let v = (true, Some(false), (true, true))
+
+let _ = switch v {
+| (true, _, _) => 1
+| _ => 2
+}
 
 // switch v {
 //           ^com
@@ -8,6 +13,9 @@ let v = (true, Some(false))
 
 // switch v { | (t, _) }
 //                ^com
+
+// switch v { | (_, _, (f, _)) }
+//                       ^com
 
 let x = true
 

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -176,3 +176,6 @@ let s = (true, Some(true), [false])
 
 // switch s { | (true, []) => () | (true, , [])  }
 //                                       ^com
+
+// switch z { | One |  }
+//                   ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -170,3 +170,9 @@ let s = (true, Some(true), [false])
 
 // switch s { | (true, , []) }
 //                    ^com
+
+// switch s { | (true, []) => () |  }
+//                                 ^com
+
+// switch s { | (true, []) => () | (true, , [])  }
+//                                       ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -179,3 +179,15 @@ let s = (true, Some(true), [false])
 
 // switch z { | One |  }
 //                   ^com
+
+// switch z { | One | Two(true | )  }
+//                              ^com
+
+// switch z { | One | Three({test: true}, true | )  }
+//                                              ^com
+
+// switch b { | #one | #two(true | )  }
+//                                ^com
+
+// switch b { | #one | #three({test: true}, true | )  }
+//                                                ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -72,3 +72,6 @@ let _ = switch f {
   nest.nested
 | _ => false
 }
+
+// let {} = f
+//      ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -127,3 +127,35 @@ ignore(o)
 
 // switch o { | Some() }
 //                   ^com
+
+type multiPayloadVariant = Test(int, bool, option<bool>, array<bool>)
+
+let p = Test(1, true, Some(false), [])
+
+// switch p { | Test(1, )}
+//                     ^com
+
+// switch p { | Test(1, true, )}
+//                           ^com
+
+// switch p { | Test(1, , None)}
+//                     ^com
+
+// switch p { | Test(1, true, None, )}
+//                                 ^com
+
+type multiPayloadPolyVariant = [#test(int, bool, option<bool>, array<bool>)]
+
+let v: multiPayloadPolyVariant = #test(1, true, Some(false), [])
+
+// switch v { | #test(1, )}
+//                      ^com
+
+// switch v { | #test(1, true, )}
+//                            ^com
+
+// switch v { | #test(1, , None)}
+//                      ^com
+
+// switch v { | #test(1, true, None, )}
+//                                  ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -42,6 +42,7 @@ let f: someRecord = {
 }
 
 let z = (f, true)
+ignore(z)
 
 // switch f { | }
 //             ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -20,7 +20,37 @@ let _ = switch v {
 let x = true
 
 // switch x { |
-//              ^com
+//             ^com
 
 // switch x { | t
 //               ^com
+
+type nestedRecord = {nested: bool}
+
+type rec someRecord = {
+  first: int,
+  second: (bool, option<someRecord>),
+  optThird: option<[#first | #second(someRecord)]>,
+  nest: nestedRecord,
+}
+
+let f: someRecord = {
+  first: 123,
+  second: (true, None),
+  optThird: None,
+  nest: {nested: true},
+}
+
+let z = (f, true)
+
+// switch f { | {}}
+//               ^com
+
+// switch f { | {fi}}
+//                 ^com
+
+// switch z { | ({o}, _)}
+//                 ^com
+
+// switch f { | {nest: {}}}
+//                      ^com

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -49,6 +49,9 @@ let z = (f, true)
 // switch f { | {}}
 //               ^com
 
+// switch f { | {first,  , second }}
+//                      ^com
+
 // switch f { | {fi}}
 //                 ^com
 

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -93,6 +93,9 @@ ignore(z)
 // switch z { | Three({})}
 //                     ^com
 
+// switch z { | Three({}, t)}
+//                         ^com
+
 type somePolyVariant = [#one | #two(bool) | #three(someRecord, bool)]
 let b: somePolyVariant = #two(true)
 ignore(b)
@@ -105,6 +108,9 @@ ignore(b)
 
 // switch b { | #three({})}
 //                      ^com
+
+// switch b { | #three({}, t)}
+//                          ^com
 
 let c: array<bool> = []
 ignore(c)

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -43,6 +43,9 @@ let f: someRecord = {
 
 let z = (f, true)
 
+// switch f { | }
+//             ^com
+
 // switch f { | {}}
 //               ^com
 
@@ -51,6 +54,9 @@ let z = (f, true)
 
 // switch z { | ({o}, _)}
 //                 ^com
+
+// switch f { | {nest: }}
+//                    ^com
 
 // switch f { | {nest: {}}}
 //                      ^com

--- a/analysis/tests/src/expected/BrokenParserCases.res.txt
+++ b/analysis/tests/src/expected/BrokenParserCases.res.txt
@@ -4,3 +4,10 @@ Pexp_apply ...[2:11->2:17] (~isOff2:19->2:24=...[2:27->2:29])
 Completable: Cargument Value[someFn]($0)
 []
 
+Complete src/BrokenParserCases.res 6:18
+looking for: Cpath Value[s] 
+posCursor:[6:18] posNoWhite:[6:17] Found expr:[6:3->6:21]
+posCursor:[6:18] posNoWhite:[6:17] Found pattern:[6:16->6:19]
+Completable: Cpattern Value[s]=t
+[]
+

--- a/analysis/tests/src/expected/BrokenParserCases.res.txt
+++ b/analysis/tests/src/expected/BrokenParserCases.res.txt
@@ -5,7 +5,6 @@ Completable: Cargument Value[someFn]($0)
 []
 
 Complete src/BrokenParserCases.res 6:18
-looking for: Cpath Value[s] 
 posCursor:[6:18] posNoWhite:[6:17] Found expr:[6:3->6:21]
 posCursor:[6:18] posNoWhite:[6:17] Found pattern:[6:16->6:19]
 Completable: Cpattern Value[s]=t

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -965,6 +965,7 @@ Resolved opens 2 Completion.res Completion.res
 []
 
 Complete src/Completion.res 243:8
+looking for: Cpath Value[someR] 
 posCursor:[243:8] posNoWhite:[243:7] Found expr:[241:8->246:1]
 posCursor:[243:8] posNoWhite:[243:7] Found expr:[242:14->243:8]
 Pexp_apply ...[243:3->243:4] (...[242:14->242:15], ...[243:5->243:8])
@@ -1442,6 +1443,7 @@ posCursor:[355:23] posNoWhite:[355:22] Found expr:[355:12->355:23]
 
 Complete src/Completion.res 362:8
 posCursor:[362:8] posNoWhite:[362:7] Found expr:[360:8->365:3]
+looking for: Cpath Value[x] 
 posCursor:[362:8] posNoWhite:[362:7] Found expr:[361:2->365:3]
 posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->364:5]
 posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->362:8]
@@ -1477,6 +1479,7 @@ Resolved opens 2 Completion.res Completion.res
 
 Complete src/Completion.res 373:21
 posCursor:[373:21] posNoWhite:[373:20] Found expr:[371:8->376:3]
+looking for: Cpath Value[x] 
 posCursor:[373:21] posNoWhite:[373:20] Found expr:[372:2->376:3]
 posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->375:5]
 posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->373:21]

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1446,10 +1446,37 @@ looking for: Cpath Value[x]
 posCursor:[362:8] posNoWhite:[362:7] Found expr:[361:2->365:3]
 posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->364:5]
 posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->362:8]
+Ppat_construct T:[362:7->362:8]
 Completable: Cpattern Value[x]=T
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Resolved opens 2 Completion.res Completion.res
-[]
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Resolved opens 2 Completion.res Completion.res
+[{
+    "label": "That",
+    "kind": 4,
+    "tags": [],
+    "detail": "That\n\ntype v = This | That",
+    "documentation": null
+  }, {
+    "label": "This",
+    "kind": 4,
+    "tags": [],
+    "detail": "This\n\ntype v = This | That",
+    "documentation": null
+  }, {
+    "label": "TableclothMap",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }, {
+    "label": "TypeDefinition",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }]
 
 Complete src/Completion.res 373:21
 posCursor:[373:21] posNoWhite:[373:20] Found expr:[371:8->376:3]
@@ -1457,7 +1484,17 @@ looking for: Cpath Value[x]
 posCursor:[373:21] posNoWhite:[373:20] Found expr:[372:2->376:3]
 posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->375:5]
 posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->373:21]
-[]
+Ppat_construct AndThatOther.T:[373:7->373:21]
+Completable: Cpath Value[AndThatOther, T]
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Resolved opens 2 Completion.res Completion.res
+[{
+    "label": "ThatOther",
+    "kind": 4,
+    "tags": [],
+    "detail": "ThatOther\n\ntype v = And | ThatOther",
+    "documentation": null
+  }]
 
 Complete src/Completion.res 378:24
 posCursor:[378:24] posNoWhite:[378:23] Found expr:[378:12->378:26]

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1442,7 +1442,6 @@ posCursor:[355:23] posNoWhite:[355:22] Found expr:[355:12->355:23]
 
 Complete src/Completion.res 362:8
 posCursor:[362:8] posNoWhite:[362:7] Found expr:[360:8->365:3]
-looking for: Cpath Value[x] 
 posCursor:[362:8] posNoWhite:[362:7] Found expr:[361:2->365:3]
 posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->364:5]
 posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->362:8]
@@ -1480,7 +1479,6 @@ Resolved opens 2 Completion.res Completion.res
 
 Complete src/Completion.res 373:21
 posCursor:[373:21] posNoWhite:[373:20] Found expr:[371:8->376:3]
-looking for: Cpath Value[x] 
 posCursor:[373:21] posNoWhite:[373:20] Found expr:[372:2->376:3]
 posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->375:5]
 posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->373:21]

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -965,7 +965,6 @@ Resolved opens 2 Completion.res Completion.res
 []
 
 Complete src/Completion.res 243:8
-looking for: Cpath Value[someR] 
 posCursor:[243:8] posNoWhite:[243:7] Found expr:[241:8->246:1]
 posCursor:[243:8] posNoWhite:[243:7] Found expr:[242:14->243:8]
 Pexp_apply ...[243:3->243:4] (...[242:14->242:15], ...[243:5->243:8])

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1447,35 +1447,10 @@ looking for: Cpath Value[x]
 posCursor:[362:8] posNoWhite:[362:7] Found expr:[361:2->365:3]
 posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->364:5]
 posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->362:8]
-Ppat_construct T:[362:7->362:8]
-Completable: Cpath Value[T]
+Completable: Cpattern Value[x]=T
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Resolved opens 2 Completion.res Completion.res
-[{
-    "label": "That",
-    "kind": 4,
-    "tags": [],
-    "detail": "That\n\ntype v = This | That",
-    "documentation": null
-  }, {
-    "label": "This",
-    "kind": 4,
-    "tags": [],
-    "detail": "This\n\ntype v = This | That",
-    "documentation": null
-  }, {
-    "label": "TableclothMap",
-    "kind": 9,
-    "tags": [],
-    "detail": "file module",
-    "documentation": null
-  }, {
-    "label": "TypeDefinition",
-    "kind": 9,
-    "tags": [],
-    "detail": "file module",
-    "documentation": null
-  }]
+[]
 
 Complete src/Completion.res 373:21
 posCursor:[373:21] posNoWhite:[373:20] Found expr:[371:8->376:3]
@@ -1483,17 +1458,7 @@ looking for: Cpath Value[x]
 posCursor:[373:21] posNoWhite:[373:20] Found expr:[372:2->376:3]
 posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->375:5]
 posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->373:21]
-Ppat_construct AndThatOther.T:[373:7->373:21]
-Completable: Cpath Value[AndThatOther, T]
-Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
-Resolved opens 2 Completion.res Completion.res
-[{
-    "label": "ThatOther",
-    "kind": 4,
-    "tags": [],
-    "detail": "ThatOther\n\ntype v = And | ThatOther",
-    "documentation": null
-  }]
+[]
 
 Complete src/Completion.res 378:24
 posCursor:[378:24] posNoWhite:[378:23] Found expr:[378:12->378:26]

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -473,3 +473,159 @@ Completable: Cpattern Value[o]->variantPayload::Some($0)
     "documentation": null
   }]
 
+Complete src/CompletionPattern.res 134:23
+looking for: Cpath Value[p] 
+posCursor:[134:23] posNoWhite:[134:22] Found expr:[134:3->134:26]
+posCursor:[134:23] posNoWhite:[134:22] Found pattern:[134:16->134:25]
+Completable: Cpattern Value[p]->variantPayload::Test($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 137:29
+looking for: Cpath Value[p] 
+posCursor:[137:29] posNoWhite:[137:28] Found expr:[137:3->137:32]
+posCursor:[137:29] posNoWhite:[137:28] Found pattern:[137:16->137:31]
+posCursor:[137:29] posNoWhite:[137:28] Found pattern:[137:20->137:32]
+Completable: Cpattern Value[p]->variantPayload::Test($2)
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 140:23
+looking for: Cpath Value[p] 
+posCursor:[140:23] posNoWhite:[140:22] Found expr:[140:3->140:32]
+posCursor:[140:23] posNoWhite:[140:22] Found pattern:[140:16->140:31]
+posCursor:[140:23] posNoWhite:[140:22] Found pattern:[140:20->140:32]
+Completable: Cpattern Value[p]->variantPayload::Test($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 143:35
+looking for: Cpath Value[p] 
+posCursor:[143:35] posNoWhite:[143:34] Found expr:[143:3->143:38]
+posCursor:[143:35] posNoWhite:[143:34] Found pattern:[143:16->143:37]
+posCursor:[143:35] posNoWhite:[143:34] Found pattern:[143:20->143:38]
+Completable: Cpattern Value[p]->variantPayload::Test($3)
+[{
+    "label": "[]",
+    "kind": 12,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "sortText": "a",
+    "insertText": "[$0]",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 150:24
+looking for: Cpath Value[v] 
+posCursor:[150:24] posNoWhite:[150:23] Found expr:[150:3->150:27]
+posCursor:[150:24] posNoWhite:[150:23] Found pattern:[150:16->150:26]
+Completable: Cpattern Value[v]->polyvariantPayload::test($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 153:30
+looking for: Cpath Value[v] 
+posCursor:[153:30] posNoWhite:[153:29] Found expr:[153:3->153:33]
+posCursor:[153:30] posNoWhite:[153:29] Found pattern:[153:16->153:32]
+posCursor:[153:30] posNoWhite:[153:29] Found pattern:[153:21->153:32]
+Completable: Cpattern Value[v]->polyvariantPayload::test($2)
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 156:24
+looking for: Cpath Value[v] 
+posCursor:[156:24] posNoWhite:[156:23] Found expr:[156:3->156:33]
+posCursor:[156:24] posNoWhite:[156:23] Found pattern:[156:16->156:32]
+posCursor:[156:24] posNoWhite:[156:23] Found pattern:[156:21->156:32]
+Completable: Cpattern Value[v]->polyvariantPayload::test($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 159:36
+looking for: Cpath Value[v] 
+posCursor:[159:36] posNoWhite:[159:35] Found expr:[159:3->159:39]
+posCursor:[159:36] posNoWhite:[159:35] Found pattern:[159:16->159:38]
+posCursor:[159:36] posNoWhite:[159:35] Found pattern:[159:21->159:38]
+Completable: Cpattern Value[v]->polyvariantPayload::test($3)
+[{
+    "label": "[]",
+    "kind": 12,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "sortText": "a",
+    "insertText": "[$0]",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -261,7 +261,9 @@ Complete src/CompletionPattern.res 87:20
 looking for: Cpath Value[z] 
 posCursor:[87:20] posNoWhite:[87:19] Found expr:[87:3->87:22]
 posCursor:[87:20] posNoWhite:[87:19] Found pattern:[87:16->87:21]
+Ppat_construct Two:[87:16->87:19]
 posCursor:[87:20] posNoWhite:[87:19] Found pattern:[87:19->87:21]
+Ppat_construct ():[87:19->87:21]
 Completable: Cpattern Value[z]->variantPayload::Two($0)
 [{
     "label": "true",
@@ -281,6 +283,7 @@ Complete src/CompletionPattern.res 90:21
 looking for: Cpath Value[z] 
 posCursor:[90:21] posNoWhite:[90:20] Found expr:[90:3->90:23]
 posCursor:[90:21] posNoWhite:[90:20] Found pattern:[90:16->90:22]
+Ppat_construct Two:[90:16->90:19]
 posCursor:[90:21] posNoWhite:[90:20] Found pattern:[90:20->90:21]
 Completable: Cpattern Value[z]=t->variantPayload::Two($0)
 [{
@@ -295,6 +298,7 @@ Complete src/CompletionPattern.res 93:23
 looking for: Cpath Value[z] 
 posCursor:[93:23] posNoWhite:[93:22] Found expr:[93:3->93:26]
 posCursor:[93:23] posNoWhite:[93:22] Found pattern:[93:16->93:25]
+Ppat_construct Three:[93:16->93:21]
 posCursor:[93:23] posNoWhite:[93:22] Found pattern:[93:22->93:24]
 Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
 [{
@@ -327,6 +331,7 @@ Complete src/CompletionPattern.res 96:27
 looking for: Cpath Value[z] 
 posCursor:[96:27] posNoWhite:[96:26] Found expr:[96:3->96:29]
 posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:16->96:28]
+Ppat_construct Three:[96:16->96:21]
 posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:21->96:29]
 posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:26->96:27]
 Completable: Cpattern Value[z]=t->variantPayload::Three($1)
@@ -343,6 +348,7 @@ looking for: Cpath Value[b]
 posCursor:[103:21] posNoWhite:[103:20] Found expr:[103:3->103:23]
 posCursor:[103:21] posNoWhite:[103:20] Found pattern:[103:16->103:22]
 posCursor:[103:21] posNoWhite:[103:20] Found pattern:[103:20->103:21]
+Ppat_construct ():[103:20->103:21]
 Completable: Cpattern Value[b]->polyvariantPayload::two($0)
 [{
     "label": "true",
@@ -456,7 +462,9 @@ Complete src/CompletionPattern.res 127:21
 looking for: Cpath Value[o] 
 posCursor:[127:21] posNoWhite:[127:20] Found expr:[127:3->127:24]
 posCursor:[127:21] posNoWhite:[127:20] Found pattern:[127:16->127:22]
+Ppat_construct Some:[127:16->127:20]
 posCursor:[127:21] posNoWhite:[127:20] Found pattern:[127:20->127:22]
+Ppat_construct ():[127:20->127:22]
 Completable: Cpattern Value[o]->variantPayload::Some($0)
 [{
     "label": "true",
@@ -476,6 +484,7 @@ Complete src/CompletionPattern.res 134:23
 looking for: Cpath Value[p] 
 posCursor:[134:23] posNoWhite:[134:22] Found expr:[134:3->134:26]
 posCursor:[134:23] posNoWhite:[134:22] Found pattern:[134:16->134:25]
+Ppat_construct Test:[134:16->134:20]
 Completable: Cpattern Value[p]->variantPayload::Test($1)
 [{
     "label": "true",
@@ -495,6 +504,7 @@ Complete src/CompletionPattern.res 137:29
 looking for: Cpath Value[p] 
 posCursor:[137:29] posNoWhite:[137:28] Found expr:[137:3->137:32]
 posCursor:[137:29] posNoWhite:[137:28] Found pattern:[137:16->137:31]
+Ppat_construct Test:[137:16->137:20]
 posCursor:[137:29] posNoWhite:[137:28] Found pattern:[137:20->137:32]
 Completable: Cpattern Value[p]->variantPayload::Test($2)
 [{
@@ -517,6 +527,7 @@ Complete src/CompletionPattern.res 140:23
 looking for: Cpath Value[p] 
 posCursor:[140:23] posNoWhite:[140:22] Found expr:[140:3->140:32]
 posCursor:[140:23] posNoWhite:[140:22] Found pattern:[140:16->140:31]
+Ppat_construct Test:[140:16->140:20]
 posCursor:[140:23] posNoWhite:[140:22] Found pattern:[140:20->140:32]
 Completable: Cpattern Value[p]->variantPayload::Test($1)
 [{
@@ -537,6 +548,7 @@ Complete src/CompletionPattern.res 143:35
 looking for: Cpath Value[p] 
 posCursor:[143:35] posNoWhite:[143:34] Found expr:[143:3->143:38]
 posCursor:[143:35] posNoWhite:[143:34] Found pattern:[143:16->143:37]
+Ppat_construct Test:[143:16->143:20]
 posCursor:[143:35] posNoWhite:[143:34] Found pattern:[143:20->143:38]
 Completable: Cpattern Value[p]->variantPayload::Test($3)
 [{
@@ -632,6 +644,7 @@ Complete src/CompletionPattern.res 164:17
 looking for: Cpath Value[s] 
 posCursor:[164:17] posNoWhite:[164:16] Found expr:[164:3->164:20]
 posCursor:[164:17] posNoWhite:[164:16] Found pattern:[164:16->164:18]
+Ppat_construct ():[164:16->164:18]
 Completable: Cpattern Value[s]->tuple($0)
 [{
     "label": "true",
@@ -757,6 +770,7 @@ looking for: Cpath Value[z]
 posCursor:[182:32] posNoWhite:[182:31] Found expr:[182:3->182:37]
 posCursor:[182:32] posNoWhite:[182:31] Found pattern:[182:16->182:34]
 posCursor:[182:32] posNoWhite:[182:31] Found pattern:[182:22->182:34]
+Ppat_construct Two:[182:22->182:25]
 Completable: Cpattern Value[z]->variantPayload::Two($0)
 [{
     "label": "true",
@@ -777,6 +791,7 @@ looking for: Cpath Value[z]
 posCursor:[185:48] posNoWhite:[185:47] Found expr:[185:3->185:53]
 posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:16->185:50]
 posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:22->185:50]
+Ppat_construct Three:[185:22->185:27]
 posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:27->185:53]
 Completable: Cpattern Value[z]->variantPayload::Three($1)
 [{

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -169,7 +169,7 @@ Completable: Cpattern Value[z]=o->tuple($0), recordBody
 
 Complete src/CompletionPattern.res 60:22
 looking for: Cpath Value[f] 
-posCursor:[60:22] posNoWhite:[60:21] Found expr:[60:3->60:25]
+posCursor:[60:22] posNoWhite:[60:21] Found expr:[60:3->73:1]
 posCursor:[60:22] posNoWhite:[60:21] Found pattern:[60:16->60:25]
 Completable: Cpattern Value[f]->recordField(nest)
 [{
@@ -189,6 +189,23 @@ posCursor:[63:24] posNoWhite:[63:23] Found expr:[63:3->63:27]
 posCursor:[63:24] posNoWhite:[63:23] Found pattern:[63:16->63:26]
 posCursor:[63:24] posNoWhite:[63:23] Found pattern:[63:23->63:25]
 Completable: Cpattern Value[f]->recordField(nest), recordBody
+[{
+    "label": "nested",
+    "kind": 5,
+    "tags": [],
+    "detail": "nested: bool\n\nnestedRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 69:22
+looking for: Cpath Value[f] 
+posCursor:[69:22] posNoWhite:[69:21] Found expr:[66:8->73:1]
+posCursor:[69:22] posNoWhite:[69:21] Found expr:[68:2->71:13]
+posCursor:[69:22] posNoWhite:[69:21] Found expr:[69:5->71:13]
+looking for: Cpath Value[nest] 
+posCursor:[69:22] posNoWhite:[69:21] Found expr:[69:5->69:24]
+posCursor:[69:22] posNoWhite:[69:21] Found pattern:[69:21->69:23]
+Completable: Cpattern Value[nest]->recordBody
 [{
     "label": "nested",
     "kind": 5,

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -263,7 +263,7 @@ looking for: Cpath Value[z]
 posCursor:[86:20] posNoWhite:[86:19] Found expr:[86:3->86:22]
 posCursor:[86:20] posNoWhite:[86:19] Found pattern:[86:16->86:21]
 posCursor:[86:20] posNoWhite:[86:19] Found pattern:[86:19->86:21]
-Completable: Cpattern Value[z]->variantPayload(Two)
+Completable: Cpattern Value[z]->variantPayload::Two($0)
 [{
     "label": "true",
     "kind": 4,
@@ -283,7 +283,7 @@ looking for: Cpath Value[z]
 posCursor:[89:21] posNoWhite:[89:20] Found expr:[89:3->89:23]
 posCursor:[89:21] posNoWhite:[89:20] Found pattern:[89:16->89:22]
 posCursor:[89:21] posNoWhite:[89:20] Found pattern:[89:20->89:21]
-Completable: Cpattern Value[z]=t->variantPayload(Two)
+Completable: Cpattern Value[z]=t->variantPayload::Two($0)
 [{
     "label": "true",
     "kind": 4,
@@ -297,7 +297,7 @@ looking for: Cpath Value[z]
 posCursor:[92:23] posNoWhite:[92:22] Found expr:[92:3->92:26]
 posCursor:[92:23] posNoWhite:[92:22] Found pattern:[92:16->92:25]
 posCursor:[92:23] posNoWhite:[92:22] Found pattern:[92:22->92:24]
-Completable: Cpattern Value[z]->variantPayload(Three), recordBody
+Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
 [{
     "label": "first",
     "kind": 5,
@@ -330,7 +330,7 @@ posCursor:[95:27] posNoWhite:[95:26] Found expr:[95:3->95:29]
 posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:16->95:28]
 posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:21->95:29]
 posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:26->95:27]
-Completable: Cpattern Value[z]=t->variantPayload(Three), tuple($1)
+Completable: Cpattern Value[z]=t->variantPayload::Three($1)
 [{
     "label": "true",
     "kind": 4,
@@ -344,7 +344,7 @@ looking for: Cpath Value[b]
 posCursor:[102:21] posNoWhite:[102:20] Found expr:[102:3->102:23]
 posCursor:[102:21] posNoWhite:[102:20] Found pattern:[102:16->102:22]
 posCursor:[102:21] posNoWhite:[102:20] Found pattern:[102:20->102:21]
-Completable: Cpattern Value[b]->polyvariantPayload(two)
+Completable: Cpattern Value[b]->polyvariantPayload::two($0)
 [{
     "label": "true",
     "kind": 4,
@@ -364,7 +364,7 @@ looking for: Cpath Value[b]
 posCursor:[105:22] posNoWhite:[105:21] Found expr:[105:3->105:24]
 posCursor:[105:22] posNoWhite:[105:21] Found pattern:[105:16->105:23]
 posCursor:[105:22] posNoWhite:[105:21] Found pattern:[105:21->105:22]
-Completable: Cpattern Value[b]=t->polyvariantPayload(two)
+Completable: Cpattern Value[b]=t->polyvariantPayload::two($0)
 [{
     "label": "true",
     "kind": 4,
@@ -378,7 +378,7 @@ looking for: Cpath Value[b]
 posCursor:[108:24] posNoWhite:[108:23] Found expr:[108:3->108:27]
 posCursor:[108:24] posNoWhite:[108:23] Found pattern:[108:16->108:26]
 posCursor:[108:24] posNoWhite:[108:23] Found pattern:[108:23->108:25]
-Completable: Cpattern Value[b]->polyvariantPayload(three), recordBody
+Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
 [{
     "label": "first",
     "kind": 5,
@@ -411,7 +411,7 @@ posCursor:[111:28] posNoWhite:[111:27] Found expr:[111:3->111:30]
 posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:16->111:29]
 posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:22->111:29]
 posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:27->111:28]
-Completable: Cpattern Value[b]=t->polyvariantPayload(three), tuple($1)
+Completable: Cpattern Value[b]=t->polyvariantPayload::three($1)
 [{
     "label": "true",
     "kind": 4,

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -1,0 +1,48 @@
+Complete src/CompletionPattern.res 2:13
+posCursor:[2:13] posNoWhite:[2:12] Found expr:[2:3->2:13]
+[]
+
+Complete src/CompletionPattern.res 5:15
+XXX Not found!
+Completable: Cpattern Value[v]
+[{
+    "label": "(_, _)",
+    "kind": 12,
+    "tags": [],
+    "detail": "(bool, option<bool>)",
+    "documentation": null,
+    "insertText": "(${1:_}, ${2:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 8:18
+looking for: Cpath Value[v] 
+posCursor:[8:18] posNoWhite:[8:17] Found expr:[8:3->8:24]
+posCursor:[8:18] posNoWhite:[8:17] Found pattern:[8:16->8:22]
+posCursor:[8:18] posNoWhite:[8:17] Found pattern:[8:17->8:18]
+Completable: Cpattern Value[v]=t->tuple($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 13:16
+posCursor:[13:16] posNoWhite:[13:14] Found expr:[13:3->13:15]
+[]
+
+Complete src/CompletionPattern.res 16:17
+looking for: Cpath Value[x] 
+posCursor:[16:17] posNoWhite:[16:16] Found expr:[16:3->16:17]
+posCursor:[16:17] posNoWhite:[16:16] Found pattern:[16:16->16:17]
+Completable: Cpattern Value[x]=t
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -723,3 +723,32 @@ Completable: Cpattern Value[s]->tuple($1)
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionPattern.res 179:21
+XXX Not found!
+Completable: Cpattern Value[z]
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
+  }, {
+    "label": "Two(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
+    "documentation": null,
+    "insertText": "Two(${1:_})",
+    "insertTextFormat": 2
+  }, {
+    "label": "Three(_, _)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
+    "documentation": null,
+    "insertText": "Three(${1:_}, ${2:_})",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -16,7 +16,6 @@ Completable: Cpattern Value[v]
   }]
 
 Complete src/CompletionPattern.res 13:18
-looking for: Cpath Value[v] 
 posCursor:[13:18] posNoWhite:[13:17] Found expr:[13:3->13:24]
 posCursor:[13:18] posNoWhite:[13:17] Found pattern:[13:16->13:22]
 posCursor:[13:18] posNoWhite:[13:17] Found pattern:[13:17->13:18]
@@ -30,7 +29,6 @@ Completable: Cpattern Value[v]=t->tuple($0)
   }]
 
 Complete src/CompletionPattern.res 16:25
-looking for: Cpath Value[v] 
 posCursor:[16:25] posNoWhite:[16:24] Found expr:[16:3->16:32]
 posCursor:[16:25] posNoWhite:[16:24] Found pattern:[16:16->16:30]
 posCursor:[16:25] posNoWhite:[16:24] Found pattern:[16:23->16:29]
@@ -62,7 +60,6 @@ Completable: Cpattern Value[x]
   }]
 
 Complete src/CompletionPattern.res 24:17
-looking for: Cpath Value[x] 
 posCursor:[24:17] posNoWhite:[24:16] Found expr:[24:3->24:17]
 posCursor:[24:17] posNoWhite:[24:16] Found pattern:[24:16->24:17]
 Completable: Cpattern Value[x]=t
@@ -89,7 +86,6 @@ Completable: Cpattern Value[f]
   }]
 
 Complete src/CompletionPattern.res 49:17
-looking for: Cpath Value[f] 
 posCursor:[49:17] posNoWhite:[49:16] Found expr:[49:3->49:19]
 posCursor:[49:17] posNoWhite:[49:16] Found pattern:[49:16->49:18]
 Completable: Cpattern Value[f]->recordBody
@@ -120,7 +116,6 @@ Completable: Cpattern Value[f]->recordBody
   }]
 
 Complete src/CompletionPattern.res 52:24
-looking for: Cpath Value[f] 
 posCursor:[52:24] posNoWhite:[52:22] Found expr:[52:3->52:36]
 posCursor:[52:24] posNoWhite:[52:22] Found pattern:[52:16->52:35]
 Completable: Cpattern Value[f]->recordBody
@@ -139,7 +134,6 @@ Completable: Cpattern Value[f]->recordBody
   }]
 
 Complete src/CompletionPattern.res 55:19
-looking for: Cpath Value[f] 
 posCursor:[55:19] posNoWhite:[55:18] Found expr:[55:3->55:21]
 posCursor:[55:19] posNoWhite:[55:18] Found pattern:[55:16->55:20]
 posCursor:[55:19] posNoWhite:[55:18] Found pattern:[55:17->55:19]
@@ -153,7 +147,6 @@ Completable: Cpattern Value[f]=fi->recordBody
   }]
 
 Complete src/CompletionPattern.res 58:19
-looking for: Cpath Value[z] 
 posCursor:[58:19] posNoWhite:[58:18] Found expr:[58:3->58:25]
 posCursor:[58:19] posNoWhite:[58:18] Found pattern:[58:16->58:24]
 posCursor:[58:19] posNoWhite:[58:18] Found pattern:[58:17->58:20]
@@ -168,7 +161,6 @@ Completable: Cpattern Value[z]=o->tuple($0), recordBody
   }]
 
 Complete src/CompletionPattern.res 61:22
-looking for: Cpath Value[f] 
 posCursor:[61:22] posNoWhite:[61:21] Found expr:[61:3->74:1]
 posCursor:[61:22] posNoWhite:[61:21] Found pattern:[61:16->61:25]
 Completable: Cpattern Value[f]->recordField(nest)
@@ -184,7 +176,6 @@ Completable: Cpattern Value[f]->recordField(nest)
   }]
 
 Complete src/CompletionPattern.res 64:24
-looking for: Cpath Value[f] 
 posCursor:[64:24] posNoWhite:[64:23] Found expr:[64:3->64:27]
 posCursor:[64:24] posNoWhite:[64:23] Found pattern:[64:16->64:26]
 posCursor:[64:24] posNoWhite:[64:23] Found pattern:[64:23->64:25]
@@ -201,7 +192,6 @@ Complete src/CompletionPattern.res 70:22
 posCursor:[70:22] posNoWhite:[70:21] Found expr:[67:8->74:1]
 posCursor:[70:22] posNoWhite:[70:21] Found expr:[69:2->72:13]
 posCursor:[70:22] posNoWhite:[70:21] Found expr:[70:5->72:13]
-looking for: Cpath Value[nest] 
 posCursor:[70:22] posNoWhite:[70:21] Found expr:[70:5->70:24]
 posCursor:[70:22] posNoWhite:[70:21] Found pattern:[70:21->70:23]
 Completable: Cpattern Value[nest]->recordBody
@@ -214,7 +204,6 @@ Completable: Cpattern Value[nest]->recordBody
   }]
 
 Complete src/CompletionPattern.res 76:8
-looking for: Cpath Value[f] 
 posCursor:[76:8] posNoWhite:[76:7] Found pattern:[76:7->76:9]
 Completable: Cpattern Value[f]->recordBody
 [{
@@ -244,7 +233,6 @@ Completable: Cpattern Value[f]->recordBody
   }]
 
 Complete src/CompletionPattern.res 79:16
-looking for: Cpath Value[f] 
 posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:7->79:18]
 posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:14->79:17]
 posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:15->79:16]
@@ -258,7 +246,6 @@ Completable: Cpattern Value[f]=n->recordField(nest), recordBody
   }]
 
 Complete src/CompletionPattern.res 87:20
-looking for: Cpath Value[z] 
 posCursor:[87:20] posNoWhite:[87:19] Found expr:[87:3->87:22]
 posCursor:[87:20] posNoWhite:[87:19] Found pattern:[87:16->87:21]
 Ppat_construct Two:[87:16->87:19]
@@ -280,7 +267,6 @@ Completable: Cpattern Value[z]->variantPayload::Two($0)
   }]
 
 Complete src/CompletionPattern.res 90:21
-looking for: Cpath Value[z] 
 posCursor:[90:21] posNoWhite:[90:20] Found expr:[90:3->90:23]
 posCursor:[90:21] posNoWhite:[90:20] Found pattern:[90:16->90:22]
 Ppat_construct Two:[90:16->90:19]
@@ -295,7 +281,6 @@ Completable: Cpattern Value[z]=t->variantPayload::Two($0)
   }]
 
 Complete src/CompletionPattern.res 93:23
-looking for: Cpath Value[z] 
 posCursor:[93:23] posNoWhite:[93:22] Found expr:[93:3->93:26]
 posCursor:[93:23] posNoWhite:[93:22] Found pattern:[93:16->93:25]
 Ppat_construct Three:[93:16->93:21]
@@ -328,7 +313,6 @@ Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
   }]
 
 Complete src/CompletionPattern.res 96:27
-looking for: Cpath Value[z] 
 posCursor:[96:27] posNoWhite:[96:26] Found expr:[96:3->96:29]
 posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:16->96:28]
 Ppat_construct Three:[96:16->96:21]
@@ -344,7 +328,6 @@ Completable: Cpattern Value[z]=t->variantPayload::Three($1)
   }]
 
 Complete src/CompletionPattern.res 103:21
-looking for: Cpath Value[b] 
 posCursor:[103:21] posNoWhite:[103:20] Found expr:[103:3->103:23]
 posCursor:[103:21] posNoWhite:[103:20] Found pattern:[103:16->103:22]
 posCursor:[103:21] posNoWhite:[103:20] Found pattern:[103:20->103:21]
@@ -365,7 +348,6 @@ Completable: Cpattern Value[b]->polyvariantPayload::two($0)
   }]
 
 Complete src/CompletionPattern.res 106:22
-looking for: Cpath Value[b] 
 posCursor:[106:22] posNoWhite:[106:21] Found expr:[106:3->106:24]
 posCursor:[106:22] posNoWhite:[106:21] Found pattern:[106:16->106:23]
 posCursor:[106:22] posNoWhite:[106:21] Found pattern:[106:21->106:22]
@@ -379,7 +361,6 @@ Completable: Cpattern Value[b]=t->polyvariantPayload::two($0)
   }]
 
 Complete src/CompletionPattern.res 109:24
-looking for: Cpath Value[b] 
 posCursor:[109:24] posNoWhite:[109:23] Found expr:[109:3->109:27]
 posCursor:[109:24] posNoWhite:[109:23] Found pattern:[109:16->109:26]
 posCursor:[109:24] posNoWhite:[109:23] Found pattern:[109:23->109:25]
@@ -411,7 +392,6 @@ Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
   }]
 
 Complete src/CompletionPattern.res 112:28
-looking for: Cpath Value[b] 
 posCursor:[112:28] posNoWhite:[112:27] Found expr:[112:3->112:30]
 posCursor:[112:28] posNoWhite:[112:27] Found pattern:[112:16->112:29]
 posCursor:[112:28] posNoWhite:[112:27] Found pattern:[112:22->112:29]
@@ -440,7 +420,6 @@ Completable: Cpattern Value[c]
   }]
 
 Complete src/CompletionPattern.res 121:17
-looking for: Cpath Value[c] 
 posCursor:[121:17] posNoWhite:[121:16] Found expr:[121:3->121:20]
 posCursor:[121:17] posNoWhite:[121:16] Found pattern:[121:16->121:18]
 Completable: Cpattern Value[c]->array
@@ -459,7 +438,6 @@ Completable: Cpattern Value[c]->array
   }]
 
 Complete src/CompletionPattern.res 127:21
-looking for: Cpath Value[o] 
 posCursor:[127:21] posNoWhite:[127:20] Found expr:[127:3->127:24]
 posCursor:[127:21] posNoWhite:[127:20] Found pattern:[127:16->127:22]
 Ppat_construct Some:[127:16->127:20]
@@ -481,7 +459,6 @@ Completable: Cpattern Value[o]->variantPayload::Some($0)
   }]
 
 Complete src/CompletionPattern.res 134:23
-looking for: Cpath Value[p] 
 posCursor:[134:23] posNoWhite:[134:22] Found expr:[134:3->134:26]
 posCursor:[134:23] posNoWhite:[134:22] Found pattern:[134:16->134:25]
 Ppat_construct Test:[134:16->134:20]
@@ -501,7 +478,6 @@ Completable: Cpattern Value[p]->variantPayload::Test($1)
   }]
 
 Complete src/CompletionPattern.res 137:29
-looking for: Cpath Value[p] 
 posCursor:[137:29] posNoWhite:[137:28] Found expr:[137:3->137:32]
 posCursor:[137:29] posNoWhite:[137:28] Found pattern:[137:16->137:31]
 Ppat_construct Test:[137:16->137:20]
@@ -524,7 +500,6 @@ Completable: Cpattern Value[p]->variantPayload::Test($2)
   }]
 
 Complete src/CompletionPattern.res 140:23
-looking for: Cpath Value[p] 
 posCursor:[140:23] posNoWhite:[140:22] Found expr:[140:3->140:32]
 posCursor:[140:23] posNoWhite:[140:22] Found pattern:[140:16->140:31]
 Ppat_construct Test:[140:16->140:20]
@@ -545,7 +520,6 @@ Completable: Cpattern Value[p]->variantPayload::Test($1)
   }]
 
 Complete src/CompletionPattern.res 143:35
-looking for: Cpath Value[p] 
 posCursor:[143:35] posNoWhite:[143:34] Found expr:[143:3->143:38]
 posCursor:[143:35] posNoWhite:[143:34] Found pattern:[143:16->143:37]
 Ppat_construct Test:[143:16->143:20]
@@ -563,7 +537,6 @@ Completable: Cpattern Value[p]->variantPayload::Test($3)
   }]
 
 Complete src/CompletionPattern.res 150:24
-looking for: Cpath Value[v] 
 posCursor:[150:24] posNoWhite:[150:23] Found expr:[150:3->150:27]
 posCursor:[150:24] posNoWhite:[150:23] Found pattern:[150:16->150:26]
 Completable: Cpattern Value[v]->polyvariantPayload::test($1)
@@ -582,7 +555,6 @@ Completable: Cpattern Value[v]->polyvariantPayload::test($1)
   }]
 
 Complete src/CompletionPattern.res 153:30
-looking for: Cpath Value[v] 
 posCursor:[153:30] posNoWhite:[153:29] Found expr:[153:3->153:33]
 posCursor:[153:30] posNoWhite:[153:29] Found pattern:[153:16->153:32]
 posCursor:[153:30] posNoWhite:[153:29] Found pattern:[153:21->153:32]
@@ -604,7 +576,6 @@ Completable: Cpattern Value[v]->polyvariantPayload::test($2)
   }]
 
 Complete src/CompletionPattern.res 156:24
-looking for: Cpath Value[v] 
 posCursor:[156:24] posNoWhite:[156:23] Found expr:[156:3->156:33]
 posCursor:[156:24] posNoWhite:[156:23] Found pattern:[156:16->156:32]
 posCursor:[156:24] posNoWhite:[156:23] Found pattern:[156:21->156:32]
@@ -624,7 +595,6 @@ Completable: Cpattern Value[v]->polyvariantPayload::test($1)
   }]
 
 Complete src/CompletionPattern.res 159:36
-looking for: Cpath Value[v] 
 posCursor:[159:36] posNoWhite:[159:35] Found expr:[159:3->159:39]
 posCursor:[159:36] posNoWhite:[159:35] Found pattern:[159:16->159:38]
 posCursor:[159:36] posNoWhite:[159:35] Found pattern:[159:21->159:38]
@@ -641,7 +611,6 @@ Completable: Cpattern Value[v]->polyvariantPayload::test($3)
   }]
 
 Complete src/CompletionPattern.res 164:17
-looking for: Cpath Value[s] 
 posCursor:[164:17] posNoWhite:[164:16] Found expr:[164:3->164:20]
 posCursor:[164:17] posNoWhite:[164:16] Found pattern:[164:16->164:18]
 Ppat_construct ():[164:16->164:18]
@@ -661,7 +630,6 @@ Completable: Cpattern Value[s]->tuple($0)
   }]
 
 Complete src/CompletionPattern.res 167:23
-looking for: Cpath Value[s] 
 posCursor:[167:23] posNoWhite:[167:21] Found expr:[167:3->167:26]
 posCursor:[167:23] posNoWhite:[167:21] Found pattern:[167:16->167:24]
 Completable: Cpattern Value[s]->tuple($1)
@@ -682,7 +650,6 @@ Completable: Cpattern Value[s]->tuple($1)
   }]
 
 Complete src/CompletionPattern.res 170:22
-looking for: Cpath Value[s] 
 posCursor:[170:22] posNoWhite:[170:21] Found expr:[170:3->170:30]
 posCursor:[170:22] posNoWhite:[170:21] Found pattern:[170:16->170:28]
 Completable: Cpattern Value[s]->tuple($1)
@@ -716,7 +683,6 @@ Completable: Cpattern Value[s]
   }]
 
 Complete src/CompletionPattern.res 176:41
-looking for: Cpath Value[s] 
 posCursor:[176:41] posNoWhite:[176:40] Found expr:[176:3->176:50]
 posCursor:[176:41] posNoWhite:[176:40] Found pattern:[176:35->176:47]
 Completable: Cpattern Value[s]->tuple($1)
@@ -766,7 +732,6 @@ Completable: Cpattern Value[z]
   }]
 
 Complete src/CompletionPattern.res 182:32
-looking for: Cpath Value[z] 
 posCursor:[182:32] posNoWhite:[182:31] Found expr:[182:3->182:37]
 posCursor:[182:32] posNoWhite:[182:31] Found pattern:[182:16->182:34]
 posCursor:[182:32] posNoWhite:[182:31] Found pattern:[182:22->182:34]
@@ -787,7 +752,6 @@ Completable: Cpattern Value[z]->variantPayload::Two($0)
   }]
 
 Complete src/CompletionPattern.res 185:48
-looking for: Cpath Value[z] 
 posCursor:[185:48] posNoWhite:[185:47] Found expr:[185:3->185:53]
 posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:16->185:50]
 posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:22->185:50]
@@ -809,7 +773,6 @@ Completable: Cpattern Value[z]->variantPayload::Three($1)
   }]
 
 Complete src/CompletionPattern.res 188:34
-looking for: Cpath Value[b] 
 posCursor:[188:34] posNoWhite:[188:33] Found expr:[188:3->188:39]
 posCursor:[188:34] posNoWhite:[188:33] Found pattern:[188:16->188:36]
 posCursor:[188:34] posNoWhite:[188:33] Found pattern:[188:23->188:36]
@@ -829,7 +792,6 @@ Completable: Cpattern Value[b]->polyvariantPayload::two($0)
   }]
 
 Complete src/CompletionPattern.res 191:50
-looking for: Cpath Value[b] 
 posCursor:[191:50] posNoWhite:[191:49] Found expr:[191:3->191:55]
 posCursor:[191:50] posNoWhite:[191:49] Found pattern:[191:16->191:52]
 posCursor:[191:50] posNoWhite:[191:49] Found pattern:[191:23->191:52]

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -629,3 +629,64 @@ Completable: Cpattern Value[v]->polyvariantPayload::test($3)
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionPattern.res 164:17
+looking for: Cpath Value[s] 
+posCursor:[164:17] posNoWhite:[164:16] Found expr:[164:3->164:20]
+posCursor:[164:17] posNoWhite:[164:16] Found pattern:[164:16->164:18]
+Completable: Cpattern Value[s]->tuple($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 167:23
+looking for: Cpath Value[s] 
+posCursor:[167:23] posNoWhite:[167:21] Found expr:[167:3->167:26]
+posCursor:[167:23] posNoWhite:[167:21] Found pattern:[167:16->167:24]
+Completable: Cpattern Value[s]->tuple($1)
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 170:22
+looking for: Cpath Value[s] 
+posCursor:[170:22] posNoWhite:[170:21] Found expr:[170:3->170:30]
+posCursor:[170:22] posNoWhite:[170:21] Found pattern:[170:16->170:28]
+Completable: Cpattern Value[s]->tuple($1)
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -752,3 +752,85 @@ Completable: Cpattern Value[z]
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionPattern.res 182:32
+looking for: Cpath Value[z] 
+posCursor:[182:32] posNoWhite:[182:31] Found expr:[182:3->182:37]
+posCursor:[182:32] posNoWhite:[182:31] Found pattern:[182:16->182:34]
+posCursor:[182:32] posNoWhite:[182:31] Found pattern:[182:22->182:34]
+Completable: Cpattern Value[z]->variantPayload::Two($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 185:48
+looking for: Cpath Value[z] 
+posCursor:[185:48] posNoWhite:[185:47] Found expr:[185:3->185:53]
+posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:16->185:50]
+posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:22->185:50]
+posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:27->185:53]
+Completable: Cpattern Value[z]->variantPayload::Three($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 188:34
+looking for: Cpath Value[b] 
+posCursor:[188:34] posNoWhite:[188:33] Found expr:[188:3->188:39]
+posCursor:[188:34] posNoWhite:[188:33] Found pattern:[188:16->188:36]
+posCursor:[188:34] posNoWhite:[188:33] Found pattern:[188:23->188:36]
+Completable: Cpattern Value[b]->polyvariantPayload::two($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 191:50
+looking for: Cpath Value[b] 
+posCursor:[191:50] posNoWhite:[191:49] Found expr:[191:3->191:55]
+posCursor:[191:50] posNoWhite:[191:49] Found pattern:[191:16->191:52]
+posCursor:[191:50] posNoWhite:[191:49] Found pattern:[191:23->191:52]
+posCursor:[191:50] posNoWhite:[191:49] Found pattern:[191:29->191:52]
+Completable: Cpattern Value[b]->polyvariantPayload::three($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -119,11 +119,30 @@ Completable: Cpattern Value[f]->recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 51:19
+Complete src/CompletionPattern.res 51:24
 looking for: Cpath Value[f] 
-posCursor:[51:19] posNoWhite:[51:18] Found expr:[51:3->51:21]
-posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:16->51:20]
-posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:17->51:19]
+posCursor:[51:24] posNoWhite:[51:22] Found expr:[51:3->51:36]
+posCursor:[51:24] posNoWhite:[51:22] Found pattern:[51:16->51:35]
+Completable: Cpattern Value[f]->recordBody
+[{
+    "label": "optThird",
+    "kind": 5,
+    "tags": [],
+    "detail": "optThird: option<[#second(someRecord) | #first]>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nest",
+    "kind": 5,
+    "tags": [],
+    "detail": "nest: nestedRecord\n\nsomeRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 54:19
+looking for: Cpath Value[f] 
+posCursor:[54:19] posNoWhite:[54:18] Found expr:[54:3->54:21]
+posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:16->54:20]
+posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:17->54:19]
 Completable: Cpattern Value[f]=fi->recordBody
 [{
     "label": "first",
@@ -133,12 +152,12 @@ Completable: Cpattern Value[f]=fi->recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 54:19
+Complete src/CompletionPattern.res 57:19
 looking for: Cpath Value[z] 
-posCursor:[54:19] posNoWhite:[54:18] Found expr:[54:3->54:25]
-posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:16->54:24]
-posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:17->54:20]
-posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:18->54:19]
+posCursor:[57:19] posNoWhite:[57:18] Found expr:[57:3->57:25]
+posCursor:[57:19] posNoWhite:[57:18] Found pattern:[57:16->57:24]
+posCursor:[57:19] posNoWhite:[57:18] Found pattern:[57:17->57:20]
+posCursor:[57:19] posNoWhite:[57:18] Found pattern:[57:18->57:19]
 Completable: Cpattern Value[z]=o->tuple($0), recordBody
 [{
     "label": "optThird",
@@ -148,10 +167,10 @@ Completable: Cpattern Value[z]=o->tuple($0), recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 57:22
+Complete src/CompletionPattern.res 60:22
 looking for: Cpath Value[f] 
-posCursor:[57:22] posNoWhite:[57:21] Found expr:[57:3->57:25]
-posCursor:[57:22] posNoWhite:[57:21] Found pattern:[57:16->57:25]
+posCursor:[60:22] posNoWhite:[60:21] Found expr:[60:3->60:25]
+posCursor:[60:22] posNoWhite:[60:21] Found pattern:[60:16->60:25]
 Completable: Cpattern Value[f]->recordField(nest)
 [{
     "label": "{}",
@@ -164,11 +183,11 @@ Completable: Cpattern Value[f]->recordField(nest)
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionPattern.res 60:24
+Complete src/CompletionPattern.res 63:24
 looking for: Cpath Value[f] 
-posCursor:[60:24] posNoWhite:[60:23] Found expr:[60:3->60:27]
-posCursor:[60:24] posNoWhite:[60:23] Found pattern:[60:16->60:26]
-posCursor:[60:24] posNoWhite:[60:23] Found pattern:[60:23->60:25]
+posCursor:[63:24] posNoWhite:[63:23] Found expr:[63:3->63:27]
+posCursor:[63:24] posNoWhite:[63:23] Found pattern:[63:16->63:26]
+posCursor:[63:24] posNoWhite:[63:23] Found pattern:[63:23->63:25]
 Completable: Cpattern Value[f]->recordField(nest), recordBody
 [{
     "label": "nested",

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -214,3 +214,33 @@ Completable: Cpattern Value[nest]->recordBody
     "documentation": null
   }]
 
+Complete src/CompletionPattern.res 75:8
+looking for: Cpath Value[f] 
+posCursor:[75:8] posNoWhite:[75:7] Found pattern:[75:7->75:9]
+Completable: Cpattern Value[f]->recordBody
+[{
+    "label": "first",
+    "kind": 5,
+    "tags": [],
+    "detail": "first: int\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "second",
+    "kind": 5,
+    "tags": [],
+    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "optThird",
+    "kind": 5,
+    "tags": [],
+    "detail": "optThird: option<[#second(someRecord) | #first]>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nest",
+    "kind": 5,
+    "tags": [],
+    "detail": "nest: nestedRecord\n\nsomeRecord",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -44,9 +44,22 @@ Completable: Cpattern Value[v]=f->tuple($2), tuple($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 21:16
-posCursor:[21:16] posNoWhite:[21:14] Found expr:[21:3->21:15]
-[]
+Complete src/CompletionPattern.res 21:15
+XXX Not found!
+Completable: Cpattern Value[x]
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
 
 Complete src/CompletionPattern.res 24:17
 looking for: Cpath Value[x] 
@@ -58,6 +71,80 @@ Completable: Cpattern Value[x]=t
     "kind": 4,
     "tags": [],
     "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 45:17
+looking for: Cpath Value[f] 
+posCursor:[45:17] posNoWhite:[45:16] Found expr:[45:3->45:19]
+posCursor:[45:17] posNoWhite:[45:16] Found pattern:[45:16->45:18]
+Completable: Cpattern Value[f]
+[{
+    "label": "first",
+    "kind": 5,
+    "tags": [],
+    "detail": "first: int\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "second",
+    "kind": 5,
+    "tags": [],
+    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "optThird",
+    "kind": 5,
+    "tags": [],
+    "detail": "optThird: option<[#second(someRecord) | #first]>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nest",
+    "kind": 5,
+    "tags": [],
+    "detail": "nest: nestedRecord\n\nsomeRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 48:19
+looking for: Cpath Value[f] 
+posCursor:[48:19] posNoWhite:[48:18] Found expr:[48:3->48:21]
+posCursor:[48:19] posNoWhite:[48:18] Found pattern:[48:16->48:20]
+posCursor:[48:19] posNoWhite:[48:18] Found pattern:[48:17->48:19]
+Completable: Cpattern Value[f]=fi
+[{
+    "label": "first",
+    "kind": 5,
+    "tags": [],
+    "detail": "first: int\n\nsomeRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 51:19
+looking for: Cpath Value[z] 
+posCursor:[51:19] posNoWhite:[51:18] Found expr:[51:3->51:25]
+posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:16->51:24]
+posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:17->51:20]
+posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:18->51:19]
+Completable: Cpattern Value[z]=o->tuple($0)
+[{
+    "label": "optThird",
+    "kind": 5,
+    "tags": [],
+    "detail": "optThird: option<[#second(someRecord) | #first]>\n\nsomeRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 54:24
+looking for: Cpath Value[f] 
+posCursor:[54:24] posNoWhite:[54:23] Found expr:[54:3->54:27]
+posCursor:[54:24] posNoWhite:[54:23] Found pattern:[54:16->54:26]
+posCursor:[54:24] posNoWhite:[54:23] Found pattern:[54:23->54:25]
+Completable: Cpattern Value[f]->recordField(nest)
+[{
+    "label": "nested",
+    "kind": 5,
+    "tags": [],
+    "detail": "nested: bool\n\nnestedRecord",
     "documentation": null
   }]
 

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -263,7 +263,7 @@ looking for: Cpath Value[z]
 posCursor:[86:20] posNoWhite:[86:19] Found expr:[86:3->86:22]
 posCursor:[86:20] posNoWhite:[86:19] Found pattern:[86:16->86:21]
 posCursor:[86:20] posNoWhite:[86:19] Found pattern:[86:19->86:21]
-Completable: Cpattern Value[z]->variantPayload::Two($0)
+Completable: Cpattern Value[z]->variantPayload(Two)
 [{
     "label": "true",
     "kind": 4,
@@ -283,7 +283,7 @@ looking for: Cpath Value[z]
 posCursor:[89:21] posNoWhite:[89:20] Found expr:[89:3->89:23]
 posCursor:[89:21] posNoWhite:[89:20] Found pattern:[89:16->89:22]
 posCursor:[89:21] posNoWhite:[89:20] Found pattern:[89:20->89:21]
-Completable: Cpattern Value[z]=t->variantPayload::Two($0)
+Completable: Cpattern Value[z]=t->variantPayload(Two)
 [{
     "label": "true",
     "kind": 4,
@@ -297,7 +297,7 @@ looking for: Cpath Value[z]
 posCursor:[92:23] posNoWhite:[92:22] Found expr:[92:3->92:26]
 posCursor:[92:23] posNoWhite:[92:22] Found pattern:[92:16->92:25]
 posCursor:[92:23] posNoWhite:[92:22] Found pattern:[92:22->92:24]
-Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
+Completable: Cpattern Value[z]->variantPayload(Three), recordBody
 [{
     "label": "first",
     "kind": 5,
@@ -324,12 +324,27 @@ Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 99:21
+Complete src/CompletionPattern.res 95:27
+looking for: Cpath Value[z] 
+posCursor:[95:27] posNoWhite:[95:26] Found expr:[95:3->95:29]
+posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:16->95:28]
+posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:21->95:29]
+posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:26->95:27]
+Completable: Cpattern Value[z]=t->variantPayload(Three), tuple($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 102:21
 looking for: Cpath Value[b] 
-posCursor:[99:21] posNoWhite:[99:20] Found expr:[99:3->99:23]
-posCursor:[99:21] posNoWhite:[99:20] Found pattern:[99:16->99:22]
-posCursor:[99:21] posNoWhite:[99:20] Found pattern:[99:20->99:21]
-Completable: Cpattern Value[b]->polyvariantPayload::two($0)
+posCursor:[102:21] posNoWhite:[102:20] Found expr:[102:3->102:23]
+posCursor:[102:21] posNoWhite:[102:20] Found pattern:[102:16->102:22]
+posCursor:[102:21] posNoWhite:[102:20] Found pattern:[102:20->102:21]
+Completable: Cpattern Value[b]->polyvariantPayload(two)
 [{
     "label": "true",
     "kind": 4,
@@ -344,12 +359,12 @@ Completable: Cpattern Value[b]->polyvariantPayload::two($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 102:22
+Complete src/CompletionPattern.res 105:22
 looking for: Cpath Value[b] 
-posCursor:[102:22] posNoWhite:[102:21] Found expr:[102:3->102:24]
-posCursor:[102:22] posNoWhite:[102:21] Found pattern:[102:16->102:23]
-posCursor:[102:22] posNoWhite:[102:21] Found pattern:[102:21->102:22]
-Completable: Cpattern Value[b]=t->polyvariantPayload::two($0)
+posCursor:[105:22] posNoWhite:[105:21] Found expr:[105:3->105:24]
+posCursor:[105:22] posNoWhite:[105:21] Found pattern:[105:16->105:23]
+posCursor:[105:22] posNoWhite:[105:21] Found pattern:[105:21->105:22]
+Completable: Cpattern Value[b]=t->polyvariantPayload(two)
 [{
     "label": "true",
     "kind": 4,
@@ -358,12 +373,12 @@ Completable: Cpattern Value[b]=t->polyvariantPayload::two($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 105:24
+Complete src/CompletionPattern.res 108:24
 looking for: Cpath Value[b] 
-posCursor:[105:24] posNoWhite:[105:23] Found expr:[105:3->105:27]
-posCursor:[105:24] posNoWhite:[105:23] Found pattern:[105:16->105:26]
-posCursor:[105:24] posNoWhite:[105:23] Found pattern:[105:23->105:25]
-Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
+posCursor:[108:24] posNoWhite:[108:23] Found expr:[108:3->108:27]
+posCursor:[108:24] posNoWhite:[108:23] Found pattern:[108:16->108:26]
+posCursor:[108:24] posNoWhite:[108:23] Found pattern:[108:23->108:25]
+Completable: Cpattern Value[b]->polyvariantPayload(three), recordBody
 [{
     "label": "first",
     "kind": 5,
@@ -390,7 +405,22 @@ Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 111:15
+Complete src/CompletionPattern.res 111:28
+looking for: Cpath Value[b] 
+posCursor:[111:28] posNoWhite:[111:27] Found expr:[111:3->111:30]
+posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:16->111:29]
+posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:22->111:29]
+posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:27->111:28]
+Completable: Cpattern Value[b]=t->polyvariantPayload(three), tuple($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 117:15
 XXX Not found!
 Completable: Cpattern Value[c]
 [{
@@ -404,10 +434,10 @@ Completable: Cpattern Value[c]
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionPattern.res 114:17
+Complete src/CompletionPattern.res 120:17
 looking for: Cpath Value[c] 
-posCursor:[114:17] posNoWhite:[114:16] Found expr:[114:3->114:20]
-posCursor:[114:17] posNoWhite:[114:16] Found pattern:[114:16->114:18]
+posCursor:[120:17] posNoWhite:[120:16] Found expr:[120:3->120:20]
+posCursor:[120:17] posNoWhite:[120:16] Found pattern:[120:16->120:18]
 Completable: Cpattern Value[c]->array
 [{
     "label": "true",

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -244,3 +244,17 @@ Completable: Cpattern Value[f]->recordBody
     "documentation": null
   }]
 
+Complete src/CompletionPattern.res 78:16
+looking for: Cpath Value[f] 
+posCursor:[78:16] posNoWhite:[78:15] Found pattern:[78:7->78:18]
+posCursor:[78:16] posNoWhite:[78:15] Found pattern:[78:14->78:17]
+posCursor:[78:16] posNoWhite:[78:15] Found pattern:[78:15->78:16]
+Completable: Cpattern Value[f]=n->recordField(nest), recordBody
+[{
+    "label": "nested",
+    "kind": 5,
+    "tags": [],
+    "detail": "nested: bool\n\nnestedRecord",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -74,7 +74,7 @@ Completable: Cpattern Value[x]=t
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 45:15
+Complete src/CompletionPattern.res 46:15
 XXX Not found!
 Completable: Cpattern Value[f]
 [{
@@ -88,10 +88,10 @@ Completable: Cpattern Value[f]
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionPattern.res 48:17
+Complete src/CompletionPattern.res 49:17
 looking for: Cpath Value[f] 
-posCursor:[48:17] posNoWhite:[48:16] Found expr:[48:3->48:19]
-posCursor:[48:17] posNoWhite:[48:16] Found pattern:[48:16->48:18]
+posCursor:[49:17] posNoWhite:[49:16] Found expr:[49:3->49:19]
+posCursor:[49:17] posNoWhite:[49:16] Found pattern:[49:16->49:18]
 Completable: Cpattern Value[f]->recordBody
 [{
     "label": "first",
@@ -119,10 +119,10 @@ Completable: Cpattern Value[f]->recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 51:24
+Complete src/CompletionPattern.res 52:24
 looking for: Cpath Value[f] 
-posCursor:[51:24] posNoWhite:[51:22] Found expr:[51:3->51:36]
-posCursor:[51:24] posNoWhite:[51:22] Found pattern:[51:16->51:35]
+posCursor:[52:24] posNoWhite:[52:22] Found expr:[52:3->52:36]
+posCursor:[52:24] posNoWhite:[52:22] Found pattern:[52:16->52:35]
 Completable: Cpattern Value[f]->recordBody
 [{
     "label": "optThird",
@@ -138,11 +138,11 @@ Completable: Cpattern Value[f]->recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 54:19
+Complete src/CompletionPattern.res 55:19
 looking for: Cpath Value[f] 
-posCursor:[54:19] posNoWhite:[54:18] Found expr:[54:3->54:21]
-posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:16->54:20]
-posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:17->54:19]
+posCursor:[55:19] posNoWhite:[55:18] Found expr:[55:3->55:21]
+posCursor:[55:19] posNoWhite:[55:18] Found pattern:[55:16->55:20]
+posCursor:[55:19] posNoWhite:[55:18] Found pattern:[55:17->55:19]
 Completable: Cpattern Value[f]=fi->recordBody
 [{
     "label": "first",
@@ -152,12 +152,12 @@ Completable: Cpattern Value[f]=fi->recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 57:19
+Complete src/CompletionPattern.res 58:19
 looking for: Cpath Value[z] 
-posCursor:[57:19] posNoWhite:[57:18] Found expr:[57:3->57:25]
-posCursor:[57:19] posNoWhite:[57:18] Found pattern:[57:16->57:24]
-posCursor:[57:19] posNoWhite:[57:18] Found pattern:[57:17->57:20]
-posCursor:[57:19] posNoWhite:[57:18] Found pattern:[57:18->57:19]
+posCursor:[58:19] posNoWhite:[58:18] Found expr:[58:3->58:25]
+posCursor:[58:19] posNoWhite:[58:18] Found pattern:[58:16->58:24]
+posCursor:[58:19] posNoWhite:[58:18] Found pattern:[58:17->58:20]
+posCursor:[58:19] posNoWhite:[58:18] Found pattern:[58:18->58:19]
 Completable: Cpattern Value[z]=o->tuple($0), recordBody
 [{
     "label": "optThird",
@@ -167,10 +167,10 @@ Completable: Cpattern Value[z]=o->tuple($0), recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 60:22
+Complete src/CompletionPattern.res 61:22
 looking for: Cpath Value[f] 
-posCursor:[60:22] posNoWhite:[60:21] Found expr:[60:3->73:1]
-posCursor:[60:22] posNoWhite:[60:21] Found pattern:[60:16->60:25]
+posCursor:[61:22] posNoWhite:[61:21] Found expr:[61:3->74:1]
+posCursor:[61:22] posNoWhite:[61:21] Found pattern:[61:16->61:25]
 Completable: Cpattern Value[f]->recordField(nest)
 [{
     "label": "{}",
@@ -183,11 +183,11 @@ Completable: Cpattern Value[f]->recordField(nest)
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionPattern.res 63:24
+Complete src/CompletionPattern.res 64:24
 looking for: Cpath Value[f] 
-posCursor:[63:24] posNoWhite:[63:23] Found expr:[63:3->63:27]
-posCursor:[63:24] posNoWhite:[63:23] Found pattern:[63:16->63:26]
-posCursor:[63:24] posNoWhite:[63:23] Found pattern:[63:23->63:25]
+posCursor:[64:24] posNoWhite:[64:23] Found expr:[64:3->64:27]
+posCursor:[64:24] posNoWhite:[64:23] Found pattern:[64:16->64:26]
+posCursor:[64:24] posNoWhite:[64:23] Found pattern:[64:23->64:25]
 Completable: Cpattern Value[f]->recordField(nest), recordBody
 [{
     "label": "nested",
@@ -197,14 +197,14 @@ Completable: Cpattern Value[f]->recordField(nest), recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 69:22
+Complete src/CompletionPattern.res 70:22
 looking for: Cpath Value[f] 
-posCursor:[69:22] posNoWhite:[69:21] Found expr:[66:8->73:1]
-posCursor:[69:22] posNoWhite:[69:21] Found expr:[68:2->71:13]
-posCursor:[69:22] posNoWhite:[69:21] Found expr:[69:5->71:13]
+posCursor:[70:22] posNoWhite:[70:21] Found expr:[67:8->74:1]
+posCursor:[70:22] posNoWhite:[70:21] Found expr:[69:2->72:13]
+posCursor:[70:22] posNoWhite:[70:21] Found expr:[70:5->72:13]
 looking for: Cpath Value[nest] 
-posCursor:[69:22] posNoWhite:[69:21] Found expr:[69:5->69:24]
-posCursor:[69:22] posNoWhite:[69:21] Found pattern:[69:21->69:23]
+posCursor:[70:22] posNoWhite:[70:21] Found expr:[70:5->70:24]
+posCursor:[70:22] posNoWhite:[70:21] Found pattern:[70:21->70:23]
 Completable: Cpattern Value[nest]->recordBody
 [{
     "label": "nested",
@@ -214,9 +214,9 @@ Completable: Cpattern Value[nest]->recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 75:8
+Complete src/CompletionPattern.res 76:8
 looking for: Cpath Value[f] 
-posCursor:[75:8] posNoWhite:[75:7] Found pattern:[75:7->75:9]
+posCursor:[76:8] posNoWhite:[76:7] Found pattern:[76:7->76:9]
 Completable: Cpattern Value[f]->recordBody
 [{
     "label": "first",
@@ -244,11 +244,11 @@ Completable: Cpattern Value[f]->recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 78:16
+Complete src/CompletionPattern.res 79:16
 looking for: Cpath Value[f] 
-posCursor:[78:16] posNoWhite:[78:15] Found pattern:[78:7->78:18]
-posCursor:[78:16] posNoWhite:[78:15] Found pattern:[78:14->78:17]
-posCursor:[78:16] posNoWhite:[78:15] Found pattern:[78:15->78:16]
+posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:7->79:18]
+posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:14->79:17]
+posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:15->79:16]
 Completable: Cpattern Value[f]=n->recordField(nest), recordBody
 [{
     "label": "nested",
@@ -258,11 +258,11 @@ Completable: Cpattern Value[f]=n->recordField(nest), recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 86:20
+Complete src/CompletionPattern.res 87:20
 looking for: Cpath Value[z] 
-posCursor:[86:20] posNoWhite:[86:19] Found expr:[86:3->86:22]
-posCursor:[86:20] posNoWhite:[86:19] Found pattern:[86:16->86:21]
-posCursor:[86:20] posNoWhite:[86:19] Found pattern:[86:19->86:21]
+posCursor:[87:20] posNoWhite:[87:19] Found expr:[87:3->87:22]
+posCursor:[87:20] posNoWhite:[87:19] Found pattern:[87:16->87:21]
+posCursor:[87:20] posNoWhite:[87:19] Found pattern:[87:19->87:21]
 Completable: Cpattern Value[z]->variantPayload::Two($0)
 [{
     "label": "true",
@@ -278,11 +278,11 @@ Completable: Cpattern Value[z]->variantPayload::Two($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 89:21
+Complete src/CompletionPattern.res 90:21
 looking for: Cpath Value[z] 
-posCursor:[89:21] posNoWhite:[89:20] Found expr:[89:3->89:23]
-posCursor:[89:21] posNoWhite:[89:20] Found pattern:[89:16->89:22]
-posCursor:[89:21] posNoWhite:[89:20] Found pattern:[89:20->89:21]
+posCursor:[90:21] posNoWhite:[90:20] Found expr:[90:3->90:23]
+posCursor:[90:21] posNoWhite:[90:20] Found pattern:[90:16->90:22]
+posCursor:[90:21] posNoWhite:[90:20] Found pattern:[90:20->90:21]
 Completable: Cpattern Value[z]=t->variantPayload::Two($0)
 [{
     "label": "true",
@@ -292,11 +292,11 @@ Completable: Cpattern Value[z]=t->variantPayload::Two($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 92:23
+Complete src/CompletionPattern.res 93:23
 looking for: Cpath Value[z] 
-posCursor:[92:23] posNoWhite:[92:22] Found expr:[92:3->92:26]
-posCursor:[92:23] posNoWhite:[92:22] Found pattern:[92:16->92:25]
-posCursor:[92:23] posNoWhite:[92:22] Found pattern:[92:22->92:24]
+posCursor:[93:23] posNoWhite:[93:22] Found expr:[93:3->93:26]
+posCursor:[93:23] posNoWhite:[93:22] Found pattern:[93:16->93:25]
+posCursor:[93:23] posNoWhite:[93:22] Found pattern:[93:22->93:24]
 Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
 [{
     "label": "first",
@@ -324,12 +324,12 @@ Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 95:27
+Complete src/CompletionPattern.res 96:27
 looking for: Cpath Value[z] 
-posCursor:[95:27] posNoWhite:[95:26] Found expr:[95:3->95:29]
-posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:16->95:28]
-posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:21->95:29]
-posCursor:[95:27] posNoWhite:[95:26] Found pattern:[95:26->95:27]
+posCursor:[96:27] posNoWhite:[96:26] Found expr:[96:3->96:29]
+posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:16->96:28]
+posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:21->96:29]
+posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:26->96:27]
 Completable: Cpattern Value[z]=t->variantPayload::Three($1)
 [{
     "label": "true",
@@ -339,11 +339,11 @@ Completable: Cpattern Value[z]=t->variantPayload::Three($1)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 102:21
+Complete src/CompletionPattern.res 103:21
 looking for: Cpath Value[b] 
-posCursor:[102:21] posNoWhite:[102:20] Found expr:[102:3->102:23]
-posCursor:[102:21] posNoWhite:[102:20] Found pattern:[102:16->102:22]
-posCursor:[102:21] posNoWhite:[102:20] Found pattern:[102:20->102:21]
+posCursor:[103:21] posNoWhite:[103:20] Found expr:[103:3->103:23]
+posCursor:[103:21] posNoWhite:[103:20] Found pattern:[103:16->103:22]
+posCursor:[103:21] posNoWhite:[103:20] Found pattern:[103:20->103:21]
 Completable: Cpattern Value[b]->polyvariantPayload::two($0)
 [{
     "label": "true",
@@ -359,11 +359,11 @@ Completable: Cpattern Value[b]->polyvariantPayload::two($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 105:22
+Complete src/CompletionPattern.res 106:22
 looking for: Cpath Value[b] 
-posCursor:[105:22] posNoWhite:[105:21] Found expr:[105:3->105:24]
-posCursor:[105:22] posNoWhite:[105:21] Found pattern:[105:16->105:23]
-posCursor:[105:22] posNoWhite:[105:21] Found pattern:[105:21->105:22]
+posCursor:[106:22] posNoWhite:[106:21] Found expr:[106:3->106:24]
+posCursor:[106:22] posNoWhite:[106:21] Found pattern:[106:16->106:23]
+posCursor:[106:22] posNoWhite:[106:21] Found pattern:[106:21->106:22]
 Completable: Cpattern Value[b]=t->polyvariantPayload::two($0)
 [{
     "label": "true",
@@ -373,11 +373,11 @@ Completable: Cpattern Value[b]=t->polyvariantPayload::two($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 108:24
+Complete src/CompletionPattern.res 109:24
 looking for: Cpath Value[b] 
-posCursor:[108:24] posNoWhite:[108:23] Found expr:[108:3->108:27]
-posCursor:[108:24] posNoWhite:[108:23] Found pattern:[108:16->108:26]
-posCursor:[108:24] posNoWhite:[108:23] Found pattern:[108:23->108:25]
+posCursor:[109:24] posNoWhite:[109:23] Found expr:[109:3->109:27]
+posCursor:[109:24] posNoWhite:[109:23] Found pattern:[109:16->109:26]
+posCursor:[109:24] posNoWhite:[109:23] Found pattern:[109:23->109:25]
 Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
 [{
     "label": "first",
@@ -405,12 +405,12 @@ Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 111:28
+Complete src/CompletionPattern.res 112:28
 looking for: Cpath Value[b] 
-posCursor:[111:28] posNoWhite:[111:27] Found expr:[111:3->111:30]
-posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:16->111:29]
-posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:22->111:29]
-posCursor:[111:28] posNoWhite:[111:27] Found pattern:[111:27->111:28]
+posCursor:[112:28] posNoWhite:[112:27] Found expr:[112:3->112:30]
+posCursor:[112:28] posNoWhite:[112:27] Found pattern:[112:16->112:29]
+posCursor:[112:28] posNoWhite:[112:27] Found pattern:[112:22->112:29]
+posCursor:[112:28] posNoWhite:[112:27] Found pattern:[112:27->112:28]
 Completable: Cpattern Value[b]=t->polyvariantPayload::three($1)
 [{
     "label": "true",
@@ -420,7 +420,7 @@ Completable: Cpattern Value[b]=t->polyvariantPayload::three($1)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 117:15
+Complete src/CompletionPattern.res 118:15
 XXX Not found!
 Completable: Cpattern Value[c]
 [{
@@ -434,10 +434,10 @@ Completable: Cpattern Value[c]
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionPattern.res 120:17
+Complete src/CompletionPattern.res 121:17
 looking for: Cpath Value[c] 
-posCursor:[120:17] posNoWhite:[120:16] Found expr:[120:3->120:20]
-posCursor:[120:17] posNoWhite:[120:16] Found pattern:[120:16->120:18]
+posCursor:[121:17] posNoWhite:[121:16] Found expr:[121:3->121:20]
+posCursor:[121:17] posNoWhite:[121:16] Found pattern:[121:16->121:18]
 Completable: Cpattern Value[c]->array
 [{
     "label": "true",

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -74,11 +74,25 @@ Completable: Cpattern Value[x]=t
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 45:17
-looking for: Cpath Value[f] 
-posCursor:[45:17] posNoWhite:[45:16] Found expr:[45:3->45:19]
-posCursor:[45:17] posNoWhite:[45:16] Found pattern:[45:16->45:18]
+Complete src/CompletionPattern.res 45:15
+XXX Not found!
 Completable: Cpattern Value[f]
+[{
+    "label": "{}",
+    "kind": 12,
+    "tags": [],
+    "detail": "someRecord",
+    "documentation": null,
+    "sortText": "a",
+    "insertText": "{$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 48:17
+looking for: Cpath Value[f] 
+posCursor:[48:17] posNoWhite:[48:16] Found expr:[48:3->48:19]
+posCursor:[48:17] posNoWhite:[48:16] Found pattern:[48:16->48:18]
+Completable: Cpattern Value[f]->recordBody
 [{
     "label": "first",
     "kind": 5,
@@ -105,12 +119,12 @@ Completable: Cpattern Value[f]
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 48:19
+Complete src/CompletionPattern.res 51:19
 looking for: Cpath Value[f] 
-posCursor:[48:19] posNoWhite:[48:18] Found expr:[48:3->48:21]
-posCursor:[48:19] posNoWhite:[48:18] Found pattern:[48:16->48:20]
-posCursor:[48:19] posNoWhite:[48:18] Found pattern:[48:17->48:19]
-Completable: Cpattern Value[f]=fi
+posCursor:[51:19] posNoWhite:[51:18] Found expr:[51:3->51:21]
+posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:16->51:20]
+posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:17->51:19]
+Completable: Cpattern Value[f]=fi->recordBody
 [{
     "label": "first",
     "kind": 5,
@@ -119,13 +133,13 @@ Completable: Cpattern Value[f]=fi
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 51:19
+Complete src/CompletionPattern.res 54:19
 looking for: Cpath Value[z] 
-posCursor:[51:19] posNoWhite:[51:18] Found expr:[51:3->51:25]
-posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:16->51:24]
-posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:17->51:20]
-posCursor:[51:19] posNoWhite:[51:18] Found pattern:[51:18->51:19]
-Completable: Cpattern Value[z]=o->tuple($0)
+posCursor:[54:19] posNoWhite:[54:18] Found expr:[54:3->54:25]
+posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:16->54:24]
+posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:17->54:20]
+posCursor:[54:19] posNoWhite:[54:18] Found pattern:[54:18->54:19]
+Completable: Cpattern Value[z]=o->tuple($0), recordBody
 [{
     "label": "optThird",
     "kind": 5,
@@ -134,12 +148,28 @@ Completable: Cpattern Value[z]=o->tuple($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 54:24
+Complete src/CompletionPattern.res 57:22
 looking for: Cpath Value[f] 
-posCursor:[54:24] posNoWhite:[54:23] Found expr:[54:3->54:27]
-posCursor:[54:24] posNoWhite:[54:23] Found pattern:[54:16->54:26]
-posCursor:[54:24] posNoWhite:[54:23] Found pattern:[54:23->54:25]
+posCursor:[57:22] posNoWhite:[57:21] Found expr:[57:3->57:25]
+posCursor:[57:22] posNoWhite:[57:21] Found pattern:[57:16->57:25]
 Completable: Cpattern Value[f]->recordField(nest)
+[{
+    "label": "{}",
+    "kind": 12,
+    "tags": [],
+    "detail": "nestedRecord",
+    "documentation": null,
+    "sortText": "a",
+    "insertText": "{$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 60:24
+looking for: Cpath Value[f] 
+posCursor:[60:24] posNoWhite:[60:23] Found expr:[60:3->60:27]
+posCursor:[60:24] posNoWhite:[60:23] Found pattern:[60:16->60:26]
+posCursor:[60:24] posNoWhite:[60:23] Found pattern:[60:23->60:25]
+Completable: Cpattern Value[f]->recordField(nest), recordBody
 [{
     "label": "nested",
     "kind": 5,

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -390,3 +390,36 @@ Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
     "documentation": null
   }]
 
+Complete src/CompletionPattern.res 111:15
+XXX Not found!
+Completable: Cpattern Value[c]
+[{
+    "label": "[]",
+    "kind": 12,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "sortText": "a",
+    "insertText": "[$0]",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 114:17
+looking for: Cpath Value[c] 
+posCursor:[114:17] posNoWhite:[114:16] Found expr:[114:3->114:20]
+posCursor:[114:17] posNoWhite:[114:16] Found pattern:[114:16->114:18]
+Completable: Cpattern Value[c]->array
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -258,3 +258,69 @@ Completable: Cpattern Value[f]=n->recordField(nest), recordBody
     "documentation": null
   }]
 
+Complete src/CompletionPattern.res 86:20
+looking for: Cpath Value[z] 
+posCursor:[86:20] posNoWhite:[86:19] Found expr:[86:3->86:22]
+posCursor:[86:20] posNoWhite:[86:19] Found pattern:[86:16->86:21]
+posCursor:[86:20] posNoWhite:[86:19] Found pattern:[86:19->86:21]
+Completable: Cpattern Value[z]->variantPayload::Two($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 89:21
+looking for: Cpath Value[z] 
+posCursor:[89:21] posNoWhite:[89:20] Found expr:[89:3->89:23]
+posCursor:[89:21] posNoWhite:[89:20] Found pattern:[89:16->89:22]
+posCursor:[89:21] posNoWhite:[89:20] Found pattern:[89:20->89:21]
+Completable: Cpattern Value[z]=t->variantPayload::Two($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 92:23
+looking for: Cpath Value[z] 
+posCursor:[92:23] posNoWhite:[92:22] Found expr:[92:3->92:26]
+posCursor:[92:23] posNoWhite:[92:22] Found pattern:[92:16->92:25]
+posCursor:[92:23] posNoWhite:[92:22] Found pattern:[92:22->92:24]
+Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
+[{
+    "label": "first",
+    "kind": 5,
+    "tags": [],
+    "detail": "first: int\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "second",
+    "kind": 5,
+    "tags": [],
+    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "optThird",
+    "kind": 5,
+    "tags": [],
+    "detail": "optThird: option<[#second(someRecord) | #first]>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nest",
+    "kind": 5,
+    "tags": [],
+    "detail": "nest: nestedRecord\n\nsomeRecord",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -453,3 +453,23 @@ Completable: Cpattern Value[c]->array
     "documentation": null
   }]
 
+Complete src/CompletionPattern.res 127:21
+looking for: Cpath Value[o] 
+posCursor:[127:21] posNoWhite:[127:20] Found expr:[127:3->127:24]
+posCursor:[127:21] posNoWhite:[127:20] Found pattern:[127:16->127:22]
+posCursor:[127:21] posNoWhite:[127:20] Found pattern:[127:20->127:22]
+Completable: Cpattern Value[o]->variantPayload::Some($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -324,3 +324,69 @@ Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
     "documentation": null
   }]
 
+Complete src/CompletionPattern.res 99:21
+looking for: Cpath Value[b] 
+posCursor:[99:21] posNoWhite:[99:20] Found expr:[99:3->99:23]
+posCursor:[99:21] posNoWhite:[99:20] Found pattern:[99:16->99:22]
+posCursor:[99:21] posNoWhite:[99:20] Found pattern:[99:20->99:21]
+Completable: Cpattern Value[b]->polyvariantPayload::two($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 102:22
+looking for: Cpath Value[b] 
+posCursor:[102:22] posNoWhite:[102:21] Found expr:[102:3->102:24]
+posCursor:[102:22] posNoWhite:[102:21] Found pattern:[102:16->102:23]
+posCursor:[102:22] posNoWhite:[102:21] Found pattern:[102:21->102:22]
+Completable: Cpattern Value[b]=t->polyvariantPayload::two($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 105:24
+looking for: Cpath Value[b] 
+posCursor:[105:24] posNoWhite:[105:23] Found expr:[105:3->105:27]
+posCursor:[105:24] posNoWhite:[105:23] Found pattern:[105:16->105:26]
+posCursor:[105:24] posNoWhite:[105:23] Found pattern:[105:23->105:25]
+Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
+[{
+    "label": "first",
+    "kind": 5,
+    "tags": [],
+    "detail": "first: int\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "second",
+    "kind": 5,
+    "tags": [],
+    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "optThird",
+    "kind": 5,
+    "tags": [],
+    "detail": "optThird: option<[#second(someRecord) | #first]>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nest",
+    "kind": 5,
+    "tags": [],
+    "detail": "nest: nestedRecord\n\nsomeRecord",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -198,7 +198,6 @@ Completable: Cpattern Value[f]->recordField(nest), recordBody
   }]
 
 Complete src/CompletionPattern.res 70:22
-looking for: Cpath Value[f] 
 posCursor:[70:22] posNoWhite:[70:21] Found expr:[67:8->74:1]
 posCursor:[70:22] posNoWhite:[70:21] Found expr:[69:2->72:13]
 posCursor:[70:22] posNoWhite:[70:21] Found expr:[70:5->72:13]
@@ -673,6 +672,40 @@ Complete src/CompletionPattern.res 170:22
 looking for: Cpath Value[s] 
 posCursor:[170:22] posNoWhite:[170:21] Found expr:[170:3->170:30]
 posCursor:[170:22] posNoWhite:[170:21] Found pattern:[170:16->170:28]
+Completable: Cpattern Value[s]->tuple($1)
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 173:35
+XXX Not found!
+Completable: Cpattern Value[s]
+[{
+    "label": "(_, _, _)",
+    "kind": 12,
+    "tags": [],
+    "detail": "(bool, option<bool>, array<bool>)",
+    "documentation": null,
+    "insertText": "(${1:_}, ${2:_}, ${3:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionPattern.res 176:41
+looking for: Cpath Value[s] 
+posCursor:[176:41] posNoWhite:[176:40] Found expr:[176:3->176:50]
+posCursor:[176:41] posNoWhite:[176:40] Found pattern:[176:35->176:47]
 Completable: Cpattern Value[s]->tuple($1)
 [{
     "label": "None",

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -1,25 +1,25 @@
-Complete src/CompletionPattern.res 2:13
-posCursor:[2:13] posNoWhite:[2:12] Found expr:[2:3->2:13]
+Complete src/CompletionPattern.res 7:13
+posCursor:[7:13] posNoWhite:[7:12] Found expr:[7:3->7:13]
 []
 
-Complete src/CompletionPattern.res 5:15
+Complete src/CompletionPattern.res 10:15
 XXX Not found!
 Completable: Cpattern Value[v]
 [{
-    "label": "(_, _)",
+    "label": "(_, _, _)",
     "kind": 12,
     "tags": [],
-    "detail": "(bool, option<bool>)",
+    "detail": "(bool, option<bool>, (bool, bool))",
     "documentation": null,
-    "insertText": "(${1:_}, ${2:_})",
+    "insertText": "(${1:_}, ${2:_}, ${3:_})",
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionPattern.res 8:18
+Complete src/CompletionPattern.res 13:18
 looking for: Cpath Value[v] 
-posCursor:[8:18] posNoWhite:[8:17] Found expr:[8:3->8:24]
-posCursor:[8:18] posNoWhite:[8:17] Found pattern:[8:16->8:22]
-posCursor:[8:18] posNoWhite:[8:17] Found pattern:[8:17->8:18]
+posCursor:[13:18] posNoWhite:[13:17] Found expr:[13:3->13:24]
+posCursor:[13:18] posNoWhite:[13:17] Found pattern:[13:16->13:22]
+posCursor:[13:18] posNoWhite:[13:17] Found pattern:[13:17->13:18]
 Completable: Cpattern Value[v]=t->tuple($0)
 [{
     "label": "true",
@@ -29,14 +29,29 @@ Completable: Cpattern Value[v]=t->tuple($0)
     "documentation": null
   }]
 
-Complete src/CompletionPattern.res 13:16
-posCursor:[13:16] posNoWhite:[13:14] Found expr:[13:3->13:15]
+Complete src/CompletionPattern.res 16:25
+looking for: Cpath Value[v] 
+posCursor:[16:25] posNoWhite:[16:24] Found expr:[16:3->16:32]
+posCursor:[16:25] posNoWhite:[16:24] Found pattern:[16:16->16:30]
+posCursor:[16:25] posNoWhite:[16:24] Found pattern:[16:23->16:29]
+posCursor:[16:25] posNoWhite:[16:24] Found pattern:[16:24->16:25]
+Completable: Cpattern Value[v]=f->tuple($2), tuple($0)
+[{
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionPattern.res 21:16
+posCursor:[21:16] posNoWhite:[21:14] Found expr:[21:3->21:15]
 []
 
-Complete src/CompletionPattern.res 16:17
+Complete src/CompletionPattern.res 24:17
 looking for: Cpath Value[x] 
-posCursor:[16:17] posNoWhite:[16:16] Found expr:[16:3->16:17]
-posCursor:[16:17] posNoWhite:[16:16] Found pattern:[16:16->16:17]
+posCursor:[24:17] posNoWhite:[24:16] Found expr:[24:3->24:17]
+posCursor:[24:17] posNoWhite:[24:16] Found pattern:[24:16->24:17]
 Completable: Cpattern Value[x]=t
 [{
     "label": "true",


### PR DESCRIPTION
This isn't complete yet, but I want to validate the approach with you @cristianoc before I continue deeper. This PR does the following:
- Introduces the concept of pattern completion
- Adds logic for tracking what type we're at in the current pattern. Currently handles tuples and record fields, but will eventually handle everything that can appear in a pattern (like variant/polyvariant constructors + payloads, options, array literals, etc)
