### PR TITLE
[WIP] Annotated completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Support inline records in completion. https://github.com/rescript-lang/rescript-vscode/pull/695
 - Add way to autocomplete an exhaustive switch statement for identifiers. Example: an identifier that's a variant can have a switch autoinserted matching all variant cases. https://github.com/rescript-lang/rescript-vscode/pull/699
 - Support typed expression completion for lowercase (builtin) JSX tags. https://github.com/rescript-lang/rescript-vscode/pull/702
+- Support typed expression completion driven by type annotations. https://github.com/rescript-lang/rescript-vscode/pull/711
 
 #### :nail_care: Polish
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -598,8 +598,10 @@ let completionsGetCompletionType ~full = function
   | {Completion.kind = ExtractedType (typ, _); env} :: _ -> Some (typ, env)
   | _ -> None
 
+type getCompletionsForContextPathMode = Regular | Pipe
+
 let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
-    ~exact ~scope ?(mode = `Regular) (contextPath : Completable.contextPath) =
+    ~exact ~scope ?(mode = Regular) (contextPath : Completable.contextPath) =
   let package = full.package in
   match contextPath with
   | CPString ->
@@ -632,7 +634,7 @@ let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
     ]
   | CPArray (Some cp) -> (
     match mode with
-    | `Regular -> (
+    | Regular -> (
       match
         cp
         |> getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos
@@ -645,7 +647,7 @@ let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
           Completion.create "dummy" ~env
             ~kind:(Completion.ExtractedType (Tarray (env, typ), `Type));
         ])
-    | `Pipe ->
+    | Pipe ->
       (* Pipe completion with array just needs to know that it's an array, not
          what inner type it has. *)
       [
@@ -772,7 +774,7 @@ let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
     match
       cp
       |> getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
-           ~exact:true ~scope ~mode:`Pipe
+           ~exact:true ~scope ~mode:Pipe
       |> completionsGetTypeEnv
     with
     | None -> []

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -630,6 +630,19 @@ let rec getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
           (Completion.Value
              (Ctype.newconstr (Path.Pident (Ident.create "array")) []));
     ]
+  | CPOption cp -> (
+    match
+      cp
+      |> getCompletionsForContextPath ~full ~opens ~rawOpens ~allFiles ~pos ~env
+           ~exact:true ~scope
+      |> completionsGetCompletionType ~full
+    with
+    | None -> []
+    | Some (typ, env) ->
+      [
+        Completion.create "dummy" ~env
+          ~kind:(Completion.ExtractedType (Toption (env, typ), `Type));
+      ])
   | CPId (path, completionContext) ->
     path
     |> getCompletionsForPath ~package ~opens ~allFiles ~pos ~exact

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -141,7 +141,12 @@ let rec exprToContextPath (e : Parsetree.expression) =
   | Pexp_constant (Pconst_string _) -> Some Completable.CPString
   | Pexp_constant (Pconst_integer _) -> Some CPInt
   | Pexp_constant (Pconst_float _) -> Some CPFloat
-  | Pexp_array _ -> Some CPArray
+  | Pexp_array exprs ->
+    Some
+      (CPArray
+         (match exprs with
+         | [] -> None
+         | exp :: _ -> exprToContextPath exp))
   | Pexp_ident {txt} -> Some (CPId (Utils.flattenLongIdent txt, Value))
   | Pexp_field (e1, {txt = Lident name}) -> (
     match exprToContextPath e1 with

--- a/analysis/src/DumpAst.ml
+++ b/analysis/src/DumpAst.ml
@@ -59,10 +59,10 @@ let printCoreType typ ~pos =
   match typ.ptyp_desc with
   | Ptyp_any -> "Ptyp_any"
   | Ptyp_var name -> "Ptyp_var(" ^ str name ^ ")"
-  | Ptyp_constr (loc, _types) ->
+  | Ptyp_constr (lid, _types) ->
     "Ptyp_constr("
-    ^ (loc |> printLocDenominatorLoc ~pos)
-    ^ (Utils.flattenLongIdent loc.txt |> ident |> str)
+    ^ (lid |> printLocDenominatorLoc ~pos)
+    ^ (Utils.flattenLongIdent lid.txt |> ident |> str)
     ^ ")"
   | Ptyp_variant _ -> "Ptyp_variant(<unimplemented>)"
   | _ -> "<unimplemented_ptyp_desc>"

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -64,6 +64,7 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         ~item:
           {
             Type.decl;
+            name = ident.name;
             kind =
               (match type_kind with
               | Type_abstract -> (
@@ -167,6 +168,7 @@ let forTypeDeclaration ~env ~(exported : Exported.t)
       ~item:
         {
           Type.decl = typ_type;
+          name = name.txt;
           kind =
             (match typ_kind with
             | Ttype_abstract -> (

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -64,7 +64,7 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         ~item:
           {
             Type.decl;
-            name = ident.name;
+            name = name.txt;
             kind =
               (match type_kind with
               | Type_abstract -> (

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -297,7 +297,7 @@ type polyVariantConstructor = {name: string; args: Types.type_expr list}
 (** An type that can be used to drive completion *)
 type completionType =
   | Tuple of QueryEnv.t * Types.type_expr list * Types.type_expr
-  | Toption of QueryEnv.t * Types.type_expr
+  | Toption of QueryEnv.t * completionType
   | Tbool of QueryEnv.t
   | Tarray of QueryEnv.t * Types.type_expr
   | Tstring of QueryEnv.t

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -315,7 +315,11 @@ type completionType =
   | Trecord of {
       env: QueryEnv.t;
       fields: field list;
-      name: [`Str of string | `TypeExpr of Types.type_expr];
+      definition:
+        [ `NameOnly of string
+          (** When we only have the name, like when pulling the record from a declared type. *)
+        | `TypeExpr of Types.type_expr
+          (** When we have the full type expr from the compiler. *) ];
     }
   | TinlineRecord of {env: QueryEnv.t; fields: field list}
   | Tfunction of {env: QueryEnv.t; args: typedFnArg list; typ: Types.type_expr}

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -589,6 +589,7 @@ module Completable = struct
     | CPArray
     | CPInt
     | CPFloat
+    | CPOption of contextPath
     | CPApply of contextPath * Asttypes.arg_label list
     | CPId of string list * completionContext
     | CPField of contextPath * string
@@ -662,6 +663,7 @@ module Completable = struct
       | CPString -> "string"
       | CPInt -> "int"
       | CPFloat -> "float"
+      | CPOption ctxPath -> "option<" ^ contextPathToString ctxPath ^ ">"
       | CPApply (cp, labels) ->
         contextPathToString cp ^ "("
         ^ (labels

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -322,8 +322,6 @@ type extractedType =
 
 type completionType =
   | TypeExpr of Types.type_expr
-  | InlineRecord of field list
-  | ResolvedType of Type.t
   | ExtractedType of extractedType
 
 module Completion = struct

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -299,7 +299,7 @@ type completionType =
   | Tuple of QueryEnv.t * Types.type_expr list * Types.type_expr
   | Toption of QueryEnv.t * completionType
   | Tbool of QueryEnv.t
-  | Tarray of QueryEnv.t * Types.type_expr
+  | Tarray of QueryEnv.t * completionType
   | Tstring of QueryEnv.t
   | Tvariant of {
       env: QueryEnv.t;
@@ -336,7 +336,7 @@ module Completion = struct
     | Field of field * string
     | FileModule of string
     | Snippet of string
-    | ExtractedType of completionType
+    | ExtractedType of completionType * [`Value | `Type]
 
   type t = {
     name: string;
@@ -387,8 +387,8 @@ module Completion = struct
     | ObjLabel _ -> 4
     | Label _ -> 4
     | Field (_, _) -> 5
-    | Type _ | ExtractedType _ -> 22
-    | Value _ -> 12
+    | Type _ | ExtractedType (_, `Type) -> 22
+    | Value _ | ExtractedType (_, `Value) -> 12
     | Snippet _ -> 15
 end
 

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -294,8 +294,8 @@ end
 
 type polyVariantConstructor = {name: string; args: Types.type_expr list}
 
-(** An extracted type from a type expr *)
-type extractedType =
+(** An type that can be used to drive completion *)
+type completionType =
   | Tuple of QueryEnv.t * Types.type_expr list * Types.type_expr
   | Toption of QueryEnv.t * Types.type_expr
   | Tbool of QueryEnv.t
@@ -320,10 +320,6 @@ type extractedType =
   | TinlineRecord of {env: QueryEnv.t; fields: field list}
   | Tfunction of {env: QueryEnv.t; args: typedFnArg list; typ: Types.type_expr}
 
-type completionType =
-  | TypeExpr of Types.type_expr
-  | ExtractedType of extractedType
-
 module Completion = struct
   type kind =
     | Module of Module.t
@@ -336,7 +332,7 @@ module Completion = struct
     | Field of field * string
     | FileModule of string
     | Snippet of string
-    | ExtractedType of extractedType
+    | ExtractedType of completionType
 
   type t = {
     name: string;

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -586,7 +586,7 @@ module Completable = struct
 
   type contextPath =
     | CPString
-    | CPArray
+    | CPArray of contextPath option
     | CPInt
     | CPFloat
     | CPOption of contextPath
@@ -673,7 +673,8 @@ module Completable = struct
                | Optional s -> "?" ^ s)
           |> String.concat ", ")
         ^ ")"
-      | CPArray -> "array"
+      | CPArray (Some ctxPath) -> "array<" ^ contextPathToString ctxPath ^ ">"
+      | CPArray None -> "array"
       | CPId (sl, completionContext) ->
         completionContextToString completionContext ^ list sl
       | CPField (cp, s) -> contextPathToString cp ^ "." ^ str s

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -34,8 +34,6 @@ type field = {
   docstring: string list;
 }
 
-type completionType = TypeExpr of Types.type_expr | InlineRecord of field list
-
 type constructorArgs =
   | InlineRecord of field list
   | Args of (Types.type_expr * Location.t) list
@@ -141,6 +139,11 @@ module Declared = struct
     item: 'item;
   }
 end
+
+type completionType =
+  | TypeExpr of Types.type_expr
+  | InlineRecord of field list
+  | ResolvedType of Type.t
 
 module Stamps : sig
   type t

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -381,8 +381,8 @@ let typeIsUnit (typ : Types.type_expr) =
 
 let contextPathFromCoreType (coreType : Parsetree.core_type) =
   match coreType.ptyp_desc with
-  | Ptyp_constr (loc, []) ->
-    Some (Completable.CPId (loc.txt |> Utils.flattenLongIdent, Type))
+  | Ptyp_constr (lid, []) ->
+    Some (Completable.CPId (lid.txt |> Utils.flattenLongIdent, Type))
   | _ -> None
 
 let printRecordFromFields ?name (fields : field list) =

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -379,10 +379,13 @@ let typeIsUnit (typ : Types.type_expr) =
     true
   | _ -> false
 
-let contextPathFromCoreType (coreType : Parsetree.core_type) =
+let rec contextPathFromCoreType (coreType : Parsetree.core_type) =
   match coreType.ptyp_desc with
-  | Ptyp_constr (lid, []) ->
-    Some (Completable.CPId (lid.txt |> Utils.flattenLongIdent, Type))
+  | Ptyp_constr ({txt = Lident "option"}, [innerTyp]) ->
+    innerTyp |> contextPathFromCoreType
+    |> Option.map (fun innerTyp -> Completable.CPOption innerTyp)
+  | Ptyp_constr (lid, _) ->
+    Some (CPId (lid.txt |> Utils.flattenLongIdent, Type))
   | _ -> None
 
 let printRecordFromFields ?name (fields : field list) =

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -212,3 +212,10 @@ let rec expandPath (path : Path.t) =
   | Pident id -> [Ident.name id]
   | Pdot (p, s, _) -> s :: expandPath p
   | Papply _ -> []
+
+module Option = struct
+  let flatMap f o =
+    match o with
+    | None -> None
+    | Some v -> f v
+end

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -168,6 +168,7 @@ let rec unwrapIfOption (t : Types.type_expr) =
   | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> unwrapIfOption t1
   | Tconstr (Path.Pident {name = "option"}, [unwrappedType], _) -> unwrappedType
   | _ -> t
+
 let isReactComponent (vb : Parsetree.value_binding) =
   vb.pvb_attributes
   |> List.exists (function

--- a/analysis/tests/src/CompletionTypeAnnotation.res
+++ b/analysis/tests/src/CompletionTypeAnnotation.res
@@ -40,3 +40,18 @@ type someTuple = (bool, option<bool>)
 
 // let x: option<someVariant> =
 //                             ^com
+
+// let x: option<someVariant> = Some()
+//                                   ^com
+
+// let x: array<someVariant> =
+//                            ^com
+
+// let x: array<someVariant> = []
+//                              ^com
+
+// let x: array<option<someVariant>> =
+//                                    ^com
+
+// let x: option<array<someVariant>> = Some([])
+//                                           ^com

--- a/analysis/tests/src/CompletionTypeAnnotation.res
+++ b/analysis/tests/src/CompletionTypeAnnotation.res
@@ -24,3 +24,16 @@ type somePolyVariant = [#one | #two(bool)]
 
 // let x: somePolyVariant = #o
 //                            ^com
+
+type someFunc = (int, string) => bool
+
+// let x: someFunc =
+//                  ^com
+
+type someTuple = (bool, option<bool>)
+
+// let x: someTuple =
+//                   ^com
+
+// let x: someTuple = (true, )
+//                          ^com

--- a/analysis/tests/src/CompletionTypeAnnotation.res
+++ b/analysis/tests/src/CompletionTypeAnnotation.res
@@ -37,3 +37,6 @@ type someTuple = (bool, option<bool>)
 
 // let x: someTuple = (true, )
 //                          ^com
+
+// let x: option<someVariant> =
+//                             ^com

--- a/analysis/tests/src/CompletionTypeAnnotation.res
+++ b/analysis/tests/src/CompletionTypeAnnotation.res
@@ -1,0 +1,26 @@
+type someRecord = {
+  age: int,
+  name: string,
+}
+
+type someVariant = One | Two(bool)
+
+type somePolyVariant = [#one | #two(bool)]
+
+// let x: someRecord =
+//                    ^com
+
+// let x: someRecord = {}
+//                      ^com
+
+// let x: someVariant =
+//                     ^com
+
+// let x: someVariant = O
+//                       ^com
+
+// let x: somePolyVariant =
+//                         ^com
+
+// let x: somePolyVariant = #o
+//                            ^com

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -379,7 +379,7 @@ Found type for function (~age: int, ~name: string) => string
 
 Complete src/Completion.res 26:13
 posCursor:[26:13] posNoWhite:[26:12] Found expr:[26:3->26:13]
-Completable: Cpath array->m
+Completable: Cpath array<int>->m
 [{
     "label": "Js.Array2.mapi",
     "kind": 12,

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -169,7 +169,7 @@ Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(nested
     "insertTextFormat": 2
   }, {
     "label": "Some({})",
-    "kind": 12,
+    "kind": 22,
     "tags": [],
     "detail": "otherRecord",
     "documentation": null,
@@ -264,7 +264,7 @@ Pexp_apply ...[56:11->56:25] (...[56:26->56:60])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($0)
 [{
     "label": "{}",
-    "kind": 12,
+    "kind": 22,
     "tags": [],
     "detail": "someRecord",
     "documentation": null,
@@ -590,7 +590,7 @@ Pexp_apply ...[135:11->135:31] (...[135:32->135:66])
 Completable: Cexpression CArgument Value[fnTakingInlineRecord]($0)->variantPayload::WithInlineRecord($0), recordField(nestedRecord)
 [{
     "label": "{}",
-    "kind": 12,
+    "kind": 22,
     "tags": [],
     "detail": "otherRecord",
     "documentation": null,

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -497,13 +497,13 @@ Completable: Cexpression CArgument Value[fnTakingRecordWithOptVariant]($0)->reco
     "label": "None",
     "kind": 4,
     "tags": [],
-    "detail": "someVariant",
+    "detail": "type someVariant = One | Two | Three(int, string)",
     "documentation": null
   }, {
     "label": "Some(_)",
     "kind": 4,
     "tags": [],
-    "detail": "someVariant",
+    "detail": "type someVariant = One | Two | Three(int, string)",
     "documentation": null,
     "insertText": "Some(${1:_})",
     "insertTextFormat": 2

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -169,7 +169,7 @@ Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(nested
     "insertTextFormat": 2
   }, {
     "label": "Some({})",
-    "kind": 22,
+    "kind": 12,
     "tags": [],
     "detail": "otherRecord",
     "documentation": null,
@@ -264,7 +264,7 @@ Pexp_apply ...[56:11->56:25] (...[56:26->56:60])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($0)
 [{
     "label": "{}",
-    "kind": 22,
+    "kind": 12,
     "tags": [],
     "detail": "someRecord",
     "documentation": null,
@@ -590,7 +590,7 @@ Pexp_apply ...[135:11->135:31] (...[135:32->135:66])
 Completable: Cexpression CArgument Value[fnTakingInlineRecord]($0)->variantPayload::WithInlineRecord($0), recordField(nestedRecord)
 [{
     "label": "{}",
-    "kind": 22,
+    "kind": 12,
     "tags": [],
     "detail": "otherRecord",
     "documentation": null,

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -158,7 +158,7 @@ Completable: Cexpression CArgument Value[someFnTakingVariant]($0)=So
     "label": "Some(_)",
     "kind": 4,
     "tags": [],
-    "detail": "someVariant",
+    "detail": "type someVariant = One | Two | Three(int, string)",
     "documentation": null,
     "sortText": "A Some(_)",
     "insertText": "Some(${1:_})",

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -410,7 +410,7 @@ XXX Not found!
 Completable: Cpattern Value[c]
 [{
     "label": "[]",
-    "kind": 12,
+    "kind": 22,
     "tags": [],
     "detail": "bool",
     "documentation": null,
@@ -539,7 +539,7 @@ posCursor:[143:35] posNoWhite:[143:34] Found pattern:[143:20->143:38]
 Completable: Cpattern Value[p]->variantPayload::Test($3)
 [{
     "label": "[]",
-    "kind": 12,
+    "kind": 22,
     "tags": [],
     "detail": "bool",
     "documentation": null,
@@ -625,7 +625,7 @@ posCursor:[159:36] posNoWhite:[159:35] Found pattern:[159:21->159:38]
 Completable: Cpattern Value[v]->polyvariantPayload::test($3)
 [{
     "label": "[]",
-    "kind": 12,
+    "kind": 22,
     "tags": [],
     "detail": "bool",
     "documentation": null,

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -76,7 +76,7 @@ XXX Not found!
 Completable: Cpattern Value[f]
 [{
     "label": "{}",
-    "kind": 12,
+    "kind": 22,
     "tags": [],
     "detail": "someRecord",
     "documentation": null,
@@ -166,7 +166,7 @@ posCursor:[61:22] posNoWhite:[61:21] Found pattern:[61:16->61:25]
 Completable: Cpattern Value[f]->recordField(nest)
 [{
     "label": "{}",
-    "kind": 12,
+    "kind": 22,
     "tags": [],
     "detail": "nestedRecord",
     "documentation": null,

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -110,3 +110,61 @@ Completable: Cexpression Type[somePolyVariant]=#o
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionTypeAnnotation.res 29:20
+XXX Not found!
+Completable: Cexpression Type[someFunc]
+[{
+    "label": "(v1, v2) => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "(int, string) => bool",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "(${1:v1}, ${2:v2}) => {$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionTypeAnnotation.res 34:21
+XXX Not found!
+Completable: Cexpression Type[someTuple]
+[{
+    "label": "(_, _)",
+    "kind": 12,
+    "tags": [],
+    "detail": "(bool, option<bool>)",
+    "documentation": null,
+    "insertText": "(${1:_}, ${2:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionTypeAnnotation.res 37:28
+XXX Not found!
+Completable: Cexpression Type[someTuple]->tuple($1)
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }, {
+    "label": "Some(true)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }, {
+    "label": "Some(false)",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -203,3 +203,94 @@ Completable: Cexpression option<Type[someVariant]>
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionTypeAnnotation.res 43:37
+XXX Not found!
+Completable: Cexpression option<Type[someVariant]>->variantPayload::Some($0)
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
+  }, {
+    "label": "Two(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "Two(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionTypeAnnotation.res 46:30
+XXX Not found!
+Completable: Cexpression array<Type[someVariant]>
+[{
+    "label": "[]",
+    "kind": 12,
+    "tags": [],
+    "detail": "type someVariant = One | Two(bool)",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "[$0]",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionTypeAnnotation.res 49:32
+XXX Not found!
+Completable: Cexpression array<Type[someVariant]>->array
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
+  }, {
+    "label": "Two(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "Two(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionTypeAnnotation.res 52:38
+XXX Not found!
+Completable: Cexpression array<option<Type[someVariant]>>
+[{
+    "label": "[]",
+    "kind": 12,
+    "tags": [],
+    "detail": "option<someVariant>",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "[$0]",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionTypeAnnotation.res 55:45
+XXX Not found!
+Completable: Cexpression option<array<Type[someVariant]>>->variantPayload::Some($0), array
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
+  }, {
+    "label": "Two(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "Two(${1:_})",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -168,3 +168,38 @@ Completable: Cexpression Type[someTuple]->tuple($1)
     "documentation": null
   }]
 
+Complete src/CompletionTypeAnnotation.res 40:31
+XXX Not found!
+Completable: Cexpression option<Type[someVariant]>
+[{
+    "label": "None",
+    "kind": 4,
+    "tags": [],
+    "detail": "type someVariant = One | Two(bool)",
+    "documentation": null
+  }, {
+    "label": "Some(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "type someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "Some(${1:_})",
+    "insertTextFormat": 2
+  }, {
+    "label": "Some(One)",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "Some(One)",
+    "insertTextFormat": 2
+  }, {
+    "label": "Some(Two(_))",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
+    "documentation": null,
+    "insertText": "Some(Two(${1:_}))",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -3,9 +3,9 @@ XXX Not found!
 Completable: Cexpression Type[someRecord]
 [{
     "label": "{}",
-    "kind": 4,
+    "kind": 22,
     "tags": [],
-    "detail": "Inline record",
+    "detail": "type someRecord = {age: int, name: string}",
     "documentation": null,
     "sortText": "A",
     "insertText": "{$0}",
@@ -17,15 +17,15 @@ XXX Not found!
 Completable: Cexpression Type[someRecord]->recordBody
 [{
     "label": "age",
-    "kind": 4,
+    "kind": 5,
     "tags": [],
-    "detail": "Inline record",
+    "detail": "age: int\n\ntype someRecord = {age: int, name: string}",
     "documentation": null
   }, {
     "label": "name",
-    "kind": 4,
+    "kind": 5,
     "tags": [],
-    "detail": "Inline record",
+    "detail": "name: string\n\ntype someRecord = {age: int, name: string}",
     "documentation": null
   }]
 
@@ -36,7 +36,7 @@ Completable: Cexpression Type[someVariant]
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype  = One | Two(bool)",
+    "detail": "One\n\ntype someVariant = One | Two(bool)",
     "documentation": null,
     "insertText": "One",
     "insertTextFormat": 2
@@ -44,7 +44,7 @@ Completable: Cexpression Type[someVariant]
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype  = One | Two(bool)",
+    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
     "documentation": null,
     "insertText": "Two(${1:_})",
     "insertTextFormat": 2
@@ -57,7 +57,7 @@ Completable: Cexpression Type[someVariant]=O
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype  = One | Two(bool)",
+    "detail": "One\n\ntype someVariant = One | Two(bool)",
     "documentation": null,
     "sortText": "A One",
     "insertText": "One",

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -1,25 +1,67 @@
 Complete src/CompletionTypeAnnotation.res 9:22
 XXX Not found!
-[]
+Completable: Cexpression Type[someRecord]
+[{
+    "label": "{}",
+    "kind": 4,
+    "tags": [],
+    "detail": "Inline record",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "{$0}",
+    "insertTextFormat": 2
+  }]
 
 Complete src/CompletionTypeAnnotation.res 12:24
-posCursor:[12:24] posNoWhite:[12:23] Found expr:[12:23->12:25]
-[]
+XXX Not found!
+Completable: Cexpression Type[someRecord]->recordBody
+[{
+    "label": "age",
+    "kind": 4,
+    "tags": [],
+    "detail": "Inline record",
+    "documentation": null
+  }, {
+    "label": "name",
+    "kind": 4,
+    "tags": [],
+    "detail": "Inline record",
+    "documentation": null
+  }]
 
 Complete src/CompletionTypeAnnotation.res 15:23
 XXX Not found!
-[]
-
-Complete src/CompletionTypeAnnotation.res 18:25
-posCursor:[18:25] posNoWhite:[18:24] Found expr:[18:24->18:25]
-Pexp_construct O:[18:24->18:25] None
-Completable: Cpath Value[O]
+Completable: Cexpression Type[someVariant]
 [{
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool)",
-    "documentation": null
+    "detail": "One\n\ntype  = One | Two(bool)",
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
+  }, {
+    "label": "Two(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two(bool)\n\ntype  = One | Two(bool)",
+    "documentation": null,
+    "insertText": "Two(${1:_})",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionTypeAnnotation.res 18:25
+XXX Not found!
+Completable: Cexpression Type[someVariant]=O
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype  = One | Two(bool)",
+    "documentation": null,
+    "sortText": "A One",
+    "insertText": "One",
+    "insertTextFormat": 2
   }, {
     "label": "Obj",
     "kind": 9,
@@ -36,9 +78,35 @@ Completable: Cpath Value[O]
 
 Complete src/CompletionTypeAnnotation.res 21:27
 XXX Not found!
-[]
+Completable: Cexpression Type[somePolyVariant]
+[{
+    "label": "#one",
+    "kind": 4,
+    "tags": [],
+    "detail": "#one\n\n[#one | #two(bool)]",
+    "documentation": null,
+    "insertText": "#one",
+    "insertTextFormat": 2
+  }, {
+    "label": "#two(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "#two(bool)\n\n[#one | #two(bool)]",
+    "documentation": null,
+    "insertText": "#two(${1:_})",
+    "insertTextFormat": 2
+  }]
 
 Complete src/CompletionTypeAnnotation.res 24:30
-posCursor:[24:30] posNoWhite:[24:29] Found expr:[24:28->24:30]
-[]
+XXX Not found!
+Completable: Cexpression Type[somePolyVariant]=#o
+[{
+    "label": "#one",
+    "kind": 4,
+    "tags": [],
+    "detail": "#one\n\n[#one | #two(bool)]",
+    "documentation": null,
+    "insertText": "one",
+    "insertTextFormat": 2
+  }]
 

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -1,0 +1,44 @@
+Complete src/CompletionTypeAnnotation.res 9:22
+XXX Not found!
+[]
+
+Complete src/CompletionTypeAnnotation.res 12:24
+posCursor:[12:24] posNoWhite:[12:23] Found expr:[12:23->12:25]
+[]
+
+Complete src/CompletionTypeAnnotation.res 15:23
+XXX Not found!
+[]
+
+Complete src/CompletionTypeAnnotation.res 18:25
+posCursor:[18:25] posNoWhite:[18:24] Found expr:[18:24->18:25]
+Pexp_construct O:[18:24->18:25] None
+Completable: Cpath Value[O]
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two(bool)",
+    "documentation": null
+  }, {
+    "label": "Obj",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }, {
+    "label": "Object",
+    "kind": 9,
+    "tags": [],
+    "detail": "file module",
+    "documentation": null
+  }]
+
+Complete src/CompletionTypeAnnotation.res 21:27
+XXX Not found!
+[]
+
+Complete src/CompletionTypeAnnotation.res 24:30
+posCursor:[24:30] posNoWhite:[24:29] Found expr:[24:28->24:30]
+[]
+

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -3,7 +3,7 @@ XXX Not found!
 Completable: Cexpression Type[someRecord]
 [{
     "label": "{}",
-    "kind": 22,
+    "kind": 12,
     "tags": [],
     "detail": "type someRecord = {age: int, name: string}",
     "documentation": null,


### PR DESCRIPTION
Completion via annotations. E.g: `let x: someVariant = O<com>` completes for the variant `someVariant`, even if the let assignment hasn't compiled previously.

Only handles "basic" types as of now. No handling of options etc.

Currently quite messy, but looking for your feedback before I continue @cristianoc .