### PR TITLE
implement exhaustive switch completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Expand options in completion to make working with options a bit more ergonomic. https://github.com/rescript-lang/rescript-vscode/pull/690
 - Let `_` trigger completion in patterns. https://github.com/rescript-lang/rescript-vscode/pull/692
 - Support inline records in completion. https://github.com/rescript-lang/rescript-vscode/pull/695
+- Add way to autocomplete an exhaustive switch statement for identifiers. Example: an identifier that's a variant can have a switch autoinserted matching all variant cases. https://github.com/rescript-lang/rescript-vscode/pull/699
 
 #### :nail_care: Polish
 

--- a/analysis/src/Protocol.ml
+++ b/analysis/src/Protocol.ml
@@ -47,6 +47,7 @@ type completionItem = {
   tags: int list;
   detail: string;
   sortText: string option;
+  filterText: string option;
   insertTextFormat: insertTextFormat option;
   insertText: string option;
   documentation: markupContent option;
@@ -129,6 +130,7 @@ let stringifyCompletionItem c =
           | None -> null
           | Some doc -> stringifyMarkupContent doc) );
       ("sortText", optWrapInQuotes c.sortText);
+      ("filterText", optWrapInQuotes c.filterText);
       ("insertText", optWrapInQuotes c.insertText);
       ( "insertTextFormat",
         match c.insertTextFormat with

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -182,3 +182,27 @@ let rec getUnqualifiedName txt =
   | Longident.Lident fieldName -> fieldName
   | Ldot (t, _) -> getUnqualifiedName t
   | _ -> ""
+
+let indent n text =
+  let spaces = String.make n ' ' in
+  let len = String.length text in
+  let text =
+    if len != 0 && text.[len - 1] = '\n' then String.sub text 0 (len - 1)
+    else text
+  in
+  let lines = String.split_on_char '\n' text in
+  match lines with
+  | [] -> ""
+  | [line] -> line
+  | line :: lines ->
+    line ^ "\n"
+    ^ (lines |> List.map (fun line -> spaces ^ line) |> String.concat "\n")
+
+let mkPosition (pos : Pos.t) =
+  let line, character = pos in
+  {Protocol.line; character}
+
+let rangeOfLoc (loc : Location.t) =
+  let start = loc |> Loc.start |> mkPosition in
+  let end_ = loc |> Loc.end_ |> mkPosition in
+  {Protocol.start; end_}

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -252,21 +252,6 @@ module AddTypeAnnotation = struct
         | _ -> ()))
 end
 
-let indent n text =
-  let spaces = String.make n ' ' in
-  let len = String.length text in
-  let text =
-    if len != 0 && text.[len - 1] = '\n' then String.sub text 0 (len - 1)
-    else text
-  in
-  let lines = String.split_on_char '\n' text in
-  match lines with
-  | [] -> ""
-  | [line] -> line
-  | line :: lines ->
-    line ^ "\n"
-    ^ (lines |> List.map (fun line -> spaces ^ line) |> String.concat "\n")
-
 let parse ~filename =
   let {Res_driver.parsetree = structure; comments} =
     Res_driver.parsingEngine.parseImplementation ~forPrinter:false ~filename
@@ -283,7 +268,7 @@ let parse ~filename =
     structure
     |> Res_printer.printImplementation ~width:!Res_cli.ResClflags.width
          ~comments:(comments |> filterComments ~loc:expr.pexp_loc)
-    |> indent range.start.character
+    |> Utils.indent range.start.character
   in
   let printStructureItem ~(range : Protocol.range)
       (item : Parsetree.structure_item) =
@@ -291,7 +276,7 @@ let parse ~filename =
     structure
     |> Res_printer.printImplementation ~width:!Res_cli.ResClflags.width
          ~comments:(comments |> filterComments ~loc:item.pstr_loc)
-    |> indent range.start.character
+    |> Utils.indent range.start.character
   in
   (structure, printExpr, printStructureItem)
 

