### PR TITLE
prevent broken locs from being added to document symbols

### DIFF
--- a/analysis/src/DocumentSymbol.ml
+++ b/analysis/src/DocumentSymbol.ml
@@ -27,11 +27,16 @@ let kindNumber = function
 let command ~path =
   let symbols = ref [] in
   let addSymbol name loc kind =
-    let range = Utils.cmtLocToRange loc in
-    let symbol : Protocol.documentSymbolItem =
-      {name; range; kind = kindNumber kind; children = []}
-    in
-    symbols := symbol :: !symbols
+    if
+      (not loc.Location.loc_ghost)
+      && loc.loc_start.pos_cnum >= 0
+      && loc.loc_end.pos_cnum >= 0
+    then
+      let range = Utils.cmtLocToRange loc in
+      let symbol : Protocol.documentSymbolItem =
+        {name; range; kind = kindNumber kind; children = []}
+      in
+      symbols := symbol :: !symbols
   in
   let rec exprKind (exp : Parsetree.expression) =
     match exp.pexp_desc with


### PR DESCRIPTION
Closes https://github.com/rescript-lang/rescript-vscode/issues/735

@cristianoc problem was that broken code like this:
```rescript
type observer = {next:}
```

...would produce a document symbol entry looking like this:
![children Array(1))](https://user-images.githubusercontent.com/1457626/221667536-2a08644a-1319-46a5-b61b-a1026aa22796.png)

Notice `character: -1` in `end`.

Is the checking I'm doing unnecessarily much? I also found no good way to add tests for this since it's only happening in broken syntax.