### PR TITLE
complete for functions creating React.element when in a JSX context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add support for completion in patterns. https://github.com/rescript-lang/rescript-vscode/pull/670
 - Add support for pattern completion of unsaved tuples. https://github.com/rescript-lang/rescript-vscode/pull/679
 - Add support for completion in typed expressions. https://github.com/rescript-lang/rescript-vscode/pull/682
+- Complete for `React.element` creator functions (`React.string` etc) when in JSX context. https://github.com/rescript-lang/rescript-vscode/pull/681
 
 #### :nail_care: Polish
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1626,9 +1626,15 @@ let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
           when checkName builtinNameToComplete ~prefix:funNamePrefix
                  ~exact:false ->
           [
-            Completion.create
+            Completion.createWithSnippet
               ~name:("React." ^ builtinNameToComplete)
-              ~kind:(Value typ) ~env;
+              ~kind:(Value typ) ~env
+              ~docstring:
+                [
+                  "Turns `" ^ builtinNameToComplete
+                  ^ "` into `React.element` so it can be used inside of JSX.";
+                ]
+              ();
           ]
           @ completions
         | _ -> completions)

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1628,7 +1628,7 @@ let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
           [
             Completion.createWithSnippet
               ~name:("React." ^ builtinNameToComplete)
-              ~kind:(Value typ) ~env
+              ~kind:(Value typ) ~env ~sortText:"A"
               ~docstring:
                 [
                   "Turns `" ^ builtinNameToComplete

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1611,15 +1611,15 @@ let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
         in
         (* We add React element functions to the completion if we're in a JSX context *)
         let forJsxCompletion =
-          match (inJsx, getTypePath typ) with
-          | true, Some (Path.Pident id) when Ident.name id = "int" -> Some "int"
-          | true, Some (Path.Pident id) when Ident.name id = "float" ->
-            Some "float"
-          | true, Some (Path.Pident id) when Ident.name id = "string" ->
-            Some "string"
-          | true, Some (Path.Pident id) when Ident.name id = "array" ->
-            Some "array"
-          | _ -> None
+          if inJsx then
+            match getTypePath typ with
+            | Some (Path.Pident id) when Ident.name id = "int" -> Some "int"
+            | Some (Path.Pident id) when Ident.name id = "float" -> Some "float"
+            | Some (Path.Pident id) when Ident.name id = "string" ->
+              Some "string"
+            | Some (Path.Pident id) when Ident.name id = "array" -> Some "array"
+            | _ -> None
+          else None
         in
         match forJsxCompletion with
         | Some builtinNameToComplete

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1618,18 +1618,7 @@ let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
           | true, Some (Path.Pident id) when Ident.name id = "string" ->
             Some "string"
           | true, Some (Path.Pident id) when Ident.name id = "array" ->
-            (* Make sure the array contains React.element *)
-            let isReactElementArray =
-              match typ |> extractType ~env ~package with
-              | Some (Tarray (_env, payload)) -> (
-                match
-                  payload |> getTypePath |> Option.map pathIdentToString
-                with
-                | Some "React.element" -> true
-                | _ -> false)
-              | _ -> false
-            in
-            if isReactElementArray then Some "array" else None
+            Some "array"
           | _ -> None
         in
         match forJsxCompletion with

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -1038,11 +1038,10 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
   in
   let value_binding (iterator : Ast_iterator.iterator)
       (value_binding : Parsetree.value_binding) =
-    if
-      locHasCursor value_binding.pvb_expr.pexp_loc
-      && Utils.isReactComponent value_binding
-    then inJsxContext := true;
-    Ast_iterator.default_iterator.value_binding iterator value_binding
+    let oldInJsxContext = !inJsxContext in
+    if Utils.isReactComponent value_binding then inJsxContext := true;
+    Ast_iterator.default_iterator.value_binding iterator value_binding;
+    inJsxContext := oldInJsxContext
   in
   let signature (iterator : Ast_iterator.iterator)
       (signature : Parsetree.signature) =
@@ -1120,6 +1119,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
     Ast_iterator.default_iterator.attribute iterator (id, payload)
   in
   let expr (iterator : Ast_iterator.iterator) (expr : Parsetree.expression) =
+    let oldInJsxContext = !inJsxContext in
     let processed = ref false in
     let setFound () =
       found := true;
@@ -1379,6 +1379,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
           processed := true
         | _ -> ());
       if not !processed then Ast_iterator.default_iterator.expr iterator expr
+      else inJsxContext := oldInJsxContext
   in
   let typ (iterator : Ast_iterator.iterator) (core_type : Parsetree.core_type) =
     if core_type.ptyp_loc |> Loc.hasPos ~pos:posNoWhite then (

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -1378,8 +1378,8 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
           scope := oldScope;
           processed := true
         | _ -> ());
-      if not !processed then Ast_iterator.default_iterator.expr iterator expr
-      else inJsxContext := oldInJsxContext
+      if not !processed then Ast_iterator.default_iterator.expr iterator expr;
+      inJsxContext := oldInJsxContext
   in
   let typ (iterator : Ast_iterator.iterator) (core_type : Parsetree.core_type) =
     if core_type.ptyp_loc |> Loc.hasPos ~pos:posNoWhite then (

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -546,6 +546,7 @@ module Completable = struct
     | CPPipe of {
         contextPath: contextPath;
         id: string;
+        inJsx: bool;  (** Whether this pipe was found in a JSX context. *)
         lhsLoc: Location.t;
             (** The loc item for the left hand side of the pipe. *)
       }
@@ -648,7 +649,10 @@ module Completable = struct
         completionContextToString completionContext ^ list sl
       | CPField (cp, s) -> contextPathToString cp ^ "." ^ str s
       | CPObj (cp, s) -> contextPathToString cp ^ "[\"" ^ s ^ "\"]"
-      | CPPipe {contextPath; id} -> contextPathToString contextPath ^ "->" ^ id
+      | CPPipe {contextPath; id; inJsx} ->
+        contextPathToString contextPath
+        ^ "->" ^ id
+        ^ if inJsx then " <<jsx>>" else ""
       | CTuple ctxPaths ->
         "CTuple("
         ^ (ctxPaths |> List.map contextPathToString |> String.concat ", ")

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -316,12 +316,13 @@ module Completion = struct
       insertTextFormat = None;
     }
 
-  let createWithSnippet ~name ?insertText ~kind ~env ?sortText () =
+  let createWithSnippet ~name ?insertText ~kind ~env ?sortText ?(docstring = [])
+      () =
     {
       name;
       env;
       deprecated = None;
-      docstring = [];
+      docstring;
       kind;
       sortText;
       insertText;

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -168,3 +168,8 @@ let rec unwrapIfOption (t : Types.type_expr) =
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> unwrapIfOption t1
   | Tconstr (Path.Pident {name = "option"}, [unwrappedType], _) -> unwrappedType
   | _ -> t
+let isReactComponent (vb : Parsetree.value_binding) =
+  vb.pvb_attributes
+  |> List.exists (function
+       | {Location.txt = "react.component"}, _payload -> true
+       | _ -> false)

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -212,13 +212,8 @@ module AddTypeAnnotation = struct
       match si.pstr_desc with
       | Pstr_value (_recFlag, bindings) ->
         let processBinding (vb : Parsetree.value_binding) =
-          let isReactComponent =
-            (* Can't add a type annotation to a react component, or the compiler crashes *)
-            vb.pvb_attributes
-            |> List.exists (function
-                 | {Location.txt = "react.component"}, _payload -> true
-                 | _ -> false)
-          in
+          (* Can't add a type annotation to a react component, or the compiler crashes *)
+          let isReactComponent = Utils.isReactComponent vb in
           if not isReactComponent then processPattern vb.pvb_pat;
           processFunction vb.pvb_expr
         in

--- a/analysis/tests/src/CompletionJsx.res
+++ b/analysis/tests/src/CompletionJsx.res
@@ -1,0 +1,37 @@
+let someString = "hello"
+ignore(someString)
+
+// someString->st
+//               ^com
+
+module SomeComponent = {
+  @react.component
+  let make = (~someProp) => {
+    let someInt = 12
+    let someArr = [React.null]
+    let someInvalidArr = [12]
+    ignore(someInt)
+    ignore(someArr)
+    ignore(someInvalidArr)
+    // someString->st
+    //               ^com
+    <div>
+      {React.string(someProp)}
+      <div> {React.null} </div>
+      // {someString->st}
+      //                ^com
+      // {"Some string"->st}
+      //                   ^com
+      // {"Some string"->Js.String2.trim->st}
+      //                                    ^com
+      // {someInt->}
+      //           ^com
+      // {12->}
+      //      ^com
+      // {someArr->a}
+      //            ^com
+      // {someInvalidArr->a}
+      //                   ^com
+    </div>
+  }
+}

--- a/analysis/tests/src/CompletionJsx.res
+++ b/analysis/tests/src/CompletionJsx.res
@@ -9,10 +9,8 @@ module SomeComponent = {
   let make = (~someProp) => {
     let someInt = 12
     let someArr = [React.null]
-    let someInvalidArr = [12]
     ignore(someInt)
     ignore(someArr)
-    ignore(someInvalidArr)
     // someString->st
     //               ^com
     <div>
@@ -30,8 +28,6 @@ module SomeComponent = {
       //      ^com
       // {someArr->a}
       //            ^com
-      // {someInvalidArr->a}
-      //                   ^com
     </div>
   }
 }

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -29,7 +29,8 @@ Completable: Cpath Value[someString]->st <<jsx>>
     "kind": 12,
     "tags": [],
     "detail": "string",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "Turns `string` into `React.element` so it can be used inside of JSX."},
+    "insertTextFormat": 2
   }, {
     "label": "Js.String2.startsWith",
     "kind": 12,
@@ -68,7 +69,8 @@ Completable: Cpath Value[someString]->st <<jsx>>
     "kind": 12,
     "tags": [],
     "detail": "string",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "Turns `string` into `React.element` so it can be used inside of JSX."},
+    "insertTextFormat": 2
   }, {
     "label": "Js.String2.startsWith",
     "kind": 12,
@@ -107,7 +109,8 @@ Completable: Cpath string->st <<jsx>>
     "kind": 12,
     "tags": [],
     "detail": "string",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "Turns `string` into `React.element` so it can be used inside of JSX."},
+    "insertTextFormat": 2
   }, {
     "label": "Js.String2.startsWith",
     "kind": 12,
@@ -146,7 +149,8 @@ Completable: Cpath Value[Js, String2, trim](Nolabel)->st <<jsx>>
     "kind": 12,
     "tags": [],
     "detail": "string",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "Turns `string` into `React.element` so it can be used inside of JSX."},
+    "insertTextFormat": 2
   }, {
     "label": "Js.String2.startsWith",
     "kind": 12,
@@ -185,7 +189,8 @@ Completable: Cpath Value[someInt]-> <<jsx>>
     "kind": 12,
     "tags": [],
     "detail": "int",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "Turns `int` into `React.element` so it can be used inside of JSX."},
+    "insertTextFormat": 2
   }, {
     "label": "Belt.Int.fromString",
     "kind": 12,
@@ -260,7 +265,8 @@ Completable: Cpath int-> <<jsx>>
     "kind": 12,
     "tags": [],
     "detail": "int",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "Turns `int` into `React.element` so it can be used inside of JSX."},