--- a/analysis/tests/src/ExhaustiveSwitch.res
+++ b/analysis/tests/src/ExhaustiveSwitch.res
@@ -1,0 +1,19 @@
+type someVariant = One | Two | Three(option<bool>)
+type somePolyVariant = [#one | #two | #three(option<bool>)]
+
+let withSomeVariant = One
+let withSomePoly: somePolyVariant = #one
+let someBool = true
+let someOpt = Some(true)
+
+// switch withSomeVarian
+//                      ^com
+
+// switch withSomePol
+//                   ^com
+
+// switch someBoo
+//               ^com
+
+// switch someOp
+//              ^com

--- a/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -1,0 +1,80 @@
+Complete src/ExhaustiveSwitch.res 8:24
+XXX Not found!
+Completable: CexhaustiveSwitch Value[withSomeVarian]
+[{
+    "label": "withSomeVariant",
+    "kind": 12,
+    "tags": [],
+    "detail": "someVariant",
+    "documentation": null
+  }, {
+    "label": "withSomeVariant (exhaustive switch)",
+    "kind": 15,
+    "tags": [],
+    "detail": "insert exhaustive switch for value",
+    "documentation": null,
+    "filterText": "withSomeVariant",
+    "insertText": "withSomeVariant {\n   | One => ${1:failwith(\"todo\")}\n   | Two => ${2:failwith(\"todo\")}\n   | Three(_) => ${3:failwith(\"todo\")}\n   }",
+    "insertTextFormat": 2
+  }]
+
+Complete src/ExhaustiveSwitch.res 11:21
+XXX Not found!
+Completable: CexhaustiveSwitch Value[withSomePol]
+[{
+    "label": "withSomePoly",
+    "kind": 12,
+    "tags": [],
+    "detail": "somePolyVariant",
+    "documentation": null
+  }, {
+    "label": "withSomePoly (exhaustive switch)",
+    "kind": 15,
+    "tags": [],
+    "detail": "insert exhaustive switch for value",
+    "documentation": null,
+    "filterText": "withSomePoly",
+    "insertText": "withSomePoly {\n   | | #one => ${1:failwith(\"todo\")}\n   | | #three(_) => ${2:failwith(\"todo\")}\n   | | #two => ${3:failwith(\"todo\")}\n   }",
+    "insertTextFormat": 2
+  }]
+
+Complete src/ExhaustiveSwitch.res 14:17
+XXX Not found!
+Completable: CexhaustiveSwitch Value[someBoo]
+[{
+    "label": "someBool",
+    "kind": 12,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "someBool (exhaustive switch)",
+    "kind": 15,
+    "tags": [],
+    "detail": "insert exhaustive switch for value",
+    "documentation": null,
+    "filterText": "someBool",
+    "insertText": "someBool {\n   | true => ${1:failwith(\"todo\")}\n   | false => ${2:failwith(\"todo\")}\n   }",
+    "insertTextFormat": 2
+  }]
+
+Complete src/ExhaustiveSwitch.res 17:16
+XXX Not found!
+Completable: CexhaustiveSwitch Value[someOp]
+[{
+    "label": "someOpt",
+    "kind": 12,
+    "tags": [],
+    "detail": "option<bool>",
+    "documentation": null
+  }, {
+    "label": "someOpt (exhaustive switch)",
+    "kind": 15,
+    "tags": [],
+    "detail": "insert exhaustive switch for value",
+    "documentation": null,
+    "filterText": "someOpt",
+    "insertText": "someOpt {\n   | Some($1) => ${2:failwith(\"todo\")}\n   | None => ${3:failwith(\"todo\")}\n   }",
+    "insertTextFormat": 2
+  }]
+

--- a/snippets.json
+++ b/snippets.json
@@ -9,17 +9,6 @@
 			"}"
 		]
 	},
-	"Switch": {
-		"prefix": [
-			"switch"
-		],
-		"body": [
-			"switch ${1:value} {",
-			"| ${2:pattern1} => ${3:expression}",
-			"${4:| ${5:pattern2} => ${6:expression}}",
-			"}"
-		]
-	},
 	"Try": {
 		"prefix": [
 			"try"


### PR DESCRIPTION
This is a proposal to solve https://github.com/rescript-lang/rescript-vscode/issues/253.
It's also the first step of https://github.com/rescript-lang/rescript-vscode/issues/684, moving snippets into the analysis bin and only outputting them where they make sense.

![exhaustive-switch](https://user-images.githubusercontent.com/1457626/212567893-4622be04-94fe-49b1-9093-4c695618855a.gif)
(this GIF isn't 100% accurate, I've done some cosmetic fixes to the completion list since recording it)

This PR does the following: When completing.. 
- an _ident_ after a _switch_
- and the switch has no cases
- and the type of the ident we're completing is something we can (reasonably) generate an exhaustive switch for
- ...add a separate completion item for the ident that, when chosen, inserts an exhaustive switch statement for that ident

Closes https://github.com/rescript-lang/rescript-vscode/issues/253