### PR TITLE
Let ppat_any trigger completion in patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Complete for `React.element` creator functions (`React.string` etc) when in JSX context. https://github.com/rescript-lang/rescript-vscode/pull/681
 - Handle optional record fields in expression/pattern completion. https://github.com/rescript-lang/rescript-vscode/pull/691
 - Expand options in completion to make working with options a bit more ergonomic. https://github.com/rescript-lang/rescript-vscode/pull/690
+- Let `_` trigger completion in patterns. https://github.com/rescript-lang/rescript-vscode/pull/692
 
 #### :nail_care: Polish
 

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -681,7 +681,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       if locHasCursor pat.Parsetree.ppat_loc then Some v else None
     in
     match pat.ppat_desc with
-    | Ppat_any | Ppat_constant _ | Ppat_interval _ -> None
+    | Ppat_constant _ | Ppat_interval _ -> None
     | Ppat_lazy p
     | Ppat_constraint (p, _)
     | Ppat_alias (p, _)
@@ -695,6 +695,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       match orPatWithItem with
       | None when isPatternHole p1 || isPatternHole p2 -> Some ("", patternPath)
       | v -> v)
+    | Ppat_any -> someIfHasCursor ("", patternPath)
     | Ppat_var {txt} -> someIfHasCursor (txt, patternPath)
     | Ppat_construct ({txt = Lident "()"}, None) ->
       (* switch s { | (<com>) }*)

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -695,7 +695,12 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor ~text =
       match orPatWithItem with
       | None when isPatternHole p1 || isPatternHole p2 -> Some ("", patternPath)
       | v -> v)
-    | Ppat_any -> someIfHasCursor ("", patternPath)
+    | Ppat_any ->
+      (* We treat any `_` as an empty completion. This is mainly because we're
+         inserting `_` in snippets and automatically put the cursor there. So
+         letting it trigger an empty completion improves the ergonomics by a
+         lot. *)
+      someIfHasCursor ("", patternPath)
     | Ppat_var {txt} -> someIfHasCursor (txt, patternPath)
     | Ppat_construct ({txt = Lident "()"}, None) ->
       (* switch s { | (<com>) }*)

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -191,3 +191,6 @@ let s = (true, Some(true), [false])
 
 // switch b { | #one | #three({test: true}, true | )  }
 //                                                ^com
+
+// switch s { | (true, _, []) }
+//                      ^com

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -871,3 +871,36 @@ Completable: Cpattern Value[b]->polyvariantPayload::three($1)
     "documentation": null
   }]
 
+Complete src/CompletionPattern.res 194:24
+posCursor:[194:24] posNoWhite:[194:23] Found expr:[194:3->194:31]
+posCursor:[194:24] posNoWhite:[194:23] Found pattern:[194:16->194:29]
+posCursor:[194:24] posNoWhite:[194:23] Found pattern:[194:23->194:24]
+Completable: Cpattern Value[s]->tuple($1)
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }, {
+    "label": "Some(true)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(false)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+


### PR DESCRIPTION
This makes it so that triggering completion on `_` (`Ppat_any`) is considered the same as triggering an empty typed completion. `Some(<com>)` and `Some(_<com>)` is now considered the same when triggering completion.

The main reason is that we're inserting `_` and putting the cursor on it via snippets. So, being able to trigger completion directly again on `_` is quite helpful.