### PR TITLE
leverage new completion features to provide hover on (some) unsaved code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :rocket: New Feature
 
 - Greatly extend completion abilities for unsaved code. WARNING: Might be a bit unstable initially. Report any issues you see. https://github.com/rescript-lang/rescript-vscode/pull/712
+- Provide hovers for more unsaved code via the new completion features. https://github.com/rescript-lang/rescript-vscode/pull/749
 
 ## 1.14.0
 

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -4,7 +4,7 @@ let completion ~debug ~path ~pos ~currentFile =
       Completions.getCompletions ~debug ~path ~pos ~currentFile ~forHover:false
     with
     | None -> []
-    | Some (completions, _) -> completions
+    | Some (completions, _, _) -> completions
   in
   print_endline
     (completions

--- a/analysis/src/Completions.ml
+++ b/analysis/src/Completions.ml
@@ -19,4 +19,4 @@ let getCompletions ~debug ~path ~pos ~currentFile ~forHover =
           |> CompletionBackEnd.processCompletable ~debug ~full ~pos ~scope ~env
                ~forHover
         in
-        Some (completables, full)))
+        Some (completables, full, scope)))

--- a/analysis/tests/src/Hover.res
+++ b/analysis/tests/src/Hover.res
@@ -129,7 +129,7 @@ let arity0a = (. ()) => {
   f
 }
 
-let arity0b = (. ()) => (. ()) => 3
+let arity0b = (. (), . ()) => 3
 //  ^hov
 
 let arity0c = (. (), ()) => 3

--- a/analysis/tests/src/Hover.res
+++ b/analysis/tests/src/Hover.res
@@ -129,7 +129,7 @@ let arity0a = (. ()) => {
   f
 }
 
-let arity0b = (. (), . ()) => 3
+let arity0b = (. ()) => (. ()) => 3
 //  ^hov
 
 let arity0c = (. (), ()) => 3