+    "insertTextFormat": 2
   }, {
     "label": "Belt.Int.fromString",
     "kind": 12,
@@ -335,7 +341,8 @@ Completable: Cpath Value[someArr]->a <<jsx>>
     "kind": 12,
     "tags": [],
     "detail": "array<React.element>",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "Turns `array` into `React.element` so it can be used inside of JSX."},
+    "insertTextFormat": 2
   }, {
     "label": "Js.Array2.append",
     "kind": 12,

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -1,0 +1,389 @@
+Complete src/CompletionJsx.res 3:17
+posCursor:[3:17] posNoWhite:[3:16] Found expr:[3:3->3:17]
+Completable: Cpath Value[someString]->st
+[{
+    "label": "Js.String2.startsWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWith(\"BuckleScript\", \"Buckle\") == true\nJs.String2.startsWith(\"BuckleScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
+  }, {
+    "label": "Js.String2.startsWithFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
+  }]
+
+Complete src/CompletionJsx.res 15:21
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[8:13->35:3]
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[9:4->34:10]
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[10:4->34:10]
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[11:4->34:10]
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[12:4->34:10]
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[13:4->34:10]
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[14:4->34:10]
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[15:7->34:10]
+posCursor:[15:21] posNoWhite:[15:20] Found expr:[15:7->15:21]
+Completable: Cpath Value[someString]->st <<jsx>>
+[{
+    "label": "React.string",
+    "kind": 12,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }, {
+    "label": "Js.String2.startsWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWith(\"BuckleScript\", \"Buckle\") == true\nJs.String2.startsWith(\"BuckleScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
+  }, {
+    "label": "Js.String2.startsWithFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
+  }]
+
+Complete src/CompletionJsx.res 20:24
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[8:13->35:3]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[9:4->34:10]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[10:4->34:10]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[11:4->34:10]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[12:4->34:10]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[13:4->34:10]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[14:4->34:10]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[17:5->34:10]
+JSX <div:[17:5->17:8] > _children:17:8
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[17:8->34:4]
+Pexp_construct :::[18:7->34:4] [18:7->34:4]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[18:7->34:4]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[19:7->34:4]
+Pexp_construct :::[19:7->34:4] [19:7->34:4]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[19:7->34:4]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[20:10->34:4]
+Pexp_construct :::[20:10->34:4] [20:10->34:4]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[20:10->34:4]
+posCursor:[20:24] posNoWhite:[20:23] Found expr:[20:10->20:24]
+Completable: Cpath Value[someString]->st <<jsx>>
+[{
+    "label": "React.string",
+    "kind": 12,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }, {
+    "label": "Js.String2.startsWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWith(\"BuckleScript\", \"Buckle\") == true\nJs.String2.startsWith(\"BuckleScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
+  }, {
+    "label": "Js.String2.startsWithFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
+  }]
+
+Complete src/CompletionJsx.res 22:27
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[8:13->35:3]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[9:4->34:10]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[10:4->34:10]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[11:4->34:10]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[12:4->34:10]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[13:4->34:10]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[14:4->34:10]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[17:5->34:10]
+JSX <div:[17:5->17:8] > _children:17:8
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[17:8->34:4]
+Pexp_construct :::[18:7->34:4] [18:7->34:4]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[18:7->34:4]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[19:7->34:4]
+Pexp_construct :::[19:7->34:4] [19:7->34:4]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[19:7->34:4]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[22:10->34:4]
+Pexp_construct :::[22:10->34:4] [22:10->34:4]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[22:10->34:4]
+posCursor:[22:27] posNoWhite:[22:26] Found expr:[22:10->22:27]
+Completable: Cpath string->st <<jsx>>
+[{
+    "label": "React.string",
+    "kind": 12,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }, {
+    "label": "Js.String2.startsWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWith(\"BuckleScript\", \"Buckle\") == true\nJs.String2.startsWith(\"BuckleScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
+  }, {
+    "label": "Js.String2.startsWithFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
+  }]
+
+Complete src/CompletionJsx.res 24:44
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[8:13->35:3]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[9:4->34:10]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[10:4->34:10]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[11:4->34:10]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[12:4->34:10]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[13:4->34:10]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[14:4->34:10]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[17:5->34:10]
+JSX <div:[17:5->17:8] > _children:17:8
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[17:8->34:4]
+Pexp_construct :::[18:7->34:4] [18:7->34:4]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[18:7->34:4]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[19:7->34:4]
+Pexp_construct :::[19:7->34:4] [19:7->34:4]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[19:7->34:4]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[24:10->34:4]
+Pexp_construct :::[24:10->34:4] [24:10->34:4]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[24:10->34:4]
+posCursor:[24:44] posNoWhite:[24:43] Found expr:[24:10->24:44]
+Completable: Cpath Value[Js, String2, trim](Nolabel)->st <<jsx>>
+[{
+    "label": "React.string",
+    "kind": 12,
+    "tags": [],
+    "detail": "string",
+    "documentation": null
+  }, {
+    "label": "Js.String2.startsWith",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWith(str, substr)` returns `true` if the `str` starts with\n`substr`, `false` otherwise.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWith(\"BuckleScript\", \"Buckle\") == true\nJs.String2.startsWith(\"BuckleScript\", \"\") == true\nJs.String2.startsWith(\"JavaScript\", \"Buckle\") == false\n```\n"}
+  }, {
+    "label": "Js.String2.startsWithFrom",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, t, int) => bool",
+    "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
+  }]
+
+Complete src/CompletionJsx.res 26:19
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[8:13->35:3]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[9:4->34:10]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[10:4->34:10]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[11:4->34:10]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[12:4->34:10]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[13:4->34:10]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[14:4->34:10]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[17:5->34:10]
+JSX <div:[17:5->17:8] > _children:17:8
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[17:8->34:4]
+Pexp_construct :::[18:7->34:4] [18:7->34:4]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[18:7->34:4]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[19:7->34:4]
+Pexp_construct :::[19:7->34:4] [19:7->34:4]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[19:7->34:4]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[26:10->34:4]
+Pexp_construct :::[26:10->34:4] [26:10->34:4]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[26:10->34:4]
+posCursor:[26:19] posNoWhite:[26:18] Found expr:[26:10->0:-1]
+Completable: Cpath Value[someInt]-> <<jsx>>
+[{
+    "label": "React.int",
+    "kind": 12,
+    "tags": [],
+    "detail": "int",
+    "documentation": null
+  }, {
+    "label": "Belt.Int.fromString",
+    "kind": 12,
+    "tags": [],
+    "detail": "string => option<int>",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `string` to an `int`. Returns `Some(int)` when the input is a number, `None` otherwise.\n\n  ```res example\n  Js.log(Belt.Int.fromString(\"1\") === Some(1)) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.*",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Multiplication of two `int` values. Same as the multiplication from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 * 2 === 4) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int./",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Division of two `int` values. Same as the division from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(4 / 2 === 2); /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n  ```res example\n  Js.log(Belt.Int.toString(1) === \"1\") /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.toFloat",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => float",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `int` to a `float`.\n\n  ```res example\n  Js.log(Belt.Int.toFloat(1) === 1.0) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.fromFloat",
+    "kind": 12,
+    "tags": [],
+    "detail": "float => int",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `float` to an `int`.\n\n  ```res example\n  Js.log(Belt.Int.fromFloat(1.0) === 1) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.-",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Subtraction of two `int` values. Same as the subtraction from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 - 1 === 1) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.+",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Addition of two `int` values. Same as the addition from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 + 2 === 4) /* true */\n  ```\n"}
+  }]
+
+Complete src/CompletionJsx.res 28:14
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[8:13->35:3]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[9:4->34:10]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[10:4->34:10]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[11:4->34:10]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[12:4->34:10]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[13:4->34:10]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[14:4->34:10]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[17:5->34:10]
+JSX <div:[17:5->17:8] > _children:17:8
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[17:8->34:4]
+Pexp_construct :::[18:7->34:4] [18:7->34:4]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[18:7->34:4]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[19:7->34:4]
+Pexp_construct :::[19:7->34:4] [19:7->34:4]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[19:7->34:4]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[28:10->34:4]
+Pexp_construct :::[28:10->34:4] [28:10->34:4]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[28:10->34:4]
+posCursor:[28:14] posNoWhite:[28:13] Found expr:[28:10->0:-1]
+Completable: Cpath int-> <<jsx>>
+[{
+    "label": "React.int",
+    "kind": 12,
+    "tags": [],
+    "detail": "int",
+    "documentation": null
+  }, {
+    "label": "Belt.Int.fromString",
+    "kind": 12,
+    "tags": [],
+    "detail": "string => option<int>",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `string` to an `int`. Returns `Some(int)` when the input is a number, `None` otherwise.\n\n  ```res example\n  Js.log(Belt.Int.fromString(\"1\") === Some(1)) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.*",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Multiplication of two `int` values. Same as the multiplication from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 * 2 === 4) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int./",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Division of two `int` values. Same as the division from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(4 / 2 === 2); /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.toString",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => string",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `int` to a `string`. Uses the JavaScript `String` constructor under the hood.\n\n  ```res example\n  Js.log(Belt.Int.toString(1) === \"1\") /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.toFloat",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => float",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `int` to a `float`.\n\n  ```res example\n  Js.log(Belt.Int.toFloat(1) === 1.0) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.fromFloat",
+    "kind": 12,
+    "tags": [],
+    "detail": "float => int",
+    "documentation": {"kind": "markdown", "value": "\n  Converts a given `float` to an `int`.\n\n  ```res example\n  Js.log(Belt.Int.fromFloat(1.0) === 1) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.-",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Subtraction of two `int` values. Same as the subtraction from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 - 1 === 1) /* true */\n  ```\n"}
+  }, {
+    "label": "Belt.Int.+",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, int) => int",
+    "documentation": {"kind": "markdown", "value": "\n  Addition of two `int` values. Same as the addition from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 + 2 === 4) /* true */\n  ```\n"}
+  }]
+
+Complete src/CompletionJsx.res 30:20
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[8:13->35:3]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[9:4->34:10]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[10:4->34:10]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[11:4->34:10]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[12:4->34:10]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[13:4->34:10]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[14:4->34:10]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[17:5->34:10]
+JSX <div:[17:5->17:8] > _children:17:8
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[17:8->34:4]
+Pexp_construct :::[18:7->34:4] [18:7->34:4]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[18:7->34:4]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[19:7->34:4]
+Pexp_construct :::[19:7->34:4] [19:7->34:4]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[19:7->34:4]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[30:10->34:4]
+Pexp_construct :::[30:10->34:4] [30:10->34:4]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[30:10->34:4]
+posCursor:[30:20] posNoWhite:[30:19] Found expr:[30:10->30:20]
+Completable: Cpath Value[someArr]->a <<jsx>>
+[{
+    "label": "React.array",
+    "kind": 12,
+    "tags": [],
+    "detail": "array<React.element>",
+    "documentation": null
+  }, {
+    "label": "Js.Array2.append",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: `append` is not type-safe. Use `concat` instead.\n\n"}
+  }]
+
+Complete src/CompletionJsx.res 32:27
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[8:13->35:3]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[9:4->34:10]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[10:4->34:10]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[11:4->34:10]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[12:4->34:10]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[13:4->34:10]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[14:4->34:10]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[17:5->34:10]
+JSX <div:[17:5->17:8] > _children:17:8
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[17:8->34:4]
+Pexp_construct :::[18:7->34:4] [18:7->34:4]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[18:7->34:4]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[19:7->34:4]
+Pexp_construct :::[19:7->34:4] [19:7->34:4]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[19:7->34:4]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[32:10->34:4]
+Pexp_construct :::[32:10->34:4] [32:10->34:4]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[32:10->34:4]
+posCursor:[32:27] posNoWhite:[32:26] Found expr:[32:10->32:27]
+Completable: Cpath Value[someInvalidArr]->a <<jsx>>
+[{
+    "label": "Js.Array2.append",
+    "kind": 12,
+    "tags": [1],
+    "detail": "(t<'a>, 'a) => t<'a>",
+    "documentation": {"kind": "markdown", "value": "Deprecated: `append` is not type-safe. Use `concat` instead.\n\n"}
+  }]
+

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -15,16 +15,14 @@ Completable: Cpath Value[someString]->st
     "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
-Complete src/CompletionJsx.res 15:21
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[8:13->35:3]
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[9:4->34:10]
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[10:4->34:10]
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[11:4->34:10]
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[12:4->34:10]
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[13:4->34:10]
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[14:4->34:10]
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[15:7->34:10]
-posCursor:[15:21] posNoWhite:[15:20] Found expr:[15:7->15:21]
+Complete src/CompletionJsx.res 13:21
+posCursor:[13:21] posNoWhite:[13:20] Found expr:[8:13->31:3]
+posCursor:[13:21] posNoWhite:[13:20] Found expr:[9:4->30:10]
+posCursor:[13:21] posNoWhite:[13:20] Found expr:[10:4->30:10]
+posCursor:[13:21] posNoWhite:[13:20] Found expr:[11:4->30:10]
+posCursor:[13:21] posNoWhite:[13:20] Found expr:[12:4->30:10]
+posCursor:[13:21] posNoWhite:[13:20] Found expr:[13:7->30:10]
+posCursor:[13:21] posNoWhite:[13:20] Found expr:[13:7->13:21]
 Completable: Cpath Value[someString]->st <<jsx>>
 [{
     "label": "React.string",
@@ -46,26 +44,24 @@ Completable: Cpath Value[someString]->st <<jsx>>
     "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
-Complete src/CompletionJsx.res 20:24
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[8:13->35:3]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[9:4->34:10]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[10:4->34:10]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[11:4->34:10]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[12:4->34:10]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[13:4->34:10]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[14:4->34:10]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[17:5->34:10]
-JSX <div:[17:5->17:8] > _children:17:8
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[17:8->34:4]
-Pexp_construct :::[18:7->34:4] [18:7->34:4]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[18:7->34:4]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[19:7->34:4]
-Pexp_construct :::[19:7->34:4] [19:7->34:4]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[19:7->34:4]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[20:10->34:4]
-Pexp_construct :::[20:10->34:4] [20:10->34:4]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[20:10->34:4]
-posCursor:[20:24] posNoWhite:[20:23] Found expr:[20:10->20:24]
+Complete src/CompletionJsx.res 18:24
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[8:13->31:3]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[9:4->30:10]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[10:4->30:10]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[11:4->30:10]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[12:4->30:10]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[15:5->30:10]
+JSX <div:[15:5->15:8] > _children:15:8
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[15:8->30:4]
+Pexp_construct :::[16:7->30:4] [16:7->30:4]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[16:7->30:4]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[17:7->30:4]
+Pexp_construct :::[17:7->30:4] [17:7->30:4]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[17:7->30:4]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[18:10->30:4]
+Pexp_construct :::[18:10->30:4] [18:10->30:4]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[18:10->30:4]
+posCursor:[18:24] posNoWhite:[18:23] Found expr:[18:10->18:24]
 Completable: Cpath Value[someString]->st <<jsx>>
 [{
     "label": "React.string",
@@ -87,26 +83,24 @@ Completable: Cpath Value[someString]->st <<jsx>>
     "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
-Complete src/CompletionJsx.res 22:27
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[8:13->35:3]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[9:4->34:10]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[10:4->34:10]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[11:4->34:10]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[12:4->34:10]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[13:4->34:10]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[14:4->34:10]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[17:5->34:10]
-JSX <div:[17:5->17:8] > _children:17:8
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[17:8->34:4]
-Pexp_construct :::[18:7->34:4] [18:7->34:4]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[18:7->34:4]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[19:7->34:4]
-Pexp_construct :::[19:7->34:4] [19:7->34:4]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[19:7->34:4]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[22:10->34:4]
-Pexp_construct :::[22:10->34:4] [22:10->34:4]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[22:10->34:4]
-posCursor:[22:27] posNoWhite:[22:26] Found expr:[22:10->22:27]
+Complete src/CompletionJsx.res 20:27
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[8:13->31:3]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[9:4->30:10]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[10:4->30:10]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[11:4->30:10]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[12:4->30:10]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[15:5->30:10]
+JSX <div:[15:5->15:8] > _children:15:8
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[15:8->30:4]
+Pexp_construct :::[16:7->30:4] [16:7->30:4]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[16:7->30:4]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[17:7->30:4]
+Pexp_construct :::[17:7->30:4] [17:7->30:4]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[17:7->30:4]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[20:10->30:4]
+Pexp_construct :::[20:10->30:4] [20:10->30:4]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[20:10->30:4]
+posCursor:[20:27] posNoWhite:[20:26] Found expr:[20:10->20:27]
 Completable: Cpath string->st <<jsx>>
 [{
     "label": "React.string",
@@ -128,26 +122,24 @@ Completable: Cpath string->st <<jsx>>
     "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
-Complete src/CompletionJsx.res 24:44
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[8:13->35:3]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[9:4->34:10]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[10:4->34:10]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[11:4->34:10]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[12:4->34:10]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[13:4->34:10]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[14:4->34:10]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[17:5->34:10]
-JSX <div:[17:5->17:8] > _children:17:8
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[17:8->34:4]
-Pexp_construct :::[18:7->34:4] [18:7->34:4]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[18:7->34:4]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[19:7->34:4]
-Pexp_construct :::[19:7->34:4] [19:7->34:4]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[19:7->34:4]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[24:10->34:4]
-Pexp_construct :::[24:10->34:4] [24:10->34:4]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[24:10->34:4]
-posCursor:[24:44] posNoWhite:[24:43] Found expr:[24:10->24:44]
+Complete src/CompletionJsx.res 22:44
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[8:13->31:3]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[9:4->30:10]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[10:4->30:10]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[11:4->30:10]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[12:4->30:10]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[15:5->30:10]
+JSX <div:[15:5->15:8] > _children:15:8
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[15:8->30:4]
+Pexp_construct :::[16:7->30:4] [16:7->30:4]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[16:7->30:4]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[17:7->30:4]
+Pexp_construct :::[17:7->30:4] [17:7->30:4]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[17:7->30:4]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[22:10->30:4]
+Pexp_construct :::[22:10->30:4] [22:10->30:4]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[22:10->30:4]
+posCursor:[22:44] posNoWhite:[22:43] Found expr:[22:10->22:44]
 Completable: Cpath Value[Js, String2, trim](Nolabel)->st <<jsx>>
 [{
     "label": "React.string",
@@ -169,26 +161,24 @@ Completable: Cpath Value[Js, String2, trim](Nolabel)->st <<jsx>>
     "documentation": {"kind": "markdown", "value": "\nES2015: `startsWithFrom(str, substr, n)` returns `true` if the `str` starts\nwith `substr` starting at position `n`, false otherwise. If `n` is negative,\nthe search starts at the beginning of `str`.\n\nSee [`String.startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith)\non MDN.\n\n```res example\nJs.String2.startsWithFrom(\"BuckleScript\", \"kle\", 3) == true\nJs.String2.startsWithFrom(\"BuckleScript\", \"\", 3) == true\nJs.String2.startsWithFrom(\"JavaScript\", \"Buckle\", 2) == false\n```\n"}
   }]
 
-Complete src/CompletionJsx.res 26:19
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[8:13->35:3]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[9:4->34:10]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[10:4->34:10]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[11:4->34:10]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[12:4->34:10]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[13:4->34:10]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[14:4->34:10]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[17:5->34:10]
-JSX <div:[17:5->17:8] > _children:17:8
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[17:8->34:4]
-Pexp_construct :::[18:7->34:4] [18:7->34:4]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[18:7->34:4]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[19:7->34:4]
-Pexp_construct :::[19:7->34:4] [19:7->34:4]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[19:7->34:4]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[26:10->34:4]
-Pexp_construct :::[26:10->34:4] [26:10->34:4]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[26:10->34:4]
-posCursor:[26:19] posNoWhite:[26:18] Found expr:[26:10->0:-1]
+Complete src/CompletionJsx.res 24:19
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[8:13->31:3]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[9:4->30:10]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[10:4->30:10]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[11:4->30:10]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[12:4->30:10]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[15:5->30:10]
+JSX <div:[15:5->15:8] > _children:15:8
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[15:8->30:4]
+Pexp_construct :::[16:7->30:4] [16:7->30:4]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[16:7->30:4]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[17:7->30:4]
+Pexp_construct :::[17:7->30:4] [17:7->30:4]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[17:7->30:4]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[24:10->30:4]
+Pexp_construct :::[24:10->30:4] [24:10->30:4]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[24:10->30:4]
+posCursor:[24:19] posNoWhite:[24:18] Found expr:[24:10->0:-1]
 Completable: Cpath Value[someInt]-> <<jsx>>
 [{
     "label": "React.int",
@@ -246,26 +236,24 @@ Completable: Cpath Value[someInt]-> <<jsx>>
     "documentation": {"kind": "markdown", "value": "\n  Addition of two `int` values. Same as the addition from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 + 2 === 4) /* true */\n  ```\n"}
   }]
 
-Complete src/CompletionJsx.res 28:14
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[8:13->35:3]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[9:4->34:10]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[10:4->34:10]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[11:4->34:10]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[12:4->34:10]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[13:4->34:10]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[14:4->34:10]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[17:5->34:10]
-JSX <div:[17:5->17:8] > _children:17:8
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[17:8->34:4]
-Pexp_construct :::[18:7->34:4] [18:7->34:4]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[18:7->34:4]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[19:7->34:4]
-Pexp_construct :::[19:7->34:4] [19:7->34:4]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[19:7->34:4]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[28:10->34:4]
-Pexp_construct :::[28:10->34:4] [28:10->34:4]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[28:10->34:4]
-posCursor:[28:14] posNoWhite:[28:13] Found expr:[28:10->0:-1]
+Complete src/CompletionJsx.res 26:14
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[8:13->31:3]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[9:4->30:10]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[10:4->30:10]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[11:4->30:10]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[12:4->30:10]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[15:5->30:10]
+JSX <div:[15:5->15:8] > _children:15:8
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[15:8->30:4]
+Pexp_construct :::[16:7->30:4] [16:7->30:4]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[16:7->30:4]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[17:7->30:4]
+Pexp_construct :::[17:7->30:4] [17:7->30:4]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[17:7->30:4]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[26:10->30:4]
+Pexp_construct :::[26:10->30:4] [26:10->30:4]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[26:10->30:4]
+posCursor:[26:14] posNoWhite:[26:13] Found expr:[26:10->0:-1]
 Completable: Cpath int-> <<jsx>>
 [{
     "label": "React.int",
@@ -323,26 +311,24 @@ Completable: Cpath int-> <<jsx>>
     "documentation": {"kind": "markdown", "value": "\n  Addition of two `int` values. Same as the addition from `Pervasives`.\n\n  ```res example\n  open Belt.Int\n  Js.log(2 + 2 === 4) /* true */\n  ```\n"}
   }]
 
-Complete src/CompletionJsx.res 30:20
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[8:13->35:3]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[9:4->34:10]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[10:4->34:10]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[11:4->34:10]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[12:4->34:10]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[13:4->34:10]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[14:4->34:10]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[17:5->34:10]
-JSX <div:[17:5->17:8] > _children:17:8
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[17:8->34:4]
-Pexp_construct :::[18:7->34:4] [18:7->34:4]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[18:7->34:4]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[19:7->34:4]
-Pexp_construct :::[19:7->34:4] [19:7->34:4]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[19:7->34:4]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[30:10->34:4]
-Pexp_construct :::[30:10->34:4] [30:10->34:4]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[30:10->34:4]
-posCursor:[30:20] posNoWhite:[30:19] Found expr:[30:10->30:20]
+Complete src/CompletionJsx.res 28:20
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[8:13->31:3]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[9:4->30:10]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[10:4->30:10]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[11:4->30:10]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[12:4->30:10]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[15:5->30:10]
+JSX <div:[15:5->15:8] > _children:15:8
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[15:8->30:4]
+Pexp_construct :::[16:7->30:4] [16:7->30:4]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[16:7->30:4]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[17:7->30:4]
+Pexp_construct :::[17:7->30:4] [17:7->30:4]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[17:7->30:4]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[28:10->30:4]
+Pexp_construct :::[28:10->30:4] [28:10->30:4]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[28:10->30:4]
+posCursor:[28:20] posNoWhite:[28:19] Found expr:[28:10->28:20]
 Completable: Cpath Value[someArr]->a <<jsx>>
 [{
     "label": "React.array",
@@ -351,35 +337,6 @@ Completable: Cpath Value[someArr]->a <<jsx>>
     "detail": "array<React.element>",
     "documentation": null
   }, {
-    "label": "Js.Array2.append",
-    "kind": 12,
-    "tags": [1],
-    "detail": "(t<'a>, 'a) => t<'a>",
-    "documentation": {"kind": "markdown", "value": "Deprecated: `append` is not type-safe. Use `concat` instead.\n\n"}
-  }]
-
-Complete src/CompletionJsx.res 32:27
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[8:13->35:3]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[9:4->34:10]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[10:4->34:10]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[11:4->34:10]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[12:4->34:10]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[13:4->34:10]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[14:4->34:10]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[17:5->34:10]
-JSX <div:[17:5->17:8] > _children:17:8
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[17:8->34:4]
-Pexp_construct :::[18:7->34:4] [18:7->34:4]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[18:7->34:4]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[19:7->34:4]
-Pexp_construct :::[19:7->34:4] [19:7->34:4]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[19:7->34:4]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[32:10->34:4]
-Pexp_construct :::[32:10->34:4] [32:10->34:4]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[32:10->34:4]
-posCursor:[32:27] posNoWhite:[32:26] Found expr:[32:10->32:27]
-Completable: Cpath Value[someInvalidArr]->a <<jsx>>
-[{
     "label": "Js.Array2.append",
     "kind": 12,
     "tags": [1],

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -30,6 +30,7 @@ Completable: Cpath Value[someString]->st <<jsx>>
     "tags": [],
     "detail": "string",
     "documentation": {"kind": "markdown", "value": "Turns `string` into `React.element` so it can be used inside of JSX."},
+    "sortText": "A",
     "insertTextFormat": 2
   }, {
     "label": "Js.String2.startsWith",
@@ -70,6 +71,7 @@ Completable: Cpath Value[someString]->st <<jsx>>
     "tags": [],
     "detail": "string",
     "documentation": {"kind": "markdown", "value": "Turns `string` into `React.element` so it can be used inside of JSX."},
+    "sortText": "A",
     "insertTextFormat": 2
   }, {
     "label": "Js.String2.startsWith",
@@ -110,6 +112,7 @@ Completable: Cpath string->st <<jsx>>
     "tags": [],
     "detail": "string",
     "documentation": {"kind": "markdown", "value": "Turns `string` into `React.element` so it can be used inside of JSX."},
+    "sortText": "A",
     "insertTextFormat": 2
   }, {
     "label": "Js.String2.startsWith",
@@ -150,6 +153,7 @@ Completable: Cpath Value[Js, String2, trim](Nolabel)->st <<jsx>>
     "tags": [],
     "detail": "string",
     "documentation": {"kind": "markdown", "value": "Turns `string` into `React.element` so it can be used inside of JSX."},
+    "sortText": "A",
     "insertTextFormat": 2
   }, {
     "label": "Js.String2.startsWith",
@@ -190,6 +194,7 @@ Completable: Cpath Value[someInt]-> <<jsx>>
     "tags": [],
     "detail": "int",
     "documentation": {"kind": "markdown", "value": "Turns `int` into `React.element` so it can be used inside of JSX."},
+    "sortText": "A",
     "insertTextFormat": 2
   }, {
     "label": "Belt.Int.fromString",
@@ -266,6 +271,7 @@ Completable: Cpath int-> <<jsx>>
     "tags": [],
     "detail": "int",
     "documentation": {"kind": "markdown", "value": "Turns `int` into `React.element` so it can be used inside of JSX."},
+    "sortText": "A",
     "insertTextFormat": 2
   }, {
     "label": "Belt.Int.fromString",
@@ -342,6 +348,7 @@ Completable: Cpath Value[someArr]->a <<jsx>>
     "tags": [],
     "detail": "array<React.element>",
     "documentation": {"kind": "markdown", "value": "Turns `array` into `React.element` so it can be used inside of JSX."},
+    "sortText": "A",
     "insertTextFormat": 2
   }, {
     "label": "Js.Array2.append",


### PR DESCRIPTION
Something I've wanted for a while. This will add `React.string`, `React.array` etc to the completion items for relevant types in pipe when in a JSX context. Being in a JSX context is defined as a) being in the body of a `make` function annotated with `@react.component`, or b) being inside of JSX.

Example:
Doing pipe completion on an `int` in JSX context will return `React.int` in the completion items, in addition to the builtin completions for `int`.

This accomplishes two things:
1. Convenience, since you otherwise have to first complete for `React`, and then the fn you're after.
2. Helps beginners with understanding that you in ReScript need to use the respective `React.element` producing functions in JSX.