### PR TITLE
Nested expression completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add support from completing polyvariants as values. https://github.com/rescript-lang/rescript-vscode/pull/669
 - Add support for completion in patterns. https://github.com/rescript-lang/rescript-vscode/pull/670
 - Add support for pattern completion of unsaved tuples. https://github.com/rescript-lang/rescript-vscode/pull/679
+- Add support for completion in typed expressions. https://github.com/rescript-lang/rescript-vscode/pull/682
 
 #### :nail_care: Polish
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -2299,12 +2299,8 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
                  in which we send it. This fixes that by providing a sort text making the typed completions
                  guaranteed to end up on top. *)
               items
-              |> List.mapi (fun index (c : Completion.t) ->
-                     {
-                       c with
-                       sortText =
-                         Some ("A" ^ string_of_int (index + 1) ^ " " ^ c.name);
-                     })
+              |> List.map (fun (c : Completion.t) ->
+                     {c with sortText = Some ("A" ^ " " ^ c.name)})
             else items
           in
           items @ regularCompletions

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1717,6 +1717,7 @@ let rec extractType ~env ~package (t : Types.type_expr) =
   | Tconstr (Path.Pident {name = "array"}, [payloadTypeExpr], _) ->
     Some (Tarray (env, payloadTypeExpr))
   | Tconstr (Path.Pident {name = "bool"}, [], _) -> Some (Tbool env)
+  | Tconstr (Path.Pident {name = "string"}, [], _) -> Some (Tstring env)
   | Tconstr (path, _, _) -> (
     match References.digConstructor ~env ~package path with
     | Some (env, {item = {decl = {type_manifest = Some t1}}}) ->
@@ -1855,7 +1856,7 @@ let completeTypedValue ~env ~full ~prefix ~completionContext =
             [
               Completion.createWithSnippet ~name:"{}"
                 ~insertText:(if !Cfg.supportsSnippets then "{$0}" else "{}")
-                ~sortText:"a" ~kind:(Value typeExpr) ~env ();
+                ~sortText:"A" ~kind:(Value typeExpr) ~env ();
             ]
           else [])
       | Some (Tarray (env, typeExpr)) ->
@@ -1863,7 +1864,19 @@ let completeTypedValue ~env ~full ~prefix ~completionContext =
           [
             Completion.createWithSnippet ~name:"[]"
               ~insertText:(if !Cfg.supportsSnippets then "[$0]" else "[]")
-              ~sortText:"a" ~kind:(Value typeExpr) ~env ();
+              ~sortText:"A" ~kind:(Value typeExpr) ~env ();
+          ]
+        else []
+      | Some (Tstring env) ->
+        if prefix = "" then
+          [
+            Completion.createWithSnippet ~name:"\"\""
+              ~insertText:(if !Cfg.supportsSnippets then "\"$0\"" else "\"\"")
+              ~sortText:"A"
+              ~kind:
+                (Value
+                   (Ctype.newconstr (Path.Pident (Ident.create "string")) []))
+              ~env ();
           ]
         else []
       | _ -> []
@@ -2297,7 +2310,7 @@ Note: The `@react.component` decorator requires the react-jsx config to be set i
                      {
                        c with
                        sortText =
-                         Some ("AAA" ^ string_of_int (index + 1) ^ " " ^ c.name);
+                         Some ("A" ^ string_of_int (index + 1) ^ " " ^ c.name);
                      })
             else items
           in

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -1,13 +1,5 @@
 open SharedTypes
 
-let extractCompletableArgValueInfo exp =
-  match exp.Parsetree.pexp_desc with
-  | Pexp_ident {txt = Lident txt} -> Some txt
-  | Pexp_construct ({txt = Lident "()"}, _) -> Some ""
-  | Pexp_construct ({txt = Lident txt}, None) -> Some txt
-  | Pexp_variant (label, None) -> Some ("#" ^ label)
-  | _ -> None
-
 let isExprHole exp =
   match exp.Parsetree.pexp_desc with
   | Pexp_extension ({txt = "rescript.exprhole"}, _) -> true

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -129,7 +129,7 @@ let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor
                    Utils.flattenLongIdent ~jsx:true jsxProps.compName.txt;
                  prefix;
                  propName = prop.name;
-                 nested;
+                 nested = List.rev nested;
                })
         | _ -> None
       else if prop.exp.pexp_loc |> Loc.end_ = (Location.none |> Loc.end_) then
@@ -237,7 +237,7 @@ let findArgCompletables ~(args : arg list) ~endPos ~posBeforeCursor
                  functionContextPath = contextPath;
                  argumentLabel = Labelled labelled.name;
                  prefix;
-                 nested;
+                 nested = List.rev nested;
                })
       else if isExprHole exp then
         Some
@@ -266,7 +266,7 @@ let findArgCompletables ~(args : arg list) ~endPos ~posBeforeCursor
                  argumentLabel =
                    Unlabelled {argumentPosition = !unlabelledCount};
                  prefix;
-                 nested;
+                 nested = List.rev nested;
                })
       else if isExprHole exp then
         Some

--- a/analysis/src/Protocol.ml
+++ b/analysis/src/Protocol.ml
@@ -109,7 +109,7 @@ let stringifyObject properties =
     |> String.concat ",\n")
   ^ "\n  }"
 
-let wrapInQuotes s = "\"" ^ s ^ "\""
+let wrapInQuotes s = "\"" ^ Json.escape s ^ "\""
 
 let optWrapInQuotes s =
   match s with
@@ -119,10 +119,10 @@ let optWrapInQuotes s =
 let stringifyCompletionItem c =
   stringifyObject
     [
-      ("label", Some (wrapInQuotes (Json.escape c.label)));
+      ("label", Some (wrapInQuotes c.label));
       ("kind", Some (string_of_int c.kind));
       ("tags", Some (c.tags |> List.map string_of_int |> array));
-      ("detail", Some (wrapInQuotes (Json.escape c.detail)));
+      ("detail", Some (wrapInQuotes c.detail));
       ( "documentation",
         Some
           (match c.documentation with

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -605,6 +605,7 @@ module Completable = struct
     | Toption of QueryEnv.t * Types.type_expr
     | Tbool of QueryEnv.t
     | Tarray of QueryEnv.t * Types.type_expr
+    | Tstring of QueryEnv.t
     | Tvariant of {
         env: QueryEnv.t;
         constructors: Constructor.t list;

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -162,3 +162,9 @@ let rec skipWhite text i =
 
 let hasBraces attributes =
   attributes |> List.exists (fun (loc, _) -> loc.Location.txt = "ns.braces")
+
+let rec unwrapIfOption (t : Types.type_expr) =
+  match t.desc with
+  | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> unwrapIfOption t1
+  | Tconstr (Path.Pident {name = "option"}, [unwrappedType], _) -> unwrappedType
+  | _ -> t

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -159,3 +159,6 @@ let rec skipWhite text i =
     match text.[i] with
     | ' ' | '\n' | '\r' | '\t' -> skipWhite text (i - 1)
     | _ -> i
+
+let hasBraces attributes =
+  attributes |> List.exists (fun (loc, _) -> loc.Location.txt = "ns.braces")

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -73,6 +73,9 @@ let fnTakingArray = (arr: array<option<bool>>) => {
 // let _ = fnTakingArray([])
 //                        ^com
 
+// let _ = fnTakingArray(s)
+//                        ^com
+
 // let _ = fnTakingArray([Some()])
 //                             ^com
 
@@ -81,3 +84,8 @@ let fnTakingArray = (arr: array<option<bool>>) => {
 
 // let _ = fnTakingArray([None, , None])
 //                             ^com
+
+let someBoolVar = true
+
+// let _ = fnTakingRecord({offline: so })
+//                                    ^com

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -3,3 +3,44 @@ let f = Some([false])
 
 // switch (s, f) { | }
 //                  ^com
+
+type otherRecord = {
+  someField: int,
+  otherField: string,
+}
+
+type rec someRecord = {
+  age: int,
+  offline: bool,
+  online: option<bool>,
+  variant: someVariant,
+  polyvariant: somePolyVariant,
+  nested: option<otherRecord>,
+}
+and someVariant = One | Two | Three(int, string)
+and somePolyVariant = [#one | #two(bool) | #three(someRecord, bool)]
+
+let fnTakingRecord = (r: someRecord) => {
+  ignore(r)
+}
+
+// let _ = fnTakingRecord({})
+//                         ^com
+
+// let _ = fnTakingRecord({n})
+//                          ^com
+
+// let _ = fnTakingRecord({offline: })
+//                                 ^com
+
+// let _ = fnTakingRecord({age: 123, })
+//                                  ^com
+
+// let _ = fnTakingRecord({age: 123,  offline: true})
+//                                   ^com
+
+// let _ = fnTakingRecord({age: 123, nested: })
+//                                          ^com
+
+// let _ = fnTakingRecord({age: 123, nested: {}})
+//                                            ^com

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -62,3 +62,22 @@ let fnTakingRecord = (r: someRecord) => {
 
 // let _ = fnTakingRecord({age: 123, polyvariant: #three({}, t) })
 //                                                            ^com
+
+let fnTakingArray = (arr: array<option<bool>>) => {
+  ignore(arr)
+}
+
+// let _ = fnTakingArray()
+//                       ^com
+
+// let _ = fnTakingArray([])
+//                        ^com
+
+// let _ = fnTakingArray([Some()])
+//                             ^com
+
+// let _ = fnTakingArray([None, ])
+//                             ^com
+
+// let _ = fnTakingArray([None, , None])
+//                             ^com

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -89,3 +89,10 @@ let someBoolVar = true
 
 // let _ = fnTakingRecord({offline: so })
 //                                    ^com
+
+let fnTakingOtherRecord = (r: otherRecord) => {
+  ignore(r)
+}
+
+// let _ = fnTakingOtherRecord({otherField: })
+//                                         ^com

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -44,3 +44,21 @@ let fnTakingRecord = (r: someRecord) => {
 
 // let _ = fnTakingRecord({age: 123, nested: {}})
 //                                            ^com
+
+// let _ = fnTakingRecord({age: 123, nested: Some({})})
+//                                                 ^com
+
+// let _ = fnTakingRecord({age: 123, variant: })
+//                                           ^com
+
+// let _ = fnTakingRecord({age: 123, variant: O })
+//                                             ^com
+
+// let _ = fnTakingRecord({age: 123, polyvariant: #three() })
+//                                                       ^com
+
+// let _ = fnTakingRecord({age: 123, polyvariant: #three({}, ) })
+//                                                          ^com
+
+// let _ = fnTakingRecord({age: 123, polyvariant: #three({}, t) })
+//                                                            ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -55,8 +55,8 @@ let someFnTakingVariant = (
 // let _ = someFnTakingVariant(~config=O)
 //                                      ^com
 
-// let _ = someFnTakingVariant(S)
-//                              ^com
+// let _ = someFnTakingVariant(So)
+//                               ^com
 
 // let _ = someFnTakingVariant(~configOpt2=O)
 //                                          ^com

--- a/analysis/tests/src/CompletionFunctionArguments.res
+++ b/analysis/tests/src/CompletionFunctionArguments.res
@@ -76,3 +76,16 @@ let fnTakingTuple = (arg: (int, int, float)) => {
 
 // let _ = fnTakingTuple()
 //                       ^com
+
+type someRecord = {
+  age: int,
+  offline: bool,
+  online: option<bool>,
+}
+
+let fnTakingRecord = (r: someRecord) => {
+  ignore(r)
+}
+
+// let _ = fnTakingRecord({})
+//                         ^com

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -463,7 +463,7 @@ Completable: Cpath Value[Js, Dict, u]
 Complete src/Completion.res 59:30
 posCursor:[59:30] posNoWhite:[59:29] Found expr:[59:15->59:30]
 JSX <O.Comp:[59:15->59:21] second[59:22->59:28]=...[59:29->59:30]> _children:None
-Completable: CjsxPropValue [O, Comp] second=z
+Completable: Cexpression CJsxPropValue [O, Comp] second=z
 [{
     "label": "zzz",
     "kind": 12,

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -175,3 +175,110 @@ Pexp_apply ...[44:11->44:25] (...[44:26->44:48])
 Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested), recordBody
 []
 
+Complete src/CompletionExpressions.res 47:51
+posCursor:[47:51] posNoWhite:[47:50] Found expr:[47:11->47:55]
+Pexp_apply ...[47:11->47:25] (...[47:26->47:54])
+Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested), variantPayload::Some($0), recordBody
+[{
+    "label": "someField",
+    "kind": 5,
+    "tags": [],
+    "detail": "someField: int\n\notherRecord",
+    "documentation": null
+  }, {
+    "label": "otherField",
+    "kind": 5,
+    "tags": [],
+    "detail": "otherField: string\n\notherRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 50:45
+posCursor:[50:45] posNoWhite:[50:44] Found expr:[50:11->50:48]
+Pexp_apply ...[50:11->50:25] (...[50:26->50:48])
+Completable: Cargument Value[fnTakingRecord]($0)->recordField(variant)
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
+  }, {
+    "label": "Two",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two\n\ntype someVariant = One | Two | Three(int, string)",
+    "documentation": null,
+    "insertText": "Two",
+    "insertTextFormat": 2
+  }, {
+    "label": "Three(_, _)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Three(int, string)\n\ntype someVariant = One | Two | Three(int, string)",
+    "documentation": null,
+    "insertText": "Three(${1:_}, ${2:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 53:47
+posCursor:[53:47] posNoWhite:[53:46] Found expr:[53:11->53:50]
+Pexp_apply ...[53:11->53:25] (...[53:26->53:49])
+Completable: Cargument Value[fnTakingRecord]($0=O)->recordField(variant)
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 56:57
+posCursor:[56:57] posNoWhite:[56:56] Found expr:[56:11->56:61]
+Pexp_apply ...[56:11->56:25] (...[56:26->56:60])
+Completable: Cargument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($0)
+[{
+    "label": "{}",
+    "kind": 12,
+    "tags": [],
+    "detail": "someRecord",
+    "documentation": null,
+    "sortText": "a",
+    "insertText": "{$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 59:60
+posCursor:[59:60] posNoWhite:[59:59] Found expr:[59:11->59:65]
+Pexp_apply ...[59:11->59:25] (...[59:26->59:64])
+Completable: Cargument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 62:62
+posCursor:[62:62] posNoWhite:[62:61] Found expr:[62:11->62:66]
+Pexp_apply ...[62:11->62:25] (...[62:26->62:65])
+Completable: Cargument Value[fnTakingRecord]($0=t)->recordField(polyvariant), polyvariantPayload::three($1)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -233,7 +233,7 @@ Completable: Cexpression CArgument Value[fnTakingRecord]($0)=O->recordField(vari
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
-    "sortText": "A1 One",
+    "sortText": "A One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -11,3 +11,203 @@ Completable: Cpattern CTuple(Value[s], Value[f])
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionExpressions.res 26:27
+posCursor:[26:27] posNoWhite:[26:26] Found expr:[26:11->26:29]
+Pexp_apply ...[26:11->26:25] (...[26:26->26:28])
+Completable: Cargument Value[fnTakingRecord]($0)->recordBody
+[{
+    "label": "age",
+    "kind": 5,
+    "tags": [],
+    "detail": "age: int\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "offline",
+    "kind": 5,
+    "tags": [],
+    "detail": "offline: bool\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "online",
+    "kind": 5,
+    "tags": [],
+    "detail": "online: option<bool>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "variant",
+    "kind": 5,
+    "tags": [],
+    "detail": "variant: someVariant\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "polyvariant",
+    "kind": 5,
+    "tags": [],
+    "detail": "polyvariant: somePolyVariant\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nested",
+    "kind": 5,
+    "tags": [],
+    "detail": "nested: option<otherRecord>\n\nsomeRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 29:28
+posCursor:[29:28] posNoWhite:[29:27] Found expr:[29:11->29:30]
+Pexp_apply ...[29:11->29:25] (...[29:27->29:28])
+Completable: Cargument Value[fnTakingRecord]($0=n)->recordBody
+[{
+    "label": "nested",
+    "kind": 5,
+    "tags": [],
+    "detail": "nested: option<otherRecord>\n\nsomeRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 32:35
+posCursor:[32:35] posNoWhite:[32:34] Found expr:[32:11->32:38]
+Pexp_apply ...[32:11->32:25] (...[32:26->32:38])
+Completable: Cargument Value[fnTakingRecord]($0)->recordField(offline)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 35:36
+posCursor:[35:36] posNoWhite:[35:35] Found expr:[35:11->35:39]
+Pexp_apply ...[35:11->35:25] (...[35:26->35:38])
+Completable: Cargument Value[fnTakingRecord]($0)->recordBody
+[{
+    "label": "offline",
+    "kind": 5,
+    "tags": [],
+    "detail": "offline: bool\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "online",
+    "kind": 5,
+    "tags": [],
+    "detail": "online: option<bool>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "variant",
+    "kind": 5,
+    "tags": [],
+    "detail": "variant: someVariant\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "polyvariant",
+    "kind": 5,
+    "tags": [],
+    "detail": "polyvariant: somePolyVariant\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nested",
+    "kind": 5,
+    "tags": [],
+    "detail": "nested: option<otherRecord>\n\nsomeRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 38:37
+posCursor:[38:37] posNoWhite:[38:35] Found expr:[38:11->38:53]
+Pexp_apply ...[38:11->38:25] (...[38:26->38:52])
+Completable: Cargument Value[fnTakingRecord]($0)->recordBody
+[{
+    "label": "online",
+    "kind": 5,
+    "tags": [],
+    "detail": "online: option<bool>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "variant",
+    "kind": 5,
+    "tags": [],
+    "detail": "variant: someVariant\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "polyvariant",
+    "kind": 5,
+    "tags": [],
+    "detail": "polyvariant: somePolyVariant\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nested",
+    "kind": 5,
+    "tags": [],
+    "detail": "nested: option<otherRecord>\n\nsomeRecord",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 41:44
+posCursor:[41:44] posNoWhite:[41:43] Found expr:[41:11->41:47]
+Pexp_apply ...[41:11->41:25] (...[41:26->41:47])
+Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested)
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "otherRecord",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "otherRecord",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 44:46
+posCursor:[44:46] posNoWhite:[44:45] Found expr:[44:11->44:49]
+Pexp_apply ...[44:11->44:25] (...[44:26->44:48])
+Completable: Cargument Value[fnTakingRecord]($0)->recordBody, recordField(nested)
+[{
+    "label": "age",
+    "kind": 5,
+    "tags": [],
+    "detail": "age: int\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "offline",
+    "kind": 5,
+    "tags": [],
+    "detail": "offline: bool\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "online",
+    "kind": 5,
+    "tags": [],
+    "detail": "online: option<bool>\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "variant",
+    "kind": 5,
+    "tags": [],
+    "detail": "variant: someVariant\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "polyvariant",
+    "kind": 5,
+    "tags": [],
+    "detail": "polyvariant: somePolyVariant\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "nested",
+    "kind": 5,
+    "tags": [],
+    "detail": "nested: option<otherRecord>\n\nsomeRecord",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -282,3 +282,96 @@ Completable: Cargument Value[fnTakingRecord]($0=t)->recordField(polyvariant), po
     "documentation": null
   }]
 
+Complete src/CompletionExpressions.res 69:25
+posCursor:[69:25] posNoWhite:[69:24] Found expr:[69:11->69:26]
+Pexp_apply ...[69:11->69:24] (...[69:25->69:26])
+Completable: Cargument Value[fnTakingArray]($0)
+[{
+    "label": "[]",
+    "kind": 12,
+    "tags": [],
+    "detail": "option<bool>",
+    "documentation": null,
+    "sortText": "a",
+    "insertText": "[$0]",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 72:26
+posCursor:[72:26] posNoWhite:[72:25] Found expr:[72:11->72:28]
+Pexp_apply ...[72:11->72:24] (...[72:25->72:27])
+Completable: Cargument Value[fnTakingArray]($0)->array
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 75:31
+posCursor:[75:31] posNoWhite:[75:30] Found expr:[75:11->75:34]
+Pexp_apply ...[75:11->75:24] (...[75:25->75:33])
+Completable: Cargument Value[fnTakingArray]($0)->array, variantPayload::Some($0)
+[{
+    "label": "true",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "false",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 78:31
+posCursor:[78:31] posNoWhite:[78:30] Found expr:[78:11->78:34]
+Pexp_apply ...[78:11->78:24] (...[78:25->78:33])
+Completable: Cargument Value[fnTakingArray]($0)->array
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 81:31
+posCursor:[81:31] posNoWhite:[81:30] Found expr:[81:11->81:40]
+Pexp_apply ...[81:11->81:24] (...[81:25->81:39])
+Completable: Cargument Value[fnTakingArray]($0)->array
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -14,7 +14,7 @@ Completable: Cpattern CTuple(Value[s], Value[f])
 Complete src/CompletionExpressions.res 26:27
 posCursor:[26:27] posNoWhite:[26:26] Found expr:[26:11->26:29]
 Pexp_apply ...[26:11->26:25] (...[26:26->26:28])
-Completable: Cargument Value[fnTakingRecord]($0)->recordBody
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordBody
 [{
     "label": "age",
     "kind": 5,
@@ -56,7 +56,7 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordBody
 Complete src/CompletionExpressions.res 29:28
 posCursor:[29:28] posNoWhite:[29:27] Found expr:[29:11->29:30]
 Pexp_apply ...[29:11->29:25] (...[29:27->29:28])
-Completable: Cargument Value[fnTakingRecord]($0=n)->recordBody
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)=n->recordBody
 [{
     "label": "nested",
     "kind": 5,
@@ -68,7 +68,7 @@ Completable: Cargument Value[fnTakingRecord]($0=n)->recordBody
 Complete src/CompletionExpressions.res 32:35
 posCursor:[32:35] posNoWhite:[32:34] Found expr:[32:11->32:38]
 Pexp_apply ...[32:11->32:25] (...[32:26->32:38])
-Completable: Cargument Value[fnTakingRecord]($0)->recordField(offline)
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(offline)
 [{
     "label": "true",
     "kind": 4,
@@ -86,7 +86,7 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordField(offline)
 Complete src/CompletionExpressions.res 35:36
 posCursor:[35:36] posNoWhite:[35:35] Found expr:[35:11->35:39]
 Pexp_apply ...[35:11->35:25] (...[35:26->35:38])
-Completable: Cargument Value[fnTakingRecord]($0)->recordBody
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordBody
 [{
     "label": "offline",
     "kind": 5,
@@ -122,7 +122,7 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordBody
 Complete src/CompletionExpressions.res 38:37
 posCursor:[38:37] posNoWhite:[38:35] Found expr:[38:11->38:53]
 Pexp_apply ...[38:11->38:25] (...[38:26->38:52])
-Completable: Cargument Value[fnTakingRecord]($0)->recordBody
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordBody
 [{
     "label": "online",
     "kind": 5,
@@ -152,7 +152,7 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordBody
 Complete src/CompletionExpressions.res 41:44
 posCursor:[41:44] posNoWhite:[41:43] Found expr:[41:11->41:47]
 Pexp_apply ...[41:11->41:25] (...[41:26->41:47])
-Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested)
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(nested)
 [{
     "label": "None",
     "kind": 4,
@@ -172,13 +172,13 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested)
 Complete src/CompletionExpressions.res 44:46
 posCursor:[44:46] posNoWhite:[44:45] Found expr:[44:11->44:49]
 Pexp_apply ...[44:11->44:25] (...[44:26->44:48])
-Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested), recordBody
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(nested), recordBody
 []
 
 Complete src/CompletionExpressions.res 47:51
 posCursor:[47:51] posNoWhite:[47:50] Found expr:[47:11->47:55]
 Pexp_apply ...[47:11->47:25] (...[47:26->47:54])
-Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested), variantPayload::Some($0), recordBody
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(nested), variantPayload::Some($0), recordBody
 [{
     "label": "someField",
     "kind": 5,
@@ -196,7 +196,7 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested), variantPa
 Complete src/CompletionExpressions.res 50:45
 posCursor:[50:45] posNoWhite:[50:44] Found expr:[50:11->50:48]
 Pexp_apply ...[50:11->50:25] (...[50:26->50:48])
-Completable: Cargument Value[fnTakingRecord]($0)->recordField(variant)
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(variant)
 [{
     "label": "One",
     "kind": 4,
@@ -226,7 +226,7 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordField(variant)
 Complete src/CompletionExpressions.res 53:47
 posCursor:[53:47] posNoWhite:[53:46] Found expr:[53:11->53:50]
 Pexp_apply ...[53:11->53:25] (...[53:26->53:49])
-Completable: Cargument Value[fnTakingRecord]($0=O)->recordField(variant)
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)=O->recordField(variant)
 [{
     "label": "One",
     "kind": 4,
@@ -235,12 +235,24 @@ Completable: Cargument Value[fnTakingRecord]($0=O)->recordField(variant)
     "documentation": null,
     "insertText": "One",
     "insertTextFormat": 2
+  }, {
+    "label": "Obj",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }, {
+    "label": "Object",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
   }]
 
 Complete src/CompletionExpressions.res 56:57
 posCursor:[56:57] posNoWhite:[56:56] Found expr:[56:11->56:61]
 Pexp_apply ...[56:11->56:25] (...[56:26->56:60])
-Completable: Cargument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($0)
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($0)
 [{
     "label": "{}",
     "kind": 12,
@@ -255,7 +267,7 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordField(polyvariant), poly
 Complete src/CompletionExpressions.res 59:60
 posCursor:[59:60] posNoWhite:[59:59] Found expr:[59:11->59:65]
 Pexp_apply ...[59:11->59:25] (...[59:26->59:64])
-Completable: Cargument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($1)
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($1)
 [{
     "label": "true",
     "kind": 4,
@@ -273,7 +285,7 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordField(polyvariant), poly
 Complete src/CompletionExpressions.res 62:62
 posCursor:[62:62] posNoWhite:[62:61] Found expr:[62:11->62:66]
 Pexp_apply ...[62:11->62:25] (...[62:26->62:65])
-Completable: Cargument Value[fnTakingRecord]($0=t)->recordField(polyvariant), polyvariantPayload::three($1)
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)=t->recordField(polyvariant), polyvariantPayload::three($1)
 [{
     "label": "true",
     "kind": 4,
@@ -285,7 +297,7 @@ Completable: Cargument Value[fnTakingRecord]($0=t)->recordField(polyvariant), po
 Complete src/CompletionExpressions.res 69:25
 posCursor:[69:25] posNoWhite:[69:24] Found expr:[69:11->69:26]
 Pexp_apply ...[69:11->69:24] (...[69:25->69:26])
-Completable: Cargument Value[fnTakingArray]($0)
+Completable: Cexpression CArgument Value[fnTakingArray]($0)
 [{
     "label": "[]",
     "kind": 12,
@@ -300,7 +312,7 @@ Completable: Cargument Value[fnTakingArray]($0)
 Complete src/CompletionExpressions.res 72:26
 posCursor:[72:26] posNoWhite:[72:25] Found expr:[72:11->72:28]
 Pexp_apply ...[72:11->72:24] (...[72:25->72:27])
-Completable: Cargument Value[fnTakingArray]($0)->array
+Completable: Cexpression CArgument Value[fnTakingArray]($0)->array
 [{
     "label": "None",
     "kind": 4,
@@ -317,10 +329,22 @@ Completable: Cargument Value[fnTakingArray]($0)->array
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 75:31
-posCursor:[75:31] posNoWhite:[75:30] Found expr:[75:11->75:34]
-Pexp_apply ...[75:11->75:24] (...[75:25->75:33])
-Completable: Cargument Value[fnTakingArray]($0)->array, variantPayload::Some($0)
+Complete src/CompletionExpressions.res 75:26
+posCursor:[75:26] posNoWhite:[75:25] Found expr:[75:11->75:27]
+Pexp_apply ...[75:11->75:24] (...[75:25->75:26])
+Completable: Cexpression CArgument Value[fnTakingArray]($0)=s
+[{
+    "label": "s",
+    "kind": 12,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 78:31
+posCursor:[78:31] posNoWhite:[78:30] Found expr:[78:11->78:34]
+Pexp_apply ...[78:11->78:24] (...[78:25->78:33])
+Completable: Cexpression CArgument Value[fnTakingArray]($0)->array, variantPayload::Some($0)
 [{
     "label": "true",
     "kind": 4,
@@ -335,10 +359,10 @@ Completable: Cargument Value[fnTakingArray]($0)->array, variantPayload::Some($0)
     "documentation": null
   }]
 
-Complete src/CompletionExpressions.res 78:31
-posCursor:[78:31] posNoWhite:[78:30] Found expr:[78:11->78:34]
-Pexp_apply ...[78:11->78:24] (...[78:25->78:33])
-Completable: Cargument Value[fnTakingArray]($0)->array
+Complete src/CompletionExpressions.res 81:31
+posCursor:[81:31] posNoWhite:[81:30] Found expr:[81:11->81:34]
+Pexp_apply ...[81:11->81:24] (...[81:25->81:33])
+Completable: Cexpression CArgument Value[fnTakingArray]($0)->array
 [{
     "label": "None",
     "kind": 4,
@@ -355,10 +379,10 @@ Completable: Cargument Value[fnTakingArray]($0)->array
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 81:31
-posCursor:[81:31] posNoWhite:[81:30] Found expr:[81:11->81:40]
-Pexp_apply ...[81:11->81:24] (...[81:25->81:39])
-Completable: Cargument Value[fnTakingArray]($0)->array
+Complete src/CompletionExpressions.res 84:31
+posCursor:[84:31] posNoWhite:[84:30] Found expr:[84:11->84:40]
+Pexp_apply ...[84:11->84:24] (...[84:25->84:39])
+Completable: Cexpression CArgument Value[fnTakingArray]($0)->array
 [{
     "label": "None",
     "kind": 4,
@@ -373,5 +397,17 @@ Completable: Cargument Value[fnTakingArray]($0)->array
     "documentation": null,
     "insertText": "Some(${1:_})",
     "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 89:38
+posCursor:[89:38] posNoWhite:[89:37] Found expr:[89:11->89:41]
+Pexp_apply ...[89:11->89:25] (...[89:26->89:40])
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)=so
+[{
+    "label": "someBoolVar",
+    "kind": 12,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
   }]
 

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -233,7 +233,7 @@ Completable: Cexpression CArgument Value[fnTakingRecord]($0)=O->recordField(vari
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
-    "sortText": "AAA1 One",
+    "sortText": "A1 One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {
@@ -260,7 +260,7 @@ Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(polyva
     "tags": [],
     "detail": "someRecord",
     "documentation": null,
-    "sortText": "a",
+    "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
   }]
@@ -305,7 +305,7 @@ Completable: Cexpression CArgument Value[fnTakingArray]($0)
     "tags": [],
     "detail": "option<bool>",
     "documentation": null,
-    "sortText": "a",
+    "sortText": "A",
     "insertText": "[$0]",
     "insertTextFormat": 2
   }]
@@ -410,5 +410,20 @@ Completable: Cexpression CArgument Value[fnTakingRecord]($0)=so
     "tags": [],
     "detail": "bool",
     "documentation": null
+  }]
+
+Complete src/CompletionExpressions.res 96:43
+posCursor:[96:43] posNoWhite:[96:42] Found expr:[96:11->96:46]
+Pexp_apply ...[96:11->96:30] (...[96:31->96:46])
+Completable: Cexpression CArgument Value[fnTakingOtherRecord]($0)->recordField(otherField)
+[{
+    "label": "\"\"",
+    "kind": 12,
+    "tags": [],
+    "detail": "string",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "\"$0\"",
+    "insertTextFormat": 2
   }]
 

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -233,6 +233,7 @@ Completable: Cexpression CArgument Value[fnTakingRecord]($0)=O->recordField(vari
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
+    "sortText": "AAA1 One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -172,42 +172,6 @@ Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested)
 Complete src/CompletionExpressions.res 44:46
 posCursor:[44:46] posNoWhite:[44:45] Found expr:[44:11->44:49]
 Pexp_apply ...[44:11->44:25] (...[44:26->44:48])
-Completable: Cargument Value[fnTakingRecord]($0)->recordBody, recordField(nested)
-[{
-    "label": "age",
-    "kind": 5,
-    "tags": [],
-    "detail": "age: int\n\nsomeRecord",
-    "documentation": null
-  }, {
-    "label": "offline",
-    "kind": 5,
-    "tags": [],
-    "detail": "offline: bool\n\nsomeRecord",
-    "documentation": null
-  }, {
-    "label": "online",
-    "kind": 5,
-    "tags": [],
-    "detail": "online: option<bool>\n\nsomeRecord",
-    "documentation": null
-  }, {
-    "label": "variant",
-    "kind": 5,
-    "tags": [],
-    "detail": "variant: someVariant\n\nsomeRecord",
-    "documentation": null
-  }, {
-    "label": "polyvariant",
-    "kind": 5,
-    "tags": [],
-    "detail": "polyvariant: somePolyVariant\n\nsomeRecord",
-    "documentation": null
-  }, {
-    "label": "nested",
-    "kind": 5,
-    "tags": [],
-    "detail": "nested: option<otherRecord>\n\nsomeRecord",
-    "documentation": null
-  }]
+Completable: Cargument Value[fnTakingRecord]($0)->recordField(nested), recordBody
+[]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -85,6 +85,12 @@ Completable: Cargument Value[someOtherFn]($0=f)
     "detail": "bool",
     "documentation": null
   }, {
+    "label": "fnTakingRecord",
+    "kind": 12,
+    "tags": [],
+    "detail": "someRecord => unit",
+    "documentation": null
+  }, {
     "label": "fnTakingTuple",
     "kind": 12,
     "tags": [],
@@ -241,5 +247,29 @@ Completable: Cargument Value[fnTakingTuple]($0)
     "documentation": null,
     "insertText": "(${1:_}, ${2:_}, ${3:_})",
     "insertTextFormat": 2
+  }]
+
+Complete src/CompletionFunctionArguments.res 89:27
+posCursor:[89:27] posNoWhite:[89:26] Found expr:[89:11->89:29]
+Pexp_apply ...[89:11->89:25] (...[89:26->89:28])
+Completable: Cargument Value[fnTakingRecord]($0)->recordBody
+[{
+    "label": "age",
+    "kind": 5,
+    "tags": [],
+    "detail": "age: int\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "offline",
+    "kind": 5,
+    "tags": [],
+    "detail": "offline: bool\n\nsomeRecord",
+    "documentation": null
+  }, {
+    "label": "online",
+    "kind": 5,
+    "tags": [],
+    "detail": "online: option<bool>\n\nsomeRecord",
+    "documentation": null
   }]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -26,7 +26,7 @@ Completable: Cexpression CArgument Value[someFn](~isOn)=t
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "sortText": "AAA1 true"
+    "sortText": "A1 true"
   }, {
     "label": "tLocalVar",
     "kind": 12,
@@ -127,7 +127,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant](~config)=O
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
-    "sortText": "AAA1 One",
+    "sortText": "A1 One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {
@@ -160,7 +160,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant]($0)=So
     "tags": [],
     "detail": "someVariant",
     "documentation": null,
-    "sortText": "AAA1 Some(_)",
+    "sortText": "A1 Some(_)",
     "insertText": "Some(${1:_})",
     "insertTextFormat": 2
   }, {
@@ -181,7 +181,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant](~configOpt2)=O
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
-    "sortText": "AAA1 One",
+    "sortText": "A1 One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {
@@ -249,7 +249,7 @@ Completable: Cexpression CArgument Value[someOtherFn]($2)=t
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "sortText": "AAA1 true"
+    "sortText": "A1 true"
   }, {
     "label": "tLocalVar",
     "kind": 12,

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -25,7 +25,8 @@ Completable: Cexpression CArgument Value[someFn](~isOn)=t
     "kind": 4,
     "tags": [],
     "detail": "bool",
-    "documentation": null
+    "documentation": null,
+    "sortText": "AAA1 true"
   }, {
     "label": "tLocalVar",
     "kind": 12,
@@ -126,6 +127,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant](~config)=O
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
+    "sortText": "AAA1 One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {
@@ -158,6 +160,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant]($0)=So
     "tags": [],
     "detail": "someVariant",
     "documentation": null,
+    "sortText": "AAA1 Some(_)",
     "insertText": "Some(${1:_})",
     "insertTextFormat": 2
   }, {
@@ -178,6 +181,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant](~configOpt2)=O
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
+    "sortText": "AAA1 One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {
@@ -244,7 +248,8 @@ Completable: Cexpression CArgument Value[someOtherFn]($2)=t
     "kind": 4,
     "tags": [],
     "detail": "bool",
-    "documentation": null
+    "documentation": null,
+    "sortText": "AAA1 true"
   }, {
     "label": "tLocalVar",
     "kind": 12,

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -1,7 +1,7 @@
 Complete src/CompletionFunctionArguments.res 10:24
 posCursor:[10:24] posNoWhite:[10:23] Found expr:[10:11->10:25]
 Pexp_apply ...[10:11->10:17] (~isOn10:19->10:23=...__ghost__[0:-1->0:-1])
-Completable: Cargument Value[someFn](~isOn)
+Completable: Cexpression CArgument Value[someFn](~isOn)
 [{
     "label": "true",
     "kind": 4,
@@ -19,7 +19,7 @@ Completable: Cargument Value[someFn](~isOn)
 Complete src/CompletionFunctionArguments.res 13:25
 posCursor:[13:25] posNoWhite:[13:24] Found expr:[13:11->13:26]
 Pexp_apply ...[13:11->13:17] (~isOn13:19->13:23=...[13:24->13:25])
-Completable: Cargument Value[someFn](~isOn=t)
+Completable: Cexpression CArgument Value[someFn](~isOn)=t
 [{
     "label": "true",
     "kind": 4,
@@ -37,7 +37,7 @@ Completable: Cargument Value[someFn](~isOn=t)
 Complete src/CompletionFunctionArguments.res 16:25
 posCursor:[16:25] posNoWhite:[16:24] Found expr:[16:11->16:26]
 Pexp_apply ...[16:11->16:17] (~isOff16:19->16:24=...__ghost__[0:-1->0:-1])
-Completable: Cargument Value[someFn](~isOff)
+Completable: Cexpression CArgument Value[someFn](~isOff)
 [{
     "label": "true",
     "kind": 4,
@@ -59,7 +59,7 @@ posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:7->23:8]
 posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:7->21:28]
 posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:14->21:28]
 Pexp_apply ...[21:14->21:20] (~isOn21:22->21:26=...__ghost__[0:-1->0:-1])
-Completable: Cargument Value[someFn](~isOn)
+Completable: Cexpression CArgument Value[someFn](~isOn)
 [{
     "label": "true",
     "kind": 4,
@@ -77,31 +77,19 @@ Completable: Cargument Value[someFn](~isOn)
 Complete src/CompletionFunctionArguments.res 34:24
 posCursor:[34:24] posNoWhite:[34:23] Found expr:[34:11->34:25]
 Pexp_apply ...[34:11->34:22] (...[34:23->34:24])
-Completable: Cargument Value[someOtherFn]($0=f)
+Completable: Cexpression CArgument Value[someOtherFn]($0)=f
 [{
     "label": "false",
     "kind": 4,
     "tags": [],
     "detail": "bool",
     "documentation": null
-  }, {
-    "label": "fnTakingRecord",
-    "kind": 12,
-    "tags": [],
-    "detail": "someRecord => unit",
-    "documentation": null
-  }, {
-    "label": "fnTakingTuple",
-    "kind": 12,
-    "tags": [],
-    "detail": "((int, int, float)) => unit",
-    "documentation": null
   }]
 
 Complete src/CompletionFunctionArguments.res 51:39
 posCursor:[51:39] posNoWhite:[51:38] Found expr:[51:11->51:40]
 Pexp_apply ...[51:11->51:30] (~config51:32->51:38=...__ghost__[0:-1->0:-1])
-Completable: Cargument Value[someFnTakingVariant](~config)
+Completable: Cexpression CArgument Value[someFnTakingVariant](~config)
 [{
     "label": "One",
     "kind": 4,
@@ -131,7 +119,7 @@ Completable: Cargument Value[someFnTakingVariant](~config)
 Complete src/CompletionFunctionArguments.res 54:40
 posCursor:[54:40] posNoWhite:[54:39] Found expr:[54:11->54:41]
 Pexp_apply ...[54:11->54:30] (~config54:32->54:38=...[54:39->54:40])
-Completable: Cargument Value[someFnTakingVariant](~config=O)
+Completable: Cexpression CArgument Value[someFnTakingVariant](~config)=O
 [{
     "label": "One",
     "kind": 4,
@@ -146,12 +134,24 @@ Completable: Cargument Value[someFnTakingVariant](~config=O)
     "tags": [],
     "detail": "module",
     "documentation": null
+  }, {
+    "label": "Obj",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }, {
+    "label": "Object",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
   }]
 
-Complete src/CompletionFunctionArguments.res 57:32
-posCursor:[57:32] posNoWhite:[57:31] Found expr:[57:11->57:33]
-Pexp_apply ...[57:11->57:30] (...[57:31->57:32])
-Completable: Cargument Value[someFnTakingVariant]($0=S)
+Complete src/CompletionFunctionArguments.res 57:33
+posCursor:[57:33] posNoWhite:[57:32] Found expr:[57:11->57:34]
+Pexp_apply ...[57:11->57:30] (...[57:31->57:33])
+Completable: Cexpression CArgument Value[someFnTakingVariant]($0)=So
 [{
     "label": "Some(_)",
     "kind": 4,
@@ -160,12 +160,18 @@ Completable: Cargument Value[someFnTakingVariant]($0=S)
     "documentation": null,
     "insertText": "Some(${1:_})",
     "insertTextFormat": 2
+  }, {
+    "label": "Sort",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
   }]
 
 Complete src/CompletionFunctionArguments.res 60:44
 posCursor:[60:44] posNoWhite:[60:43] Found expr:[60:11->60:45]
 Pexp_apply ...[60:11->60:30] (~configOpt260:32->60:42=...[60:43->60:44])
-Completable: Cargument Value[someFnTakingVariant](~configOpt2=O)
+Completable: Cexpression CArgument Value[someFnTakingVariant](~configOpt2)=O
 [{
     "label": "One",
     "kind": 4,
@@ -180,12 +186,24 @@ Completable: Cargument Value[someFnTakingVariant](~configOpt2=O)
     "tags": [],
     "detail": "module",
     "documentation": null
+  }, {
+    "label": "Obj",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }, {
+    "label": "Object",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
   }]
 
 Complete src/CompletionFunctionArguments.res 63:23
 posCursor:[63:23] posNoWhite:[63:22] Found expr:[63:11->63:24]
 Pexp_apply ...[63:11->63:22] (...[63:23->63:24])
-Completable: Cargument Value[someOtherFn]($0)
+Completable: Cexpression CArgument Value[someOtherFn]($0)
 [{
     "label": "true",
     "kind": 4,
@@ -203,7 +221,7 @@ Completable: Cargument Value[someOtherFn]($0)
 Complete src/CompletionFunctionArguments.res 66:28
 posCursor:[66:28] posNoWhite:[66:27] Found expr:[66:11->66:30]
 Pexp_apply ...[66:11->66:22] (...[66:23->66:24], ...[66:26->66:27])
-Completable: Cargument Value[someOtherFn]($2)
+Completable: Cexpression CArgument Value[someOtherFn]($2)
 [{
     "label": "true",
     "kind": 4,
@@ -220,7 +238,7 @@ Completable: Cargument Value[someOtherFn]($2)
 
 Complete src/CompletionFunctionArguments.res 69:30
 posCursor:[69:30] posNoWhite:[69:29] Found expr:[69:11->69:31]
-Completable: Cargument Value[someOtherFn]($2=t)
+Completable: Cexpression CArgument Value[someOtherFn]($2)=t
 [{
     "label": "true",
     "kind": 4,
@@ -238,7 +256,7 @@ Completable: Cargument Value[someOtherFn]($2=t)
 Complete src/CompletionFunctionArguments.res 76:25
 posCursor:[76:25] posNoWhite:[76:24] Found expr:[76:11->76:26]
 Pexp_apply ...[76:11->76:24] (...[76:25->76:26])
-Completable: Cargument Value[fnTakingTuple]($0)
+Completable: Cexpression CArgument Value[fnTakingTuple]($0)
 [{
     "label": "(_, _, _)",
     "kind": 12,
@@ -252,7 +270,7 @@ Completable: Cargument Value[fnTakingTuple]($0)
 Complete src/CompletionFunctionArguments.res 89:27
 posCursor:[89:27] posNoWhite:[89:26] Found expr:[89:11->89:29]
 Pexp_apply ...[89:11->89:25] (...[89:26->89:28])
-Completable: Cargument Value[fnTakingRecord]($0)->recordBody
+Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordBody
 [{
     "label": "age",
     "kind": 5,

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -26,7 +26,7 @@ Completable: Cexpression CArgument Value[someFn](~isOn)=t
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "sortText": "A1 true"
+    "sortText": "A true"
   }, {
     "label": "tLocalVar",
     "kind": 12,
@@ -127,7 +127,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant](~config)=O
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
-    "sortText": "A1 One",
+    "sortText": "A One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {
@@ -160,7 +160,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant]($0)=So
     "tags": [],
     "detail": "someVariant",
     "documentation": null,
-    "sortText": "A1 Some(_)",
+    "sortText": "A Some(_)",
     "insertText": "Some(${1:_})",
     "insertTextFormat": 2
   }, {
@@ -181,7 +181,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant](~configOpt2)=O
     "tags": [],
     "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
     "documentation": null,
-    "sortText": "A1 One",
+    "sortText": "A One",
     "insertText": "One",
     "insertTextFormat": 2
   }, {
@@ -249,7 +249,7 @@ Completable: Cexpression CArgument Value[someOtherFn]($2)=t
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "sortText": "A1 true"
+    "sortText": "A true"
   }, {
     "label": "tLocalVar",
     "kind": 12,

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -38,7 +38,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] test=T
     "tags": [],
     "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
-    "sortText": "AAA1 Two",
+    "sortText": "A1 Two",
     "insertText": "Two",
     "insertTextFormat": 2
   }, {
@@ -47,7 +47,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] test=T
     "tags": [],
     "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
-    "sortText": "AAA2 Three(_)",
+    "sortText": "A2 Three(_)",
     "insertText": "Three(${1:_})",
     "insertTextFormat": 2
   }, {

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -38,7 +38,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] test=T
     "tags": [],
     "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
-    "sortText": "A1 Two",
+    "sortText": "A Two",
     "insertText": "Two",
     "insertTextFormat": 2
   }, {
@@ -47,7 +47,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] test=T
     "tags": [],
     "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
-    "sortText": "A2 Three(_)",
+    "sortText": "A Three(_)",
     "insertText": "Three(${1:_})",
     "insertTextFormat": 2
   }, {

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -1,7 +1,7 @@
 Complete src/CompletionJsxProps.res 0:47
 posCursor:[0:47] posNoWhite:[0:46] Found expr:[0:12->0:47]
 JSX <CompletionSupport.TestComponent:[0:12->0:43] on[0:44->0:46]=...__ghost__[0:-1->0:-1]> _children:None
-Completable: CjsxPropValue [CompletionSupport, TestComponent] on=
+Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] on
 [{
     "label": "true",
     "kind": 4,
@@ -19,7 +19,7 @@ Completable: CjsxPropValue [CompletionSupport, TestComponent] on=
 Complete src/CompletionJsxProps.res 3:48
 posCursor:[3:48] posNoWhite:[3:47] Found expr:[3:12->3:48]
 JSX <CompletionSupport.TestComponent:[3:12->3:43] on[3:44->3:46]=...[3:47->3:48]> _children:None
-Completable: CjsxPropValue [CompletionSupport, TestComponent] on=t
+Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] on=t
 [{
     "label": "true",
     "kind": 4,
@@ -31,7 +31,7 @@ Completable: CjsxPropValue [CompletionSupport, TestComponent] on=t
 Complete src/CompletionJsxProps.res 6:50
 posCursor:[6:50] posNoWhite:[6:49] Found expr:[6:12->6:50]
 JSX <CompletionSupport.TestComponent:[6:12->6:43] test[6:44->6:48]=...[6:49->6:50]> _children:None
-Completable: CjsxPropValue [CompletionSupport, TestComponent] test=T
+Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] test=T
 [{
     "label": "Two",
     "kind": 4,
@@ -48,12 +48,24 @@ Completable: CjsxPropValue [CompletionSupport, TestComponent] test=T
     "documentation": null,
     "insertText": "Three(${1:_})",
     "insertTextFormat": 2
+  }, {
+    "label": "TableclothMap",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }, {
+    "label": "TypeDefinition",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
   }]
 
 Complete src/CompletionJsxProps.res 9:52
 posCursor:[9:52] posNoWhite:[9:51] Found expr:[9:12->9:52]
 JSX <CompletionSupport.TestComponent:[9:12->9:43] polyArg[9:44->9:51]=...__ghost__[0:-1->0:-1]> _children:None
-Completable: CjsxPropValue [CompletionSupport, TestComponent] polyArg=
+Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] polyArg
 [{
     "label": "#one",
     "kind": 4,
@@ -91,7 +103,7 @@ Completable: CjsxPropValue [CompletionSupport, TestComponent] polyArg=
 Complete src/CompletionJsxProps.res 12:54
 posCursor:[12:54] posNoWhite:[12:53] Found expr:[12:12->12:54]
 JSX <CompletionSupport.TestComponent:[12:12->12:43] polyArg[12:44->12:51]=...[12:52->12:54]> _children:None
-Completable: CjsxPropValue [CompletionSupport, TestComponent] polyArg=#t
+Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] polyArg=#t
 [{
     "label": "#three(_, _)",
     "kind": 4,

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -38,6 +38,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] test=T
     "tags": [],
     "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
+    "sortText": "AAA1 Two",
     "insertText": "Two",
     "insertTextFormat": 2
   }, {
@@ -46,6 +47,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] test=T
     "tags": [],
     "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
+    "sortText": "AAA2 Three(_)",
     "insertText": "Three(${1:_})",
     "insertTextFormat": 2
   }, {

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -80,7 +80,7 @@ Completable: Cpattern Value[f]
     "tags": [],
     "detail": "someRecord",
     "documentation": null,
-    "sortText": "a",
+    "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
   }]
@@ -170,7 +170,7 @@ Completable: Cpattern Value[f]->recordField(nest)
     "tags": [],
     "detail": "nestedRecord",
     "documentation": null,
-    "sortText": "a",
+    "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
   }]
@@ -414,7 +414,7 @@ Completable: Cpattern Value[c]
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "sortText": "a",
+    "sortText": "A",
     "insertText": "[$0]",
     "insertTextFormat": 2
   }]
@@ -531,7 +531,7 @@ Completable: Cpattern Value[p]->variantPayload::Test($3)
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "sortText": "a",
+    "sortText": "A",
     "insertText": "[$0]",
     "insertTextFormat": 2
   }]
@@ -605,7 +605,7 @@ Completable: Cpattern Value[v]->polyvariantPayload::test($3)
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "sortText": "a",
+    "sortText": "A",
     "insertText": "[$0]",
     "insertTextFormat": 2
   }]

--- a/analysis/tests/src/expected/Jsx2.res.txt
+++ b/analysis/tests/src/expected/Jsx2.res.txt
@@ -6,7 +6,7 @@ the type is not great but jump to definition works
 Complete src/Jsx2.res 8:15
 posCursor:[8:15] posNoWhite:[8:14] Found expr:[8:4->8:15]
 JSX <M:[8:4->8:5] second[8:6->8:12]=...[8:13->8:15]> _children:None
-Completable: CjsxPropValue [M] second=fi
+Completable: Cexpression CJsxPropValue [M] second=fi
 []
 
 Complete src/Jsx2.res 11:20


### PR DESCRIPTION
This extends the current expression completion to handle more cases (records, arrays, tuples, etc), and also handle nested expressions (record fields, constructor payloads, etc etc).

It's essentially a one-to-one port of the nested pattern completion, but for expressions instead.

After this lands, we can soon start refactoring and break up the giant CompletionFrontend/CompletionBackend a bit in my opinion.