@@ -211,7 +211,6 @@ let usr: useR = {
 // let f = usr
 //           ^hov
 
-
 module NotShadowed = {
   /** Stuff */
   let xx_ = 10
@@ -253,3 +252,10 @@ type variant = | /** Cool variant! */ CoolVariant | /** Other cool variant */ Ot
 
 let coolVariant = CoolVariant
 //                  ^hov
+
+// Hover on unsaved
+// let fff = "hello"; fff
+//                     ^hov
+
+// switch x { | {someField} => someField }
+//                               ^hov

--- a/analysis/tests/src/Hover.res
+++ b/analysis/tests/src/Hover.res
@@ -211,6 +211,7 @@ let usr: useR = {
 // let f = usr
 //           ^hov
 
+
 module NotShadowed = {
   /** Stuff */
   let xx_ = 10

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1593,6 +1593,7 @@ Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[FAO, forAutoObject]
 Path FAO.forAutoObject
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 {"contents": {"kind": "markdown", "value": "```rescript\n{\"age\": int, \"forAutoLabel\": FAR.forAutoRecord}\n```"}}
 
 Hover src/Completion.res 352:17

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -191,25 +191,47 @@ ContextPath Value[usr]
 Path usr
 {"contents": {"kind": "markdown", "value": "```rescript\nuseR\n```\n\n---\n\n```\n \n```\n```rescript\ntype useR = {x: int, y: list<option<r<float>>>}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C200%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype r<'a> = {i: 'a, f: float}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C101%2C0%5D)\n"}}
 
-Hover src/Hover.res 230:20
+Hover src/Hover.res 229:20
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n More Stuff "}}
 
-Hover src/Hover.res 233:17
+Hover src/Hover.res 232:17
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n More Stuff "}}
 
-Hover src/Hover.res 245:6
+Hover src/Hover.res 244:6
 Nothing at that position. Now trying to use completion.
-posCursor:[245:6] posNoWhite:[245:5] Found expr:[245:3->245:14]
-Pexp_field [245:3->245:4] someField:[245:5->245:14]
+posCursor:[244:6] posNoWhite:[244:5] Found expr:[244:3->244:14]
+Pexp_field [244:3->244:4] someField:[244:5->244:14]
 Completable: Cpath Value[x].someField
 ContextPath Value[x].someField
 ContextPath Value[x]
 Path x
 {"contents": {"kind": "markdown", "value": "```rescript\nbool\n```\n\n Mighty fine field here. "}}
 
-Hover src/Hover.res 248:19
+Hover src/Hover.res 247:19
 {"contents": {"kind": "markdown", "value": "```rescript\nbool\n```\n\n Mighty fine field here. "}}
 
-Hover src/Hover.res 253:20
-{"contents": {"kind": "markdown", "value": "```rescript\nCoolVariant\n```\n\n Cool variant! \n\n```rescript\nvariant\n```\n\n---\n\n```\n \n```\n```rescript\ntype variant = CoolVariant | OtherCoolVariant\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C251%2C0%5D)\n"}}
+Hover src/Hover.res 252:20
+{"contents": {"kind": "markdown", "value": "```rescript\nCoolVariant\n```\n\n Cool variant! \n\n```rescript\nvariant\n```\n\n---\n\n```\n \n```\n```rescript\ntype variant = CoolVariant | OtherCoolVariant\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C250%2C0%5D)\n"}}
+
+Hover src/Hover.res 256:23
+Nothing at that position. Now trying to use completion.
+posCursor:[256:23] posNoWhite:[256:22] Found expr:[256:22->256:25]
+Pexp_ident fff:[256:22->256:25]
+Completable: Cpath Value[fff]
+ContextPath Value[fff]
+Path fff
+ContextPath string
+{"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
+
+Hover src/Hover.res 259:33
+Nothing at that position. Now trying to use completion.
+posCursor:[259:33] posNoWhite:[259:32] Found expr:[259:31->259:40]
+Pexp_ident someField:[259:31->259:40]
+Completable: Cpath Value[someField]
+ContextPath Value[someField]
+Path someField
+ContextPath CPatternPath(Value[x])->recordField(someField)
+ContextPath Value[x]
+Path x
+{"contents": {"kind": "markdown", "value": "```rescript\nbool\n```"}}
 

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -191,42 +191,42 @@ ContextPath Value[usr]
 Path usr
 {"contents": {"kind": "markdown", "value": "```rescript\nuseR\n```\n\n---\n\n```\n \n```\n```rescript\ntype useR = {x: int, y: list<option<r<float>>>}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C200%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype r<'a> = {i: 'a, f: float}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C101%2C0%5D)\n"}}
 
-Hover src/Hover.res 229:20
+Hover src/Hover.res 230:20
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n More Stuff "}}
 
-Hover src/Hover.res 232:17
+Hover src/Hover.res 233:17
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```\n\n More Stuff "}}
 
-Hover src/Hover.res 244:6
+Hover src/Hover.res 245:6
 Nothing at that position. Now trying to use completion.
-posCursor:[244:6] posNoWhite:[244:5] Found expr:[244:3->244:14]
-Pexp_field [244:3->244:4] someField:[244:5->244:14]
+posCursor:[245:6] posNoWhite:[245:5] Found expr:[245:3->245:14]
+Pexp_field [245:3->245:4] someField:[245:5->245:14]
 Completable: Cpath Value[x].someField
 ContextPath Value[x].someField
 ContextPath Value[x]
 Path x
 {"contents": {"kind": "markdown", "value": "```rescript\nbool\n```\n\n Mighty fine field here. "}}
 
-Hover src/Hover.res 247:19
+Hover src/Hover.res 248:19
 {"contents": {"kind": "markdown", "value": "```rescript\nbool\n```\n\n Mighty fine field here. "}}
 
-Hover src/Hover.res 252:20
-{"contents": {"kind": "markdown", "value": "```rescript\nCoolVariant\n```\n\n Cool variant! \n\n```rescript\nvariant\n```\n\n---\n\n```\n \n```\n```rescript\ntype variant = CoolVariant | OtherCoolVariant\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C250%2C0%5D)\n"}}
+Hover src/Hover.res 253:20
+{"contents": {"kind": "markdown", "value": "```rescript\nCoolVariant\n```\n\n Cool variant! \n\n```rescript\nvariant\n```\n\n---\n\n```\n \n```\n```rescript\ntype variant = CoolVariant | OtherCoolVariant\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C251%2C0%5D)\n"}}
 
-Hover src/Hover.res 256:23
+Hover src/Hover.res 257:23
 Nothing at that position. Now trying to use completion.
-posCursor:[256:23] posNoWhite:[256:22] Found expr:[256:22->256:25]
-Pexp_ident fff:[256:22->256:25]
+posCursor:[257:23] posNoWhite:[257:22] Found expr:[257:22->257:25]
+Pexp_ident fff:[257:22->257:25]
 Completable: Cpath Value[fff]
 ContextPath Value[fff]
 Path fff
 ContextPath string
 {"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
 
-Hover src/Hover.res 259:33
+Hover src/Hover.res 260:33
 Nothing at that position. Now trying to use completion.
-posCursor:[259:33] posNoWhite:[259:32] Found expr:[259:31->259:40]
-Pexp_ident someField:[259:31->259:40]
+posCursor:[260:33] posNoWhite:[260:32] Found expr:[260:31->260:40]
+Pexp_ident someField:[260:31->260:40]
 Completable: Cpath Value[someField]
 ContextPath Value[someField]
 Path someField


### PR DESCRIPTION
This leverages the new unsaved completion code to get hovers on some unsaved code.

I would eventually like this to also work on assigned identifiers, like (all unsaved):
```rescript
let fff = makeSomeRecord()
//   ^hov should show `someRecord`, but it doesn't because it doesn't handle the actual assigned identifier
let ccc = fff
//               ^hov here it works though

```

But this is a win nonetheless so adding support for something like that can be a separate thing.