### PR TITLE
Upgrade client to fix some regressions

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageclient": "8.1.0-next.4"
+        "vscode-languageclient": "8.1.0-next.5"
       }
     },
     "node_modules/balanced-match": {
@@ -62,39 +62,39 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.1.0-next.5",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0-next.5.tgz",
-      "integrity": "sha512-9l9lB8gXW1kPECKLC5Goc41pFztSCfODY3dvGaNTJ0KfRgwKIUyIhEBSdlWT2IU4uL4Tcl/zcitpb+Lj6QP7aQ==",
+      "version": "8.1.0-next.6",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0-next.6.tgz",
+      "integrity": "sha512-AahQokGczPwXKo1Qhnn3aqkZgwUJ0rjVwhWWKW5I5LEWRoqfnWkQp7haVIV6GJRX0oyGL2ezVy7IhwgP5u/3xw==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "8.1.0-next.4",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0-next.4.tgz",
-      "integrity": "sha512-dwo3Vf1aAb3o62mDhLHRGqYaLAYWN5RXAbHKL85Cs+yCJghxYzseuGGBvOUOH3BF5scnCU2BFrghekyP1xCUmQ==",
+      "version": "8.1.0-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0-next.5.tgz",
+      "integrity": "sha512-RbL68ENqp2uPDs1rsPiD8IfhPWzUP8e12ONdtpmSlR6kmj6FLOd8fEaC1pQMGDtfPfiFCpLav8YytH25QOYwRQ==",
       "dependencies": {
         "minimatch": "^5.1.0",
         "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.3-next.4"
+        "vscode-languageserver-protocol": "3.17.3-next.5"
       },
       "engines": {
         "vscode": "^1.67.0"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.3-next.4",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3-next.4.tgz",
-      "integrity": "sha512-G6XrjZGSe2LIo7uDa860JKX97sLKc1vQF4AU4SW8DI7NNVKxnCB+vEs8gYHmle7kD9v13PvFkDCBD5ApeONGNQ==",
+      "version": "3.17.3-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3-next.5.tgz",
+      "integrity": "sha512-9HafkatRVhBVpWQrODes4JaoSu7ozHQUOzYiTmfMmxeFOUYgsSqyODp+j/c+SovcsuwABjuqnsQ9RiFkXCbeMA==",
       "dependencies": {
-        "vscode-jsonrpc": "8.1.0-next.5",
-        "vscode-languageserver-types": "3.17.3-next.1"
+        "vscode-jsonrpc": "8.1.0-next.6",
+        "vscode-languageserver-types": "3.17.3-next.2"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3-next.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3-next.1.tgz",
-      "integrity": "sha512-i7HXZs5CdNibVHXZORZw9m5Bm0mfXiGhD/tZv6f7arBtz4iatgiiHu2qInxn0fKeahhMJoBbp6irhsL9+E3UAA=="
+      "version": "3.17.3-next.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3-next.2.tgz",
+      "integrity": "sha512-3kkNSCycNKUalSJIrjIptGeY9UTJr1Nk5HT/aT00jjIwiCvIUNbRdK90av2Y3j1Jityot68dBVc3YYdwwH3zOQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -141,33 +141,33 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "8.1.0-next.5",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0-next.5.tgz",
-      "integrity": "sha512-9l9lB8gXW1kPECKLC5Goc41pFztSCfODY3dvGaNTJ0KfRgwKIUyIhEBSdlWT2IU4uL4Tcl/zcitpb+Lj6QP7aQ=="
+      "version": "8.1.0-next.6",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0-next.6.tgz",
+      "integrity": "sha512-AahQokGczPwXKo1Qhnn3aqkZgwUJ0rjVwhWWKW5I5LEWRoqfnWkQp7haVIV6GJRX0oyGL2ezVy7IhwgP5u/3xw=="
     },
     "vscode-languageclient": {
-      "version": "8.1.0-next.4",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0-next.4.tgz",
-      "integrity": "sha512-dwo3Vf1aAb3o62mDhLHRGqYaLAYWN5RXAbHKL85Cs+yCJghxYzseuGGBvOUOH3BF5scnCU2BFrghekyP1xCUmQ==",
+      "version": "8.1.0-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0-next.5.tgz",
+      "integrity": "sha512-RbL68ENqp2uPDs1rsPiD8IfhPWzUP8e12ONdtpmSlR6kmj6FLOd8fEaC1pQMGDtfPfiFCpLav8YytH25QOYwRQ==",
       "requires": {
         "minimatch": "^5.1.0",
         "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.3-next.4"
+        "vscode-languageserver-protocol": "3.17.3-next.5"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.3-next.4",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3-next.4.tgz",
-      "integrity": "sha512-G6XrjZGSe2LIo7uDa860JKX97sLKc1vQF4AU4SW8DI7NNVKxnCB+vEs8gYHmle7kD9v13PvFkDCBD5ApeONGNQ==",
+      "version": "3.17.3-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3-next.5.tgz",
+      "integrity": "sha512-9HafkatRVhBVpWQrODes4JaoSu7ozHQUOzYiTmfMmxeFOUYgsSqyODp+j/c+SovcsuwABjuqnsQ9RiFkXCbeMA==",
       "requires": {
-        "vscode-jsonrpc": "8.1.0-next.5",
-        "vscode-languageserver-types": "3.17.3-next.1"
+        "vscode-jsonrpc": "8.1.0-next.6",
+        "vscode-languageserver-types": "3.17.3-next.2"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.17.3-next.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3-next.1.tgz",
-      "integrity": "sha512-i7HXZs5CdNibVHXZORZw9m5Bm0mfXiGhD/tZv6f7arBtz4iatgiiHu2qInxn0fKeahhMJoBbp6irhsL9+E3UAA=="
+      "version": "3.17.3-next.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3-next.2.tgz",
+      "integrity": "sha512-3kkNSCycNKUalSJIrjIptGeY9UTJr1Nk5HT/aT00jjIwiCvIUNbRdK90av2Y3j1Jityot68dBVc3YYdwwH3zOQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,6 @@
   "author": "chenglou",
   "license": "MIT",
   "dependencies": {
-    "vscode-languageclient": "8.1.0-next.4"
+    "vscode-languageclient": "8.1.0-next.5"
   }
 }


### PR DESCRIPTION
While we fixed #686 already with a little workaround, I think it's better not to use a broken version of the `vscode-languageserver-node` client.