### PR TITLE
Fix jsx wrapping in completion

### DIFF
--- a/analysis/tests/src/CompletionJsxProps.res
+++ b/analysis/tests/src/CompletionJsxProps.res
@@ -19,3 +19,11 @@
 // let _ = <div onMouseEnter= />
 //                           ^com
 
+// Should wrap in {}
+// let _ = <CompletionSupport.TestComponent testArr=
+//                                                  ^com
+
+// Should not wrap in {}
+// let _ = <CompletionSupport.TestComponent testArr={[]}
+//                                                    ^com
+

--- a/analysis/tests/src/CompletionSupport.res
+++ b/analysis/tests/src/CompletionSupport.res
@@ -12,10 +12,12 @@ module TestComponent = {
   let make = (
     ~on: bool,
     ~test: testVariant,
+    ~testArr: array<testVariant>,
     ~polyArg: option<[#one | #two | #two2 | #three(int, bool)]>=?,
   ) => {
     ignore(on)
     ignore(test)
+    ignore(testArr)
     ignore(polyArg)
     React.null
   }

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -190,7 +190,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] testAr
     "tags": [],
     "detail": "One\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
-    "insertText": "{One}",
+    "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two",
@@ -198,7 +198,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] testAr
     "tags": [],
     "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
-    "insertText": "{Two}",
+    "insertText": "Two",
     "insertTextFormat": 2
   }, {
     "label": "Three(_)",
@@ -206,7 +206,7 @@ Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] testAr
     "tags": [],
     "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
     "documentation": null,
-    "insertText": "{Three(${1:_})}",
+    "insertText": "Three(${1:_})",
     "insertTextFormat": 2
   }]
 

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -165,3 +165,48 @@ Completable: Cexpression CJsxPropValue [div] onMouseEnter
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionJsxProps.res 22:52
+posCursor:[22:52] posNoWhite:[22:51] Found expr:[22:12->22:52]
+JSX <CompletionSupport.TestComponent:[22:12->22:43] testArr[22:44->22:51]=...__ghost__[0:-1->0:-1]> _children:None
+Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] testArr
+[{
+    "label": "[]",
+    "kind": 12,
+    "tags": [],
+    "detail": "type testVariant = One | Two | Three(int)",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "{[$0]}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionJsxProps.res 26:54
+posCursor:[26:54] posNoWhite:[26:53] Found expr:[26:12->26:56]
+JSX <CompletionSupport.TestComponent:[26:12->26:43] testArr[26:44->26:51]=...[26:53->26:55]> _children:None
+Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] testArr->array
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype testVariant = One | Two | Three(int)",
+    "documentation": null,
+    "insertText": "{One}",
+    "insertTextFormat": 2
+  }, {
+    "label": "Two",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
+    "documentation": null,
+    "insertText": "{Two}",
+    "insertTextFormat": 2
+  }, {
+    "label": "Three(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
+    "documentation": null,
+    "insertText": "{Three(${1:_})}",
+    "insertTextFormat": 2
+  }]
+


### PR DESCRIPTION
Didn't account for nested values when deciding when to insert braces for JSX prop values when completing.