### PR TITLE
prettify optional fields in completion detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Signature Help is now considered stable, and enabled for all users. Can still be turned off in settings.
 - Show whether record fields and variant constructors are deprecated when completing. https://github.com/rescript-lang/rescript-vscode/pull/731
+- Prettify how optional record fields are printed in the completion item detail. https://github.com/rescript-lang/rescript-vscode/pull/737
 
 ## 1.12.0
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -221,7 +221,15 @@ let kindToDetail name (kind : Completion.kind) =
   | Label typString -> typString
   | Module _ -> "module"
   | FileModule _ -> "file module"
-  | Field ({typ}, s) -> name ^ ": " ^ (typ |> Shared.typeToString) ^ "\n\n" ^ s
+  | Field ({typ; optional}, s) ->
+    (* Handle optional fields. Checking for "?" is because sometimes optional
+       fields are prefixed with "?" when completing, and at that point we don't
+       need to _also_ add a "?" after the field name, as that looks weird. *)
+    if optional && Utils.startsWith name "?" = false then
+      name ^ "?: "
+      ^ (typ |> Utils.unwrapIfOption |> Shared.typeToString)
+      ^ "\n\n" ^ s
+    else name ^ ": " ^ (typ |> Shared.typeToString) ^ "\n\n" ^ s
   | Constructor (c, s) -> showConstructor c ^ "\n\n" ^ s
   | PolyvariantConstructor ({name; args}, s) ->
     "#" ^ name

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -186,3 +186,13 @@ let something = {
   Js.log(s)
   //      ^com
 }
+
+let fff: recordWithOptionalField = {
+  someField: 123,
+  someOptField: true,
+}
+
+ignore(fff)
+
+// fff.someOpt
+//            ^com

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -747,3 +747,15 @@ Completable: Cexpression CArgument Value[Js, log]($0)=s
     "documentation": null
   }]
 
+Complete src/CompletionExpressions.res 196:14
+posCursor:[196:14] posNoWhite:[196:13] Found expr:[196:3->196:14]
+Pexp_field [196:3->196:6] someOpt:[196:7->196:14]
+Completable: Cpath Value[fff].someOpt
+[{
+    "label": "someOptField",
+    "kind": 5,
+    "tags": [],
+    "detail": "someOptField?: bool\n\ntype recordWithOptionalField = {\n  someField: int,\n  someOptField?: bool,\n}",
+    "documentation": null
+  }]
+


### PR DESCRIPTION
This prettifies how optional fields are printed in the completion detail.

Before:
```rescript
someOptionalField: option<int>
```

After:
```rescript
someOptionalField?: int
```