### PR TITLE
Open Pervasives.JsxModules by default.

### DIFF
--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -77,7 +77,7 @@ let newBsPackage ~rootPath =
                | None -> []
              in
              let opens =
-               opens_from_namespace
+               ["Pervasives"; "JsxModules"] :: opens_from_namespace
                |> List.rev_append opens_from_bsc_flags
                |> List.map (fun path -> path @ ["place holder"])
              in

--- a/analysis/tests/src/expected/BrokenParserCases.res.txt
+++ b/analysis/tests/src/expected/BrokenParserCases.res.txt
@@ -2,6 +2,7 @@ Complete src/BrokenParserCases.res 2:24
 posCursor:[2:24] posNoWhite:[2:23] Found expr:[2:11->2:30]
 Pexp_apply ...[2:11->2:17] (~isOff2:19->2:24=...[2:27->2:29])
 Completable: CnamedArg(Value[someFn], isOff, [isOff])
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someFn]
 Path someFn
 []
@@ -9,6 +10,7 @@ Path someFn
 Complete src/BrokenParserCases.res 6:17
 posCursor:[6:17] posNoWhite:[6:16] Found pattern:[6:16->6:19]
 Completable: Cpattern Value[s]=t
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[s]
 Path s
 []
@@ -18,6 +20,7 @@ posCursor:[10:29] posNoWhite:[10:27] Found pattern:[10:24->10:39]
 posCursor:[10:29] posNoWhite:[10:27] Found pattern:[10:24->10:28]
 Ppat_construct None:[10:24->10:28]
 Completable: Cpath Value[None]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[None]
 Path None
 []

--- a/analysis/tests/src/expected/CompletePrioritize1.res.txt
+++ b/analysis/tests/src/expected/CompletePrioritize1.res.txt
@@ -1,6 +1,7 @@
 Complete src/CompletePrioritize1.res 5:6
 posCursor:[5:6] posNoWhite:[5:5] Found expr:[5:3->0:-1]
 Completable: Cpath Value[a]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[a]->
 ContextPath Value[a]
 Path a

--- a/analysis/tests/src/expected/CompletePrioritize2.res.txt
+++ b/analysis/tests/src/expected/CompletePrioritize2.res.txt
@@ -1,6 +1,7 @@
 Complete src/CompletePrioritize2.res 9:7
 posCursor:[9:7] posNoWhite:[9:6] Found expr:[9:3->0:-1]
 Completable: Cpath Value[ax]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[ax]->
 ContextPath Value[ax]
 Path ax
@@ -20,6 +21,7 @@ Complete src/CompletePrioritize2.res 12:5
 posCursor:[12:5] posNoWhite:[12:4] Found expr:[12:3->12:5]
 Pexp_ident ax:[12:3->12:5]
 Completable: Cpath Value[ax]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[ax]
 Path ax
 [{

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -2,6 +2,7 @@ Complete src/Completion.res 1:11
 posCursor:[1:11] posNoWhite:[1:10] Found expr:[1:3->1:11]
 Pexp_ident MyList.m:[1:3->1:11]
 Completable: Cpath Value[MyList, m]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[MyList, m]
 Path MyList.m
 [{
@@ -76,6 +77,7 @@ Complete src/Completion.res 3:9
 posCursor:[3:9] posNoWhite:[3:8] Found expr:[3:3->3:9]
 Pexp_ident Array.:[3:3->3:9]
 Completable: Cpath Value[Array, ""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Array, ""]
 Path Array.
 [{
@@ -300,6 +302,7 @@ Complete src/Completion.res 5:10
 posCursor:[5:10] posNoWhite:[5:9] Found expr:[5:3->5:10]
 Pexp_ident Array.m:[5:3->5:10]
 Completable: Cpath Value[Array, m]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Array, m]
 Path Array.m
 [{
@@ -356,6 +359,7 @@ Complete src/Completion.res 15:17
 posCursor:[15:17] posNoWhite:[15:16] Found expr:[15:12->15:17]
 Pexp_ident Dep.c:[15:12->15:17]
 Completable: Cpath Value[Dep, c]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Dep, c]
 Path Dep.c
 [{
@@ -370,6 +374,7 @@ Complete src/Completion.res 23:20
 posCursor:[23:20] posNoWhite:[23:19] Found expr:[23:11->23:20]
 Pexp_apply ...[23:11->23:18] ()
 Completable: CnamedArg(Value[Lib, foo], "", [])
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Lib, foo]
 Path Lib.foo
 Found type for function (~age: int, ~name: string) => string
@@ -390,6 +395,7 @@ Found type for function (~age: int, ~name: string) => string
 Complete src/Completion.res 26:13
 posCursor:[26:13] posNoWhite:[26:12] Found expr:[26:3->26:13]
 Completable: Cpath array<int>->m
+Package opens Pervasives.JsxModules.place holder
 ContextPath array<int>->m
 ContextPath array<int>
 CPPipe env:Completion
@@ -411,6 +417,7 @@ Path Js.Array2.m
 Complete src/Completion.res 29:13
 posCursor:[29:13] posNoWhite:[29:12] Found expr:[29:3->29:13]
 Completable: Cpath string->toU
+Package opens Pervasives.JsxModules.place holder
 ContextPath string->toU
 ContextPath string
 CPPipe env:Completion
@@ -426,6 +433,7 @@ Path Js.String2.toU
 Complete src/Completion.res 34:8
 posCursor:[34:8] posNoWhite:[34:7] Found expr:[34:3->34:8]
 Completable: Cpath Value[op]->e
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[op]->e
 ContextPath Value[op]
 Path op
@@ -450,6 +458,7 @@ posCursor:[44:7] posNoWhite:[44:6] Found expr:[44:3->54:3]
 Pexp_apply ...[50:9->50:10] (...[44:3->50:8], ...[51:2->54:3])
 posCursor:[44:7] posNoWhite:[44:6] Found expr:[44:3->50:8]
 Completable: Cpath Value[fa]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[fa]->
 ContextPath Value[fa]
 Path fa
@@ -476,6 +485,7 @@ posCursor:[47:21] posNoWhite:[47:20] Found expr:[47:3->47:21]
 posCursor:[47:21] posNoWhite:[47:20] Found expr:[47:12->47:21]
 Pexp_ident Js.Dict.u:[47:12->47:21]
 Completable: Cpath Value[Js, Dict, u]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Js, Dict, u]
 Path Js.Dict.u
 [{
@@ -496,6 +506,7 @@ Complete src/Completion.res 59:30
 posCursor:[59:30] posNoWhite:[59:29] Found expr:[59:15->59:30]
 JSX <O.Comp:[59:15->59:21] second[59:22->59:28]=...[59:29->59:30]> _children:None
 Completable: Cexpression CJsxPropValue [O, Comp] second=z
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [O, Comp] second
 Path O.Comp.make
 [{
@@ -510,6 +521,7 @@ Complete src/Completion.res 62:23
 posCursor:[62:23] posNoWhite:[62:22] Found expr:[62:15->62:23]
 JSX <O.Comp:[62:15->62:21] z[62:22->62:23]=...[62:22->62:23]> _children:None
 Completable: Cjsx([O, Comp], z, [z])
+Package opens Pervasives.JsxModules.place holder
 Path O.Comp.make
 [{
     "label": "zoo",
@@ -522,6 +534,7 @@ Path O.Comp.make
 Complete src/Completion.res 65:8
 Attribute id:reac:[65:3->65:8] label:reac
 Completable: Cdecorator(reac)
+Package opens Pervasives.JsxModules.place holder
 [{
     "label": "react.component",
     "kind": 4,
@@ -535,6 +548,7 @@ posCursor:[68:10] posNoWhite:[68:9] Found expr:[0:-1->86:1]
 Pexp_apply ...[80:6->80:7] (...[80:8->86:1])
 Attribute id:react.let:[68:3->80:3] label:react.
 Completable: Cdecorator(react.)
+Package opens Pervasives.JsxModules.place holder
 [{
     "label": "component",
     "kind": 4,
@@ -547,6 +561,7 @@ Complete src/Completion.res 71:27
 posCursor:[71:27] posNoWhite:[71:26] Found expr:[71:11->71:27]
 Pexp_apply ...[71:11->71:18] (~name71:20->71:24=...[71:20->71:24])
 Completable: CnamedArg(Value[Lib, foo], "", [name])
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Lib, foo]
 Path Lib.foo
 Found type for function (~age: int, ~name: string) => string
@@ -562,6 +577,7 @@ Complete src/Completion.res 74:26
 posCursor:[74:26] posNoWhite:[74:25] Found expr:[74:11->74:26]
 Pexp_apply ...[74:11->74:18] (~age74:20->74:23=...[74:20->74:23])
 Completable: CnamedArg(Value[Lib, foo], "", [age])
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Lib, foo]
 Path Lib.foo
 Found type for function (~age: int, ~name: string) => string
@@ -577,6 +593,7 @@ Complete src/Completion.res 77:32
 posCursor:[77:32] posNoWhite:[77:31] Found expr:[77:11->77:32]
 Pexp_apply ...[77:11->77:18] (~age77:20->77:23=...[77:25->77:28])
 Completable: CnamedArg(Value[Lib, foo], "", [age])
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Lib, foo]
 Path Lib.foo
 Found type for function (~age: int, ~name: string) => string
@@ -592,6 +609,7 @@ Complete src/Completion.res 82:5
 posCursor:[82:5] posNoWhite:[82:4] Found expr:[80:8->86:1]
 Pexp_apply ...[80:8->80:15] (~age84:3->84:6=...[84:7->84:8], ~name85:3->85:7=...[85:8->85:10])
 Completable: CnamedArg(Value[Lib, foo], "", [age, name])
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Lib, foo]
 Path Lib.foo
 Found type for function (~age: int, ~name: string) => string
@@ -601,6 +619,7 @@ Complete src/Completion.res 90:13
 posCursor:[90:13] posNoWhite:[90:12] Found expr:[90:3->93:18]
 Pexp_send a[90:12->90:13] e:[90:3->90:10]
 Completable: Cpath Value[someObj]["a"]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someObj]["a"]
 ContextPath Value[someObj]
 Path someObj
@@ -616,6 +635,7 @@ Complete src/Completion.res 95:24
 posCursor:[95:24] posNoWhite:[95:23] Found expr:[95:3->99:6]
 Pexp_send [95:24->95:24] e:[95:3->95:22]
 Completable: Cpath Value[nestedObj]["x"]["y"][""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[nestedObj]["x"]["y"][""]
 ContextPath Value[nestedObj]["x"]["y"]
 ContextPath Value[nestedObj]["x"]
@@ -639,6 +659,7 @@ Complete src/Completion.res 99:7
 posCursor:[99:7] posNoWhite:[99:6] Found expr:[99:3->102:20]
 Pexp_send a[99:6->99:7] e:[99:3->99:4]
 Completable: Cpath Value[o]["a"]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[o]["a"]
 ContextPath Value[o]
 Path o
@@ -654,6 +675,7 @@ Complete src/Completion.res 104:17
 posCursor:[104:17] posNoWhite:[104:16] Found expr:[104:3->125:19]
 Pexp_send [104:17->104:17] e:[104:3->104:15]
 Completable: Cpath Value[no]["x"]["y"][""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[no]["x"]["y"][""]
 ContextPath Value[no]["x"]["y"]
 ContextPath Value[no]["x"]
@@ -677,6 +699,7 @@ Complete src/Completion.res 110:5
 posCursor:[110:5] posNoWhite:[110:4] Found expr:[110:3->110:5]
 Pexp_field [110:3->110:4] _:[116:0->110:5]
 Completable: Cpath Value[r].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[r].""
 ContextPath Value[r]
 Path r
@@ -698,6 +721,7 @@ Complete src/Completion.res 113:25
 posCursor:[113:25] posNoWhite:[113:24] Found expr:[113:3->113:25]
 Pexp_field [113:3->113:24] _:[116:0->113:25]
 Completable: Cpath Value[Objects, Rec, recordVal].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Objects, Rec, recordVal].""
 ContextPath Value[Objects, Rec, recordVal]
 Path Objects.Rec.recordVal
@@ -721,6 +745,7 @@ posCursor:[120:7] posNoWhite:[120:6] Found expr:[120:5->122:5]
 posCursor:[120:7] posNoWhite:[120:6] Found expr:[120:5->120:7]
 Pexp_ident my:[120:5->120:7]
 Completable: Cpath Value[my]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[my]
 Path my
 [{
@@ -735,6 +760,7 @@ Complete src/Completion.res 125:19
 posCursor:[125:19] posNoWhite:[125:18] Found expr:[125:3->145:32]
 Pexp_send [125:19->125:19] e:[125:3->125:17]
 Completable: Cpath Value[Objects, object][""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Objects, object][""]
 ContextPath Value[Objects, object]
 Path Objects.object
@@ -756,6 +782,7 @@ Complete src/Completion.res 151:6
 posCursor:[151:6] posNoWhite:[151:5] Found expr:[151:4->151:6]
 JSX <O.:[151:4->151:6] > _children:None
 Completable: Cpath Module[O, ""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[O, ""]
 Path O.
 [{
@@ -770,6 +797,7 @@ Complete src/Completion.res 157:8
 posCursor:[157:8] posNoWhite:[157:7] Found expr:[157:3->157:8]
 Pexp_field [157:3->157:7] _:[165:0->157:8]
 Completable: Cpath Value[q].aa.""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[q].aa.""
 ContextPath Value[q].aa
 ContextPath Value[q]
@@ -792,6 +820,7 @@ Complete src/Completion.res 159:9
 posCursor:[159:9] posNoWhite:[159:8] Found expr:[159:3->159:9]
 Pexp_field [159:3->159:7] n:[159:8->159:9]
 Completable: Cpath Value[q].aa.n
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[q].aa.n
 ContextPath Value[q].aa
 ContextPath Value[q]
@@ -808,6 +837,7 @@ Complete src/Completion.res 162:6
 posCursor:[162:6] posNoWhite:[162:5] Found expr:[162:3->162:6]
 Pexp_construct Lis:[162:3->162:6] None
 Completable: Cpath Value[Lis]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Lis]
 Path Lis
 [{
@@ -828,6 +858,7 @@ Complete src/Completion.res 169:16
 posCursor:[169:16] posNoWhite:[169:15] Found expr:[169:4->169:16]
 JSX <WithChildren:[169:4->169:16] > _children:None
 Completable: Cpath Module[WithChildren]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[WithChildren]
 Path WithChildren
 [{
@@ -842,6 +873,7 @@ Complete src/Completion.res 172:16
 posCursor:[172:16] posNoWhite:[172:15] Found type:[172:12->172:16]
 Ptyp_constr Js.n:[172:12->172:16]
 Completable: Cpath Type[Js, n]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[Js, n]
 Path Js.n
 [{
@@ -868,6 +900,7 @@ Complete src/Completion.res 174:20
 posCursor:[174:20] posNoWhite:[174:19] Found type:[174:12->174:20]
 Ptyp_constr ForAuto.:[174:12->174:20]
 Completable: Cpath Type[ForAuto, ""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[ForAuto, ""]
 Path ForAuto.
 [{
@@ -882,6 +915,7 @@ Complete src/Completion.res 179:13
 posCursor:[179:13] posNoWhite:[179:12] Found expr:[179:11->179:13]
 Pexp_construct As:[179:11->179:13] None
 Completable: Cpath Value[As]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[As]
 Path As
 [{
@@ -895,6 +929,7 @@ Path As
 Complete src/Completion.res 182:17
 Pmod_ident For:[182:14->182:17]
 Completable: Cpath Module[For]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[For]
 Path For
 [{
@@ -909,6 +944,7 @@ Complete src/Completion.res 190:11
 posCursor:[190:11] posNoWhite:[190:10] Found expr:[190:3->190:11]
 Pexp_ident Private.:[190:3->190:11]
 Completable: Cpath Value[Private, ""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Private, ""]
 Path Private.
 [{
@@ -923,6 +959,7 @@ Complete src/Completion.res 202:6
 posCursor:[202:6] posNoWhite:[202:5] Found expr:[202:3->202:6]
 Pexp_ident sha:[202:3->202:6]
 Completable: Cpath Value[sha]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[sha]
 Path sha
 []
@@ -932,6 +969,7 @@ posCursor:[205:6] posNoWhite:[205:5] Found expr:[205:3->205:6]
 Pexp_ident sha:[205:3->205:6]
 Completable: Cpath Value[sha]
 Raw opens: 1 Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 1 Completion.res
 ContextPath Value[sha]
 Path sha
@@ -948,6 +986,7 @@ posCursor:[208:6] posNoWhite:[208:5] Found expr:[208:3->208:6]
 Pexp_ident sha:[208:3->208:6]
 Completable: Cpath Value[sha]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[sha]
 Path sha
@@ -964,6 +1003,7 @@ posCursor:[221:22] posNoWhite:[221:21] Found expr:[221:3->224:22]
 Pexp_send [221:22->221:22] e:[221:3->221:20]
 Completable: Cpath Value[FAO, forAutoObject][""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[FAO, forAutoObject][""]
 ContextPath Value[FAO, forAutoObject]
@@ -987,6 +1027,7 @@ posCursor:[224:37] posNoWhite:[224:36] Found expr:[224:3->224:37]
 Pexp_field [224:3->224:36] _:[233:0->224:37]
 Completable: Cpath Value[FAO, forAutoObject]["forAutoLabel"].""
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[FAO, forAutoObject]["forAutoLabel"].""
 ContextPath Value[FAO, forAutoObject]["forAutoLabel"]
@@ -1010,6 +1051,7 @@ Complete src/Completion.res 227:46
 posCursor:[227:46] posNoWhite:[227:45] Found expr:[227:3->0:-1]
 Completable: Cpath Value[FAO, forAutoObject]["forAutoLabel"].forAuto->
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[FAO, forAutoObject]["forAutoLabel"].forAuto->
 ContextPath Value[FAO, forAutoObject]["forAutoLabel"].forAuto
@@ -1040,6 +1082,7 @@ posCursor:[230:55] posNoWhite:[230:54] Found expr:[230:46->230:55]
 Pexp_ident ForAuto.a:[230:46->230:55]
 Completable: Cpath Value[ForAuto, a]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ForAuto, a]
 Path ForAuto.a
@@ -1066,6 +1109,7 @@ posCursor:[234:34] posNoWhite:[234:33] Found expr:[234:32->234:34]
 Pexp_ident na:[234:32->234:34]
 Completable: Cpath Value[na]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[na]
 Path na
@@ -1081,6 +1125,7 @@ Complete src/Completion.res 237:17
 posCursor:[237:17] posNoWhite:[237:14] Found expr:[237:14->237:22]
 Completable: Cnone
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 []
 
@@ -1091,6 +1136,7 @@ posCursor:[243:8] posNoWhite:[243:7] Found expr:[243:5->243:8]
 Pexp_field [243:5->243:7] _:[245:0->243:8]
 Completable: Cpath Value[_z].""
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[_z].""
 ContextPath Value[_z]
@@ -1114,6 +1160,7 @@ posCursor:[254:17] posNoWhite:[254:16] Found expr:[254:11->254:17]
 Pexp_construct SomeLo:[254:11->254:17] None
 Completable: Cpath Value[SomeLo]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[SomeLo]
 Path SomeLo
@@ -1130,6 +1177,7 @@ posCursor:[256:29] posNoWhite:[256:28] Found type:[256:13->256:29]
 Ptyp_constr SomeLocalModule.:[256:13->256:29]
 Completable: Cpath Type[SomeLocalModule, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Type[SomeLocalModule, ""]
 Path SomeLocalModule.
@@ -1146,6 +1194,7 @@ posCursor:[261:33] posNoWhite:[261:32] Found type:[261:17->263:11]
 Ptyp_constr SomeLocalModule.:[261:17->263:11]
 Completable: Cpath Type[SomeLocalModule, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Type[SomeLocalModule, ""]
 Path SomeLocalModule.
@@ -1161,6 +1210,7 @@ Complete src/Completion.res 268:21
 Ptype_variant unary SomeLocal:[268:12->268:21]
 Completable: Cpath Value[SomeLocal]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[SomeLocal]
 Path SomeLocal
@@ -1184,6 +1234,7 @@ posCursor:[271:20] posNoWhite:[271:19] Found type:[271:11->274:3]
 Ptyp_constr SomeLocal:[271:11->274:3]
 Completable: Cpath Type[SomeLocal]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Type[SomeLocal]
 Path SomeLocal
@@ -1202,6 +1253,7 @@ posCursor:[275:15] posNoWhite:[275:14] Found expr:[275:13->275:15]
 Pexp_ident _w:[275:13->275:15]
 Completable: Cpath Value[_w]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[_w]
 Path _w
@@ -1218,6 +1270,7 @@ posCursor:[281:22] posNoWhite:[281:21] Found type:[281:21->281:22]
 Ptyp_constr s:[281:21->281:22]
 Completable: Cpath Type[s]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Type[s]
 Path s
@@ -1240,6 +1293,7 @@ posCursor:[291:30] posNoWhite:[291:29] Found expr:[291:11->291:32]
 Pexp_apply ...[291:11->291:28] ()
 Completable: CnamedArg(Value[funRecord].someFun, "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[funRecord].someFun
 ContextPath Value[funRecord]
@@ -1258,6 +1312,7 @@ posCursor:[296:11] posNoWhite:[296:10] Found expr:[296:3->296:11]
 Pexp_field [296:3->296:10] _:[299:0->296:11]
 Completable: Cpath Value[retAA](Nolabel).""
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[retAA](Nolabel).""
 ContextPath Value[retAA](Nolabel)
@@ -1282,6 +1337,7 @@ posCursor:[301:13] posNoWhite:[301:12] Found expr:[301:3->301:13]
 Pexp_apply ...[301:3->301:11] ()
 Completable: CnamedArg(Value[ff](~c), "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ff](~c)
 ContextPath Value[ff]
@@ -1325,6 +1381,7 @@ posCursor:[304:15] posNoWhite:[304:14] Found expr:[304:3->304:15]
 Pexp_apply ...[304:3->304:13] ()
 Completable: CnamedArg(Value[ff](~c)(Nolabel), "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ff](~c)(Nolabel)
 ContextPath Value[ff](~c)
@@ -1356,6 +1413,7 @@ posCursor:[307:17] posNoWhite:[307:16] Found expr:[307:3->307:17]
 Pexp_apply ...[307:3->307:15] ()
 Completable: CnamedArg(Value[ff](~c, Nolabel), "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ff](~c, Nolabel)
 ContextPath Value[ff]
@@ -1386,6 +1444,7 @@ posCursor:[310:21] posNoWhite:[310:20] Found expr:[310:3->310:21]
 Pexp_apply ...[310:3->310:19] ()
 Completable: CnamedArg(Value[ff](~c, Nolabel, Nolabel), "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ff](~c, Nolabel, Nolabel)
 ContextPath Value[ff]
@@ -1410,6 +1469,7 @@ posCursor:[313:23] posNoWhite:[313:22] Found expr:[313:3->313:23]
 Pexp_apply ...[313:3->313:21] ()
 Completable: CnamedArg(Value[ff](~c, Nolabel, ~b), "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ff](~c, Nolabel, ~b)
 ContextPath Value[ff]
@@ -1434,6 +1494,7 @@ posCursor:[316:16] posNoWhite:[316:15] Found expr:[316:3->316:16]
 Pexp_apply ...[316:3->316:14] ()
 Completable: CnamedArg(Value[ff](~opt2), "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ff](~opt2)
 ContextPath Value[ff]
@@ -1470,6 +1531,7 @@ posCursor:[323:17] posNoWhite:[323:16] Found expr:[323:3->323:17]
 Pexp_apply ...[323:3->323:15] ()
 Completable: CnamedArg(Value[withCallback], "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[withCallback]
 Path withCallback
@@ -1493,6 +1555,7 @@ posCursor:[326:21] posNoWhite:[326:20] Found expr:[326:3->326:21]
 Pexp_apply ...[326:3->326:19] ()
 Completable: CnamedArg(Value[withCallback](~a), "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[withCallback](~a)
 ContextPath Value[withCallback]
@@ -1511,6 +1574,7 @@ posCursor:[329:21] posNoWhite:[329:20] Found expr:[329:3->329:21]
 Pexp_apply ...[329:3->329:19] ()
 Completable: CnamedArg(Value[withCallback](~b), "", [])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[withCallback](~b)
 ContextPath Value[withCallback]
@@ -1539,6 +1603,7 @@ posCursor:[336:26] posNoWhite:[336:25] Found type:[336:23->338:5]
 Ptyp_constr Res:[336:23->338:5]
 Completable: Cpath Type[Res]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Type[Res]
 Path Res
@@ -1562,6 +1627,7 @@ posCursor:[343:57] posNoWhite:[343:56] Found expr:[343:53->343:57]
 Pexp_ident this:[343:53->343:57]
 Completable: Cpath Value[this]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[this]
 Path this
@@ -1579,6 +1645,7 @@ posCursor:[346:14] posNoWhite:[346:13] Found expr:[346:9->346:23]
 JSX <div:[346:9->346:12] name[346:13->346:17]=...[346:18->346:20]> _children:346:21
 Completable: Cjsx([div], name, [name])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 {"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
 
@@ -1590,10 +1657,12 @@ posCursor:[349:17] posNoWhite:[349:16] Found expr:[349:11->349:28]
 Pexp_ident FAO.forAutoObject:[349:11->349:28]
 Completable: Cpath Value[FAO, forAutoObject]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[FAO, forAutoObject]
 Path FAO.forAutoObject
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 {"contents": {"kind": "markdown", "value": "```rescript\n{\"age\": int, \"forAutoLabel\": FAR.forAutoRecord}\n```"}}
 
 Hover src/Completion.res 352:17
@@ -1602,6 +1671,7 @@ posCursor:[352:17] posNoWhite:[352:16] Found expr:[352:11->352:22]
 Pexp_apply ...[352:11->352:13] (~opt1352:15->352:19=...[352:20->352:21])
 Completable: CnamedArg(Value[ff], opt1, [opt1])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ff]
 Path ff
@@ -1628,11 +1698,13 @@ posCursor:[362:8] posNoWhite:[362:7] Found pattern:[362:7->362:8]
 Ppat_construct T:[362:7->362:8]
 Completable: Cpattern Value[x]=T
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[x]
 Path x
 Completable: Cpath Value[T]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[T]
 Path T
@@ -1669,6 +1741,7 @@ posCursor:[373:21] posNoWhite:[373:20] Found pattern:[373:7->373:21]
 Ppat_construct AndThatOther.T:[373:7->373:21]
 Completable: Cpath Value[AndThatOther, T]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[AndThatOther, T]
 Path AndThatOther.T
@@ -1689,6 +1762,7 @@ posCursor:[378:24] posNoWhite:[378:23] Found expr:[378:16->378:24]
 Pexp_ident ForAuto.:[378:16->378:24]
 Completable: Cpath Value[ForAuto, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ForAuto, ""]
 Path ForAuto.
@@ -1715,6 +1789,7 @@ posCursor:[381:38] posNoWhite:[381:37] Found expr:[381:19->381:39]
 Pexp_send [381:38->381:38] e:[381:19->381:36]
 Completable: Cpath Value[FAO, forAutoObject][""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[FAO, forAutoObject][""]
 ContextPath Value[FAO, forAutoObject]
@@ -1742,6 +1817,7 @@ posCursor:[384:24] posNoWhite:[384:23] Found expr:[384:14->384:24]
 Pexp_field [384:14->384:23] _:[384:24->384:24]
 Completable: Cpath Value[funRecord].""
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[funRecord].""
 ContextPath Value[funRecord]
@@ -1767,6 +1843,7 @@ posCursor:[389:12] posNoWhite:[389:11] Found expr:[389:6->391:4]
 posCursor:[389:12] posNoWhite:[389:11] Found expr:[389:6->389:12]
 Completable: Cpath array->ma
 Raw opens: 3 Js.place holder ... Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 3 Completion.res Completion.res js.ml
 ContextPath array->ma
 ContextPath array
@@ -1795,6 +1872,7 @@ posCursor:[397:14] posNoWhite:[397:13] Found expr:[397:13->397:16]
 Pexp_ident red:[397:13->397:16]
 Completable: Cpath Value[red]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[red]
 Path red
@@ -1815,6 +1893,7 @@ posCursor:[402:25] posNoWhite:[402:24] Found expr:[402:24->402:27]
 Pexp_ident red:[402:24->402:27]
 Completable: Cpath Value[red]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[red]
 Path red
@@ -1836,6 +1915,7 @@ posCursor:[405:22] posNoWhite:[405:21] Found expr:[405:21->405:22]
 Pexp_ident r:[405:21->405:22]
 Completable: Cpath Value[r]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[r]
 Path r
@@ -1867,6 +1947,7 @@ posCursor:[409:21] posNoWhite:[409:20] Found expr:[409:5->411:5]
 Pexp_ident SomeLocalModule.:[409:5->411:5]
 Completable: Cpath Value[SomeLocalModule, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[SomeLocalModule, ""]
 Path SomeLocalModule.
@@ -1893,6 +1974,7 @@ posCursor:[412:21] posNoWhite:[412:20] Found expr:[412:5->414:8]
 Pexp_ident SomeLocalModule.:[412:5->414:8]
 Completable: Cpath Value[SomeLocalModule, ""]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[SomeLocalModule, ""]
 Path SomeLocalModule.
@@ -1914,6 +1996,7 @@ Complete src/Completion.res 417:17
 posCursor:[417:17] posNoWhite:[417:16] Found expr:[417:11->417:17]
 Completable: Cpath int->t
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath int->t
 ContextPath int
@@ -1937,6 +2020,7 @@ Complete src/Completion.res 420:19
 posCursor:[420:19] posNoWhite:[420:18] Found expr:[420:11->420:19]
 Completable: Cpath float->t
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath float->t
 ContextPath float
@@ -1960,6 +2044,7 @@ Complete src/Completion.res 425:8
 posCursor:[425:8] posNoWhite:[425:7] Found expr:[425:3->425:8]
 Completable: Cpath Value[ok]->g
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[ok]->g
 ContextPath Value[ok]
@@ -1985,6 +2070,7 @@ posCursor:[443:15] posNoWhite:[443:14] Found expr:[443:3->443:15]
 Pexp_field [443:3->443:12] so:[443:13->443:15]
 Completable: Cpath Value[rWithDepr].so
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Value[rWithDepr].so
 ContextPath Value[rWithDepr]
@@ -2007,6 +2093,7 @@ Complete src/Completion.res 450:37
 XXX Not found!
 Completable: Cexpression Type[someVariantWithDeprecated]
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 Completion.res Completion.res
 ContextPath Type[someVariantWithDeprecated]
 Path someVariantWithDeprecated

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1,6 +1,7 @@
 Complete src/CompletionExpressions.res 3:20
 XXX Not found!
 Completable: Cpattern CTuple(Value[s], Value[f])
+Package opens Pervasives.JsxModules.place holder
 ContextPath CTuple(Value[s], Value[f])
 ContextPath Value[s]
 Path s
@@ -20,6 +21,7 @@ Complete src/CompletionExpressions.res 26:27
 posCursor:[26:27] posNoWhite:[26:26] Found expr:[26:11->26:29]
 Pexp_apply ...[26:11->26:25] (...[26:26->26:28])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -65,6 +67,7 @@ Complete src/CompletionExpressions.res 29:28
 posCursor:[29:28] posNoWhite:[29:27] Found expr:[29:11->29:30]
 Pexp_apply ...[29:11->29:25] (...[29:27->29:28])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)=n->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -80,6 +83,7 @@ Complete src/CompletionExpressions.res 32:35
 posCursor:[32:35] posNoWhite:[32:34] Found expr:[32:11->32:38]
 Pexp_apply ...[32:11->32:25] (...[32:26->32:38])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(offline)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -101,6 +105,7 @@ Complete src/CompletionExpressions.res 35:36
 posCursor:[35:36] posNoWhite:[35:35] Found expr:[35:11->35:39]
 Pexp_apply ...[35:11->35:25] (...[35:26->35:38])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -140,6 +145,7 @@ Complete src/CompletionExpressions.res 38:37
 posCursor:[38:37] posNoWhite:[38:35] Found expr:[38:11->38:53]
 Pexp_apply ...[38:11->38:25] (...[38:26->38:52])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -173,6 +179,7 @@ Complete src/CompletionExpressions.res 41:44
 posCursor:[41:44] posNoWhite:[41:43] Found expr:[41:11->41:47]
 Pexp_apply ...[41:11->41:25] (...[41:26->41:47])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(nested)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -204,6 +211,7 @@ Complete src/CompletionExpressions.res 44:46
 posCursor:[44:46] posNoWhite:[44:45] Found expr:[44:11->44:49]
 Pexp_apply ...[44:11->44:25] (...[44:26->44:48])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(nested), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -213,6 +221,7 @@ Complete src/CompletionExpressions.res 47:51
 posCursor:[47:51] posNoWhite:[47:50] Found expr:[47:11->47:55]
 Pexp_apply ...[47:11->47:25] (...[47:26->47:54])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(nested), variantPayload::Some($0), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -234,6 +243,7 @@ Complete src/CompletionExpressions.res 50:45
 posCursor:[50:45] posNoWhite:[50:44] Found expr:[50:11->50:48]
 Pexp_apply ...[50:11->50:25] (...[50:26->50:48])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(variant)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -267,6 +277,7 @@ Complete src/CompletionExpressions.res 53:47
 posCursor:[53:47] posNoWhite:[53:46] Found expr:[53:11->53:50]
 Pexp_apply ...[53:11->53:25] (...[53:26->53:49])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)=O->recordField(variant)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -297,6 +308,7 @@ Complete src/CompletionExpressions.res 56:57
 posCursor:[56:57] posNoWhite:[56:56] Found expr:[56:11->56:61]
 Pexp_apply ...[56:11->56:25] (...[56:26->56:60])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -315,6 +327,7 @@ Complete src/CompletionExpressions.res 59:60
 posCursor:[59:60] posNoWhite:[59:59] Found expr:[59:11->59:65]
 Pexp_apply ...[59:11->59:25] (...[59:26->59:64])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordField(polyvariant), polyvariantPayload::three($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -336,6 +349,7 @@ Complete src/CompletionExpressions.res 62:62
 posCursor:[62:62] posNoWhite:[62:61] Found expr:[62:11->62:66]
 Pexp_apply ...[62:11->62:25] (...[62:26->62:65])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)=t->recordField(polyvariant), polyvariantPayload::three($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -351,6 +365,7 @@ Complete src/CompletionExpressions.res 69:25
 posCursor:[69:25] posNoWhite:[69:24] Found expr:[69:11->69:26]
 Pexp_apply ...[69:11->69:24] (...[69:25->69:26])
 Completable: Cexpression CArgument Value[fnTakingArray]($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingArray]($0)
 ContextPath Value[fnTakingArray]
 Path fnTakingArray
@@ -369,6 +384,7 @@ Complete src/CompletionExpressions.res 72:26
 posCursor:[72:26] posNoWhite:[72:25] Found expr:[72:11->72:28]
 Pexp_apply ...[72:11->72:24] (...[72:25->72:27])
 Completable: Cexpression CArgument Value[fnTakingArray]($0)->array
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingArray]($0)
 ContextPath Value[fnTakingArray]
 Path fnTakingArray
@@ -404,6 +420,7 @@ Complete src/CompletionExpressions.res 75:26
 posCursor:[75:26] posNoWhite:[75:25] Found expr:[75:11->75:27]
 Pexp_apply ...[75:11->75:24] (...[75:25->75:26])
 Completable: Cexpression CArgument Value[fnTakingArray]($0)=s
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingArray]($0)
 ContextPath Value[fnTakingArray]
 Path fnTakingArray
@@ -419,6 +436,7 @@ Complete src/CompletionExpressions.res 78:31
 posCursor:[78:31] posNoWhite:[78:30] Found expr:[78:11->78:34]
 Pexp_apply ...[78:11->78:24] (...[78:25->78:33])
 Completable: Cexpression CArgument Value[fnTakingArray]($0)->array, variantPayload::Some($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingArray]($0)
 ContextPath Value[fnTakingArray]
 Path fnTakingArray
@@ -440,6 +458,7 @@ Complete src/CompletionExpressions.res 81:31
 posCursor:[81:31] posNoWhite:[81:30] Found expr:[81:11->81:34]
 Pexp_apply ...[81:11->81:24] (...[81:25->81:33])
 Completable: Cexpression CArgument Value[fnTakingArray]($0)->array
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingArray]($0)
 ContextPath Value[fnTakingArray]
 Path fnTakingArray
@@ -475,6 +494,7 @@ Complete src/CompletionExpressions.res 84:31
 posCursor:[84:31] posNoWhite:[84:30] Found expr:[84:11->84:40]
 Pexp_apply ...[84:11->84:24] (...[84:25->84:39])
 Completable: Cexpression CArgument Value[fnTakingArray]($0)->array
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingArray]($0)
 ContextPath Value[fnTakingArray]
 Path fnTakingArray
@@ -510,6 +530,7 @@ Complete src/CompletionExpressions.res 89:38
 posCursor:[89:38] posNoWhite:[89:37] Found expr:[89:11->89:41]
 Pexp_apply ...[89:11->89:25] (...[89:26->89:40])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)=so
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -525,6 +546,7 @@ Complete src/CompletionExpressions.res 96:43
 posCursor:[96:43] posNoWhite:[96:42] Found expr:[96:11->96:46]
 Pexp_apply ...[96:11->96:30] (...[96:31->96:46])
 Completable: Cexpression CArgument Value[fnTakingOtherRecord]($0)->recordField(otherField)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingOtherRecord]($0)
 ContextPath Value[fnTakingOtherRecord]
 Path fnTakingOtherRecord
@@ -543,6 +565,7 @@ Complete src/CompletionExpressions.res 108:57
 posCursor:[108:57] posNoWhite:[108:56] Found expr:[108:11->108:60]
 Pexp_apply ...[108:11->108:42] (...[108:43->108:60])
 Completable: Cexpression CArgument Value[fnTakingRecordWithOptionalField]($0)->recordField(someOptField)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecordWithOptionalField]($0)
 ContextPath Value[fnTakingRecordWithOptionalField]
 Path fnTakingRecordWithOptionalField
@@ -564,6 +587,7 @@ Complete src/CompletionExpressions.res 116:53
 posCursor:[116:53] posNoWhite:[116:52] Found expr:[116:11->116:56]
 Pexp_apply ...[116:11->116:39] (...[116:40->116:56])
 Completable: Cexpression CArgument Value[fnTakingRecordWithOptVariant]($0)->recordField(someVariant)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecordWithOptVariant]($0)
 ContextPath Value[fnTakingRecordWithOptVariant]
 Path fnTakingRecordWithOptVariant
@@ -611,6 +635,7 @@ Complete src/CompletionExpressions.res 126:49
 posCursor:[126:49] posNoWhite:[126:48] Found expr:[126:11->126:51]
 Pexp_apply ...[126:11->126:31] (...[126:32->126:50])
 Completable: Cexpression CArgument Value[fnTakingInlineRecord]($0)->variantPayload::WithInlineRecord($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingInlineRecord]($0)
 ContextPath Value[fnTakingInlineRecord]
 Path fnTakingInlineRecord
@@ -629,6 +654,7 @@ Complete src/CompletionExpressions.res 129:50
 posCursor:[129:50] posNoWhite:[129:49] Found expr:[129:11->129:53]
 Pexp_apply ...[129:11->129:31] (...[129:32->129:52])
 Completable: Cexpression CArgument Value[fnTakingInlineRecord]($0)->variantPayload::WithInlineRecord($0), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingInlineRecord]($0)
 ContextPath Value[fnTakingInlineRecord]
 Path fnTakingInlineRecord
@@ -656,6 +682,7 @@ Complete src/CompletionExpressions.res 132:51
 posCursor:[132:51] posNoWhite:[132:50] Found expr:[132:11->132:54]
 Pexp_apply ...[132:11->132:31] (...[132:32->132:53])
 Completable: Cexpression CArgument Value[fnTakingInlineRecord]($0)=s->variantPayload::WithInlineRecord($0), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingInlineRecord]($0)
 ContextPath Value[fnTakingInlineRecord]
 Path fnTakingInlineRecord
@@ -671,6 +698,7 @@ Complete src/CompletionExpressions.res 135:63
 posCursor:[135:63] posNoWhite:[135:62] Found expr:[135:11->135:67]
 Pexp_apply ...[135:11->135:31] (...[135:32->135:66])
 Completable: Cexpression CArgument Value[fnTakingInlineRecord]($0)->variantPayload::WithInlineRecord($0), recordField(nestedRecord)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingInlineRecord]($0)
 ContextPath Value[fnTakingInlineRecord]
 Path fnTakingInlineRecord
@@ -689,6 +717,7 @@ Complete src/CompletionExpressions.res 138:65
 posCursor:[138:65] posNoWhite:[138:64] Found expr:[138:11->138:70]
 Pexp_apply ...[138:11->138:31] (...[138:32->138:69])
 Completable: Cexpression CArgument Value[fnTakingInlineRecord]($0)->variantPayload::WithInlineRecord($0), recordField(nestedRecord), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingInlineRecord]($0)
 ContextPath Value[fnTakingInlineRecord]
 Path fnTakingInlineRecord
@@ -710,6 +739,7 @@ Complete src/CompletionExpressions.res 159:20
 posCursor:[159:20] posNoWhite:[159:19] Found expr:[159:3->159:21]
 Pexp_apply ...[159:3->159:19] (...[159:20->159:21])
 Completable: Cexpression CArgument Value[fnTakingCallback]($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingCallback]($0)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
@@ -728,6 +758,7 @@ Complete src/CompletionExpressions.res 162:21
 posCursor:[162:21] posNoWhite:[162:20] Found expr:[162:3->162:22]
 Pexp_apply ...[162:3->162:19] (...[162:20->162:21])
 Completable: Cexpression CArgument Value[fnTakingCallback]($0)=a
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingCallback]($0)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
@@ -737,6 +768,7 @@ Complete src/CompletionExpressions.res 165:22
 posCursor:[165:22] posNoWhite:[165:21] Found expr:[165:3->165:24]
 Pexp_apply ...[165:3->165:19] (...[165:20->165:21])
 Completable: Cexpression CArgument Value[fnTakingCallback]($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingCallback]($1)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
@@ -755,6 +787,7 @@ Complete src/CompletionExpressions.res 168:25
 posCursor:[168:25] posNoWhite:[168:24] Found expr:[168:3->168:27]
 Pexp_apply ...[168:3->168:19] (...[168:20->168:21], ...[168:23->168:24])
 Completable: Cexpression CArgument Value[fnTakingCallback]($2)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingCallback]($2)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
@@ -773,6 +806,7 @@ Complete src/CompletionExpressions.res 171:29
 posCursor:[171:29] posNoWhite:[171:27] Found expr:[171:3->171:30]
 Pexp_apply ...[171:3->171:19] (...[171:20->171:21], ...[171:23->171:24], ...[171:26->171:27])
 Completable: Cexpression CArgument Value[fnTakingCallback]($3)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingCallback]($3)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
@@ -791,6 +825,7 @@ Complete src/CompletionExpressions.res 174:32
 posCursor:[174:32] posNoWhite:[174:30] Found expr:[174:3->174:33]
 Pexp_apply ...[174:3->174:19] (...[174:20->174:21], ...[174:23->174:24], ...[174:26->174:27], ...[174:29->174:30])
 Completable: Cexpression CArgument Value[fnTakingCallback]($4)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingCallback]($4)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
@@ -809,6 +844,7 @@ Complete src/CompletionExpressions.res 177:34
 posCursor:[177:34] posNoWhite:[177:33] Found expr:[177:3->177:36]
 Pexp_apply ...[177:3->177:19] (...[177:20->177:21], ...[177:23->177:24], ...[177:26->177:27], ...[177:29->177:30], ...[177:32->177:33])
 Completable: Cexpression CArgument Value[fnTakingCallback]($5)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingCallback]($5)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
@@ -831,6 +867,7 @@ posCursor:[185:10] posNoWhite:[185:9] Found expr:[184:2->185:11]
 posCursor:[185:10] posNoWhite:[185:9] Found expr:[185:2->185:11]
 Pexp_apply ...[185:2->185:8] (...[185:9->185:10])
 Completable: Cexpression CArgument Value[Js, log]($0)=s
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[Js, log]($0)
 ContextPath Value[Js, log]
 Path Js.log
@@ -864,6 +901,7 @@ Complete src/CompletionExpressions.res 196:14
 posCursor:[196:14] posNoWhite:[196:13] Found expr:[196:3->196:14]
 Pexp_field [196:3->196:6] someOpt:[196:7->196:14]
 Completable: Cpath Value[fff].someOpt
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[fff].someOpt
 ContextPath Value[fff]
 Path fff

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -2,6 +2,7 @@ Complete src/CompletionFunctionArguments.res 10:24
 posCursor:[10:24] posNoWhite:[10:23] Found expr:[10:11->10:25]
 Pexp_apply ...[10:11->10:17] (~isOn10:19->10:23=...__ghost__[0:-1->0:-1])
 Completable: Cexpression CArgument Value[someFn](~isOn)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someFn](~isOn)
 ContextPath Value[someFn]
 Path someFn
@@ -23,6 +24,7 @@ Complete src/CompletionFunctionArguments.res 13:25
 posCursor:[13:25] posNoWhite:[13:24] Found expr:[13:11->13:26]
 Pexp_apply ...[13:11->13:17] (~isOn13:19->13:23=...[13:24->13:25])
 Completable: Cexpression CArgument Value[someFn](~isOn)=t
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someFn](~isOn)
 ContextPath Value[someFn]
 Path someFn
@@ -45,6 +47,7 @@ Complete src/CompletionFunctionArguments.res 16:25
 posCursor:[16:25] posNoWhite:[16:24] Found expr:[16:11->16:26]
 Pexp_apply ...[16:11->16:17] (~isOff16:19->16:24=...__ghost__[0:-1->0:-1])
 Completable: Cexpression CArgument Value[someFn](~isOff)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someFn](~isOff)
 ContextPath Value[someFn]
 Path someFn
@@ -70,6 +73,7 @@ posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:7->21:28]
 posCursor:[21:27] posNoWhite:[21:26] Found expr:[21:14->21:28]
 Pexp_apply ...[21:14->21:20] (~isOn21:22->21:26=...__ghost__[0:-1->0:-1])
 Completable: Cexpression CArgument Value[someFn](~isOn)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someFn](~isOn)
 ContextPath Value[someFn]
 Path someFn
@@ -91,6 +95,7 @@ Complete src/CompletionFunctionArguments.res 34:24
 posCursor:[34:24] posNoWhite:[34:23] Found expr:[34:11->34:25]
 Pexp_apply ...[34:11->34:22] (...[34:23->34:24])
 Completable: Cexpression CArgument Value[someOtherFn]($0)=f
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someOtherFn]($0)
 ContextPath Value[someOtherFn]
 Path someOtherFn
@@ -106,6 +111,7 @@ Complete src/CompletionFunctionArguments.res 51:39
 posCursor:[51:39] posNoWhite:[51:38] Found expr:[51:11->51:40]
 Pexp_apply ...[51:11->51:30] (~config51:32->51:38=...__ghost__[0:-1->0:-1])
 Completable: Cexpression CArgument Value[someFnTakingVariant](~config)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someFnTakingVariant](~config)
 ContextPath Value[someFnTakingVariant]
 Path someFnTakingVariant
@@ -139,6 +145,7 @@ Complete src/CompletionFunctionArguments.res 54:40
 posCursor:[54:40] posNoWhite:[54:39] Found expr:[54:11->54:41]
 Pexp_apply ...[54:11->54:30] (~config54:32->54:38=...[54:39->54:40])
 Completable: Cexpression CArgument Value[someFnTakingVariant](~config)=O
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someFnTakingVariant](~config)
 ContextPath Value[someFnTakingVariant]
 Path someFnTakingVariant
@@ -175,6 +182,7 @@ Complete src/CompletionFunctionArguments.res 57:33
 posCursor:[57:33] posNoWhite:[57:32] Found expr:[57:11->57:34]
 Pexp_apply ...[57:11->57:30] (...[57:31->57:33])
 Completable: Cexpression CArgument Value[someFnTakingVariant]($0)=So
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someFnTakingVariant]($0)
 ContextPath Value[someFnTakingVariant]
 Path someFnTakingVariant
@@ -199,6 +207,7 @@ Complete src/CompletionFunctionArguments.res 60:44
 posCursor:[60:44] posNoWhite:[60:43] Found expr:[60:11->60:45]
 Pexp_apply ...[60:11->60:30] (~configOpt260:32->60:42=...[60:43->60:44])
 Completable: Cexpression CArgument Value[someFnTakingVariant](~configOpt2)=O
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someFnTakingVariant](~configOpt2)
 ContextPath Value[someFnTakingVariant]
 Path someFnTakingVariant
@@ -235,6 +244,7 @@ Complete src/CompletionFunctionArguments.res 63:23
 posCursor:[63:23] posNoWhite:[63:22] Found expr:[63:11->63:24]
 Pexp_apply ...[63:11->63:22] (...[63:23->63:24])
 Completable: Cexpression CArgument Value[someOtherFn]($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someOtherFn]($0)
 ContextPath Value[someOtherFn]
 Path someOtherFn
@@ -256,6 +266,7 @@ Complete src/CompletionFunctionArguments.res 66:28
 posCursor:[66:28] posNoWhite:[66:27] Found expr:[66:11->66:30]
 Pexp_apply ...[66:11->66:22] (...[66:23->66:24], ...[66:26->66:27])
 Completable: Cexpression CArgument Value[someOtherFn]($2)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someOtherFn]($2)
 ContextPath Value[someOtherFn]
 Path someOtherFn
@@ -276,6 +287,7 @@ Path someOtherFn
 Complete src/CompletionFunctionArguments.res 69:30
 posCursor:[69:30] posNoWhite:[69:29] Found expr:[69:11->69:31]
 Completable: Cexpression CArgument Value[someOtherFn]($2)=t
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[someOtherFn]($2)
 ContextPath Value[someOtherFn]
 Path someOtherFn
@@ -298,6 +310,7 @@ Complete src/CompletionFunctionArguments.res 76:25
 posCursor:[76:25] posNoWhite:[76:24] Found expr:[76:11->76:26]
 Pexp_apply ...[76:11->76:24] (...[76:25->76:26])
 Completable: Cexpression CArgument Value[fnTakingTuple]($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingTuple]($0)
 ContextPath Value[fnTakingTuple]
 Path fnTakingTuple
@@ -315,6 +328,7 @@ Complete src/CompletionFunctionArguments.res 89:27
 posCursor:[89:27] posNoWhite:[89:26] Found expr:[89:11->89:29]
 Pexp_apply ...[89:11->89:25] (...[89:26->89:28])
 Completable: Cexpression CArgument Value[fnTakingRecord]($0)->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument Value[fnTakingRecord]($0)
 ContextPath Value[fnTakingRecord]
 Path fnTakingRecord
@@ -346,6 +360,7 @@ posCursor:[109:29] posNoWhite:[109:28] Found expr:[107:6->109:29]
 posCursor:[109:29] posNoWhite:[109:28] Found expr:[108:6->109:29]
 posCursor:[109:29] posNoWhite:[109:28] Found expr:[109:9->109:29]
 Completable: Cpath Value[thisGetsBrokenLoc]->a <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[thisGetsBrokenLoc]->a <<jsx>>
 ContextPath Value[thisGetsBrokenLoc]
 Path thisGetsBrokenLoc
@@ -369,6 +384,7 @@ posCursor:[111:27] posNoWhite:[111:26] Found expr:[107:6->111:27]
 posCursor:[111:27] posNoWhite:[111:26] Found expr:[108:6->111:27]
 posCursor:[111:27] posNoWhite:[111:26] Found expr:[111:9->111:27]
 Completable: Cpath Value[reassignedWorks]->a <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[reassignedWorks]->a <<jsx>>
 ContextPath Value[reassignedWorks]
 Path reassignedWorks

--- a/analysis/tests/src/expected/CompletionInferValues.res.txt
+++ b/analysis/tests/src/expected/CompletionInferValues.res.txt
@@ -1,6 +1,7 @@
 Complete src/CompletionInferValues.res 15:43
 posCursor:[15:43] posNoWhite:[15:42] Found expr:[15:33->15:43]
 Completable: Cpath Value[aliased]->f
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[aliased]->f
 ContextPath Value[aliased]
 Path aliased
@@ -27,6 +28,7 @@ Complete src/CompletionInferValues.res 18:30
 posCursor:[18:30] posNoWhite:[18:29] Found expr:[18:28->18:30]
 Pexp_field [18:28->18:29] _:[33:0->18:30]
 Completable: Cpath Value[x].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x].""
 ContextPath Value[x]
 Path x
@@ -51,6 +53,7 @@ Complete src/CompletionInferValues.res 21:53
 posCursor:[21:53] posNoWhite:[21:52] Found expr:[21:45->21:53]
 Pexp_field [21:45->21:52] _:[33:0->21:53]
 Completable: Cpath Value[aliased].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[aliased].""
 ContextPath Value[aliased]
 Path aliased
@@ -82,6 +85,7 @@ posCursor:[24:63] posNoWhite:[24:62] Found expr:[24:42->24:63]
 posCursor:[24:63] posNoWhite:[24:62] Found expr:[24:52->24:63]
 Pexp_field [24:52->24:62] _:[24:63->24:63]
 Completable: Cpath Value[someRecord].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someRecord].""
 ContextPath Value[someRecord]
 Path someRecord
@@ -112,6 +116,7 @@ posCursor:[27:90] posNoWhite:[27:89] Found expr:[27:69->27:90]
 posCursor:[27:90] posNoWhite:[27:89] Found expr:[27:79->27:90]
 Pexp_field [27:79->27:89] _:[27:90->27:90]
 Completable: Cpath Value[someRecord].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someRecord].""
 ContextPath Value[someRecord]
 Path someRecord
@@ -141,6 +146,7 @@ Pexp_apply ...[30:3->30:15] (...[30:16->30:38])
 posCursor:[30:36] posNoWhite:[30:35] Found expr:[30:16->30:38]
 posCursor:[30:36] posNoWhite:[30:35] Found expr:[30:27->30:36]
 Completable: Cpath Value[event]->pr
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[event]->pr
 ContextPath Value[event]
 Path event
@@ -166,6 +172,7 @@ JSX <div:[41:12->41:15] onMouseEnter[41:16->41:28]=...[41:36->41:52]> _children:
 posCursor:[41:50] posNoWhite:[41:49] Found expr:[41:36->41:52]
 posCursor:[41:50] posNoWhite:[41:49] Found expr:[41:41->41:50]
 Completable: Cpath Value[event]->pr <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[event]->pr <<jsx>>
 ContextPath Value[event]
 Path event
@@ -191,6 +198,7 @@ JSX <Div:[44:12->44:15] onMouseEnter[44:16->44:28]=...[44:36->44:52]> _children:
 posCursor:[44:50] posNoWhite:[44:49] Found expr:[44:36->44:52]
 posCursor:[44:50] posNoWhite:[44:49] Found expr:[44:41->44:50]
 Completable: Cpath Value[event]->pr <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[event]->pr <<jsx>>
 ContextPath Value[event]
 Path event
@@ -216,6 +224,7 @@ posCursor:[47:87] posNoWhite:[47:86] Found expr:[47:36->47:89]
 posCursor:[47:87] posNoWhite:[47:86] Found expr:[47:41->47:87]
 posCursor:[47:87] posNoWhite:[47:86] Found expr:[47:81->47:87]
 Completable: Cpath Value[btn]->t <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[btn]->t <<jsx>>
 ContextPath Value[btn]
 Path btn
@@ -245,6 +254,7 @@ posCursor:[50:108] posNoWhite:[50:107] Found expr:[50:36->50:110]
 posCursor:[50:108] posNoWhite:[50:107] Found expr:[50:41->50:108]
 posCursor:[50:108] posNoWhite:[50:107] Found expr:[50:100->50:108]
 Completable: Cpath Value[btn]->spl <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[btn]->spl <<jsx>>
 ContextPath Value[btn]
 Path btn
@@ -286,6 +296,7 @@ posCursor:[53:130] posNoWhite:[53:129] Found expr:[53:36->53:132]
 posCursor:[53:130] posNoWhite:[53:129] Found expr:[53:41->53:130]
 posCursor:[53:130] posNoWhite:[53:129] Found expr:[53:123->53:130]
 Completable: Cpath Value[btn]->ma <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[btn]->ma <<jsx>>
 ContextPath Value[btn]
 Path btn
@@ -312,6 +323,7 @@ Complete src/CompletionInferValues.res 56:52
 posCursor:[56:52] posNoWhite:[56:51] Found expr:[56:50->56:52]
 Pexp_field [56:50->56:51] _:[59:0->56:52]
 Completable: Cpath Value[x].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x].""
 ContextPath Value[x]
 Path x
@@ -335,6 +347,7 @@ Complete src/CompletionInferValues.res 78:78
 posCursor:[78:78] posNoWhite:[78:77] Found expr:[78:70->78:78]
 Pexp_field [78:70->78:77] _:[125:0->78:78]
 Completable: Cpath Value[srecord].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[srecord].""
 ContextPath Value[srecord]
 Path srecord
@@ -361,6 +374,7 @@ Complete src/CompletionInferValues.res 82:86
 posCursor:[82:86] posNoWhite:[82:85] Found expr:[82:78->82:86]
 Pexp_field [82:78->82:85] _:[125:0->82:86]
 Completable: Cpath Value[aliased].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[aliased].""
 ContextPath Value[aliased]
 Path aliased
@@ -381,6 +395,7 @@ Complete src/CompletionInferValues.res 86:103
 posCursor:[86:103] posNoWhite:[86:102] Found expr:[86:92->86:103]
 Pexp_field [86:92->86:102] _:[125:0->86:103]
 Completable: Cpath Value[someRecord].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someRecord].""
 ContextPath Value[someRecord]
 Path someRecord
@@ -406,6 +421,7 @@ Path someRecordWithNestedStuff
 Complete src/CompletionInferValues.res 90:81
 posCursor:[90:81] posNoWhite:[90:80] Found expr:[90:69->90:81]
 Completable: Cpath Value[things]->slic
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[things]->slic
 ContextPath Value[things]
 Path things
@@ -433,6 +449,7 @@ Path Js.String2.slic
 Complete src/CompletionInferValues.res 94:82
 posCursor:[94:82] posNoWhite:[94:81] Found expr:[94:70->94:82]
 Completable: Cpath Value[someInt]->toS
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someInt]->toS
 ContextPath Value[someInt]
 Path someInt
@@ -454,6 +471,7 @@ Path Belt.Int.toS
 Complete src/CompletionInferValues.res 98:109
 posCursor:[98:109] posNoWhite:[98:108] Found expr:[98:97->98:109]
 Completable: Cpath Value[someInt]->toS
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someInt]->toS
 ContextPath Value[someInt]
 Path someInt
@@ -479,6 +497,7 @@ Complete src/CompletionInferValues.res 102:102
 posCursor:[102:102] posNoWhite:[102:101] Found expr:[102:57->102:102]
 posCursor:[102:102] posNoWhite:[102:101] Found expr:[102:90->102:102]
 Completable: Cpath Value[someInt]->toS
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someInt]->toS
 ContextPath Value[someInt]
 Path someInt
@@ -503,6 +522,7 @@ Path Belt.Int.toS
 Complete src/CompletionInferValues.res 106:88
 posCursor:[106:88] posNoWhite:[106:87] Found expr:[106:79->106:88]
 Completable: Cpath Value[str]->slic
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[str]->slic
 ContextPath Value[str]
 Path str
@@ -530,6 +550,7 @@ Path Js.String2.slic
 Complete src/CompletionInferValues.res 110:89
 posCursor:[110:89] posNoWhite:[110:88] Found expr:[110:80->110:89]
 Completable: Cpath Value[str]->slic
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[str]->slic
 ContextPath Value[str]
 Path str
@@ -557,6 +578,7 @@ Path Js.String2.slic
 Complete src/CompletionInferValues.res 114:80
 posCursor:[114:80] posNoWhite:[114:79] Found expr:[114:70->114:80]
 Completable: Cpath Value[name]->slic
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[name]->slic
 ContextPath Value[name]
 Path name
@@ -585,6 +607,7 @@ Complete src/CompletionInferValues.res 118:67
 posCursor:[118:67] posNoWhite:[118:66] Found expr:[118:60->118:67]
 Pexp_field [118:60->118:65] s:[118:66->118:67]
 Completable: Cpath Value[inner].s
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[inner].s
 ContextPath Value[inner]
 Path inner
@@ -611,6 +634,7 @@ Path otherNestedRecord
 Complete src/CompletionInferValues.res 122:53
 posCursor:[122:53] posNoWhite:[122:52] Found expr:[122:46->122:53]
 Completable: Cpath Value[v]->toSt
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[v]->toSt
 ContextPath Value[v]
 Path v
@@ -634,6 +658,7 @@ posCursor:[130:26] posNoWhite:[130:25] Found expr:[130:24->130:36]
 posCursor:[130:26] posNoWhite:[130:25] Found pattern:[130:25->130:27]
 posCursor:[130:26] posNoWhite:[130:25] Found pattern:[130:25->130:27]
 Completable: Cpattern CArgument CArgument Value[fnWithRecordCallback]($0)($0)->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath CArgument CArgument Value[fnWithRecordCallback]($0)($0)
 ContextPath CArgument Value[fnWithRecordCallback]($0)
 ContextPath Value[fnWithRecordCallback]
@@ -659,6 +684,7 @@ posCursor:[137:30] posNoWhite:[137:29] Found expr:[137:11->137:32]
 posCursor:[137:30] posNoWhite:[137:29] Found expr:[137:24->0:-1]
 posCursor:[137:30] posNoWhite:[137:29] Found expr:[137:24->0:-1]
 Completable: Cpath Value[root]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[root]->
 ContextPath Value[root]
 Path root
@@ -692,6 +718,7 @@ posCursor:[146:30] posNoWhite:[146:29] Found expr:[146:11->146:32]
 posCursor:[146:30] posNoWhite:[146:29] Found expr:[146:24->0:-1]
 posCursor:[146:30] posNoWhite:[146:29] Found expr:[146:24->0:-1]
 Completable: Cpath Value[root]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[root]->
 ContextPath Value[root]
 Path root
@@ -727,6 +754,7 @@ Path CompletionSupport.Test.
 Complete src/CompletionInferValues.res 150:47
 XXX Not found!
 Completable: Cpattern Value[Belt, Int, toString](Nolabel)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Belt, Int, toString](Nolabel)
 ContextPath Value[Belt, Int, toString]
 Path Belt.Int.toString
@@ -744,6 +772,7 @@ Path Belt.Int.toString
 Complete src/CompletionInferValues.res 154:70
 XXX Not found!
 Completable: Cpattern Value[Js, String2, split](Nolabel, Nolabel)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Js, String2, split](Nolabel, Nolabel)
 ContextPath Value[Js, String2, split]
 Path Js.String2.split
@@ -765,6 +794,7 @@ posCursor:[158:105] posNoWhite:[158:104] Found expr:[158:81->158:106]
 posCursor:[158:105] posNoWhite:[158:104] Found expr:[158:97->158:105]
 Pexp_field [158:97->158:104] _:[158:105->158:105]
 Completable: Cpath Value[support].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[support].""
 ContextPath Value[support]
 Path support
@@ -788,6 +818,7 @@ posCursor:[162:110] posNoWhite:[162:109] Found expr:[162:81->162:111]
 posCursor:[162:110] posNoWhite:[162:109] Found expr:[162:104->0:-1]
 posCursor:[162:110] posNoWhite:[162:109] Found expr:[162:104->0:-1]
 Completable: Cpath Value[root]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[root]->
 ContextPath Value[root]
 Path root

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -1,6 +1,7 @@
 Complete src/CompletionJsx.res 3:17
 posCursor:[3:17] posNoWhite:[3:16] Found expr:[3:3->3:17]
 Completable: Cpath Value[someString]->st
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someString]->st
 ContextPath Value[someString]
 Path someString
@@ -29,6 +30,7 @@ posCursor:[13:21] posNoWhite:[13:20] Found expr:[12:4->32:10]
 posCursor:[13:21] posNoWhite:[13:20] Found expr:[13:7->32:10]
 posCursor:[13:21] posNoWhite:[13:20] Found expr:[13:7->13:21]
 Completable: Cpath Value[someString]->st <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someString]->st <<jsx>>
 ContextPath Value[someString]
 Path someString
@@ -75,6 +77,7 @@ Pexp_construct :::[18:10->32:4] [18:10->32:4]
 posCursor:[18:24] posNoWhite:[18:23] Found expr:[18:10->32:4]
 posCursor:[18:24] posNoWhite:[18:23] Found expr:[18:10->18:24]
 Completable: Cpath Value[someString]->st <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someString]->st <<jsx>>
 ContextPath Value[someString]
 Path someString
@@ -121,6 +124,7 @@ Pexp_construct :::[20:10->32:4] [20:10->32:4]
 posCursor:[20:27] posNoWhite:[20:26] Found expr:[20:10->32:4]
 posCursor:[20:27] posNoWhite:[20:26] Found expr:[20:10->20:27]
 Completable: Cpath string->st <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath string->st <<jsx>>
 ContextPath string
 CPPipe env:CompletionJsx
@@ -166,6 +170,7 @@ Pexp_construct :::[22:10->32:4] [22:10->32:4]
 posCursor:[22:44] posNoWhite:[22:43] Found expr:[22:10->32:4]
 posCursor:[22:44] posNoWhite:[22:43] Found expr:[22:10->22:44]
 Completable: Cpath Value[Js, String2, trim](Nolabel)->st <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Js, String2, trim](Nolabel)->st <<jsx>>
 ContextPath Value[Js, String2, trim](Nolabel)
 ContextPath Value[Js, String2, trim]
@@ -213,6 +218,7 @@ Pexp_construct :::[24:10->32:4] [24:10->32:4]
 posCursor:[24:19] posNoWhite:[24:18] Found expr:[24:10->32:4]
 posCursor:[24:19] posNoWhite:[24:18] Found expr:[24:10->0:-1]
 Completable: Cpath Value[someInt]-> <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someInt]-> <<jsx>>
 ContextPath Value[someInt]
 Path someInt
@@ -295,6 +301,7 @@ Pexp_construct :::[26:10->32:4] [26:10->32:4]
 posCursor:[26:14] posNoWhite:[26:13] Found expr:[26:10->32:4]
 posCursor:[26:14] posNoWhite:[26:13] Found expr:[26:10->0:-1]
 Completable: Cpath int-> <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath int-> <<jsx>>
 ContextPath int
 CPPipe env:CompletionJsx
@@ -376,6 +383,7 @@ Pexp_construct :::[28:10->32:4] [28:10->32:4]
 posCursor:[28:20] posNoWhite:[28:19] Found expr:[28:10->32:4]
 posCursor:[28:20] posNoWhite:[28:19] Found expr:[28:10->28:20]
 Completable: Cpath Value[someArr]->a <<jsx>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someArr]->a <<jsx>>
 ContextPath Value[someArr]
 Path someArr
@@ -417,6 +425,7 @@ posCursor:[30:12] posNoWhite:[30:11] Found expr:[30:10->32:4]
 posCursor:[30:12] posNoWhite:[30:11] Found expr:[30:10->30:12]
 JSX <di:[30:10->30:12] > _children:None
 Completable: ChtmlElement <di
+Package opens Pervasives.JsxModules.place holder
 [{
     "label": "<dialog>",
     "kind": 4,
@@ -444,6 +453,7 @@ Complete src/CompletionJsx.res 45:23
 posCursor:[45:23] posNoWhite:[45:22] Found expr:[45:4->45:23]
 JSX <CompWithoutJsxPpx:[45:4->45:21] n[45:22->45:23]=...[45:22->45:23]> _children:None
 Completable: Cjsx([CompWithoutJsxPpx], n, [n])
+Package opens Pervasives.JsxModules.place holder
 Path CompWithoutJsxPpx.make
 [{
     "label": "name",

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -2,6 +2,7 @@ Complete src/CompletionJsxProps.res 0:47
 posCursor:[0:47] posNoWhite:[0:46] Found expr:[0:12->0:47]
 JSX <CompletionSupport.TestComponent:[0:12->0:43] on[0:44->0:46]=...__ghost__[0:-1->0:-1]> _children:None
 Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] on
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [CompletionSupport, TestComponent] on
 Path CompletionSupport.TestComponent.make
 [{
@@ -22,6 +23,7 @@ Complete src/CompletionJsxProps.res 3:48
 posCursor:[3:48] posNoWhite:[3:47] Found expr:[3:12->3:48]
 JSX <CompletionSupport.TestComponent:[3:12->3:43] on[3:44->3:46]=...[3:47->3:48]> _children:None
 Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] on=t
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [CompletionSupport, TestComponent] on
 Path CompletionSupport.TestComponent.make
 [{
@@ -36,6 +38,7 @@ Complete src/CompletionJsxProps.res 6:50
 posCursor:[6:50] posNoWhite:[6:49] Found expr:[6:12->6:50]
 JSX <CompletionSupport.TestComponent:[6:12->6:43] test[6:44->6:48]=...[6:49->6:50]> _children:None
 Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] test=T
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [CompletionSupport, TestComponent] test
 Path CompletionSupport.TestComponent.make
 [{
@@ -74,6 +77,7 @@ Complete src/CompletionJsxProps.res 9:52
 posCursor:[9:52] posNoWhite:[9:51] Found expr:[9:12->9:52]
 JSX <CompletionSupport.TestComponent:[9:12->9:43] polyArg[9:44->9:51]=...__ghost__[0:-1->0:-1]> _children:None
 Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] polyArg
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [CompletionSupport, TestComponent] polyArg
 Path CompletionSupport.TestComponent.make
 [{
@@ -114,6 +118,7 @@ Complete src/CompletionJsxProps.res 12:54
 posCursor:[12:54] posNoWhite:[12:53] Found expr:[12:12->12:54]
 JSX <CompletionSupport.TestComponent:[12:12->12:43] polyArg[12:44->12:51]=...[12:52->12:54]> _children:None
 Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] polyArg=#t
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [CompletionSupport, TestComponent] polyArg
 Path CompletionSupport.TestComponent.make
 [{
@@ -146,6 +151,7 @@ Complete src/CompletionJsxProps.res 15:22
 posCursor:[15:22] posNoWhite:[15:21] Found expr:[15:12->15:25]
 JSX <div:[15:12->15:15] muted[15:16->15:21]=...__ghost__[0:-1->0:-1]> _children:15:23
 Completable: Cexpression CJsxPropValue [div] muted
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [div] muted
 Path ReactDOM.domProps
 Path JsxDOM.domProps
@@ -167,6 +173,7 @@ Complete src/CompletionJsxProps.res 18:29
 posCursor:[18:29] posNoWhite:[18:28] Found expr:[18:12->18:32]
 JSX <div:[18:12->18:15] onMouseEnter[18:16->18:28]=...__ghost__[0:-1->0:-1]> _children:18:30
 Completable: Cexpression CJsxPropValue [div] onMouseEnter
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [div] onMouseEnter
 Path ReactDOM.domProps
 Path JsxDOM.domProps
@@ -185,6 +192,7 @@ Complete src/CompletionJsxProps.res 22:52
 posCursor:[22:52] posNoWhite:[22:51] Found expr:[22:12->22:52]
 JSX <CompletionSupport.TestComponent:[22:12->22:43] testArr[22:44->22:51]=...__ghost__[0:-1->0:-1]> _children:None
 Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] testArr
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [CompletionSupport, TestComponent] testArr
 Path CompletionSupport.TestComponent.make
 [{
@@ -202,6 +210,7 @@ Complete src/CompletionJsxProps.res 26:54
 posCursor:[26:54] posNoWhite:[26:53] Found expr:[26:12->26:56]
 JSX <CompletionSupport.TestComponent:[26:12->26:43] testArr[26:44->26:51]=...[26:53->26:55]> _children:None
 Completable: Cexpression CJsxPropValue [CompletionSupport, TestComponent] testArr->array
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [CompletionSupport, TestComponent] testArr
 Path CompletionSupport.TestComponent.make
 [{

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -5,6 +5,7 @@ posCursor:[7:13] posNoWhite:[7:12] Found expr:[7:3->7:13]
 Complete src/CompletionPattern.res 10:15
 XXX Not found!
 Completable: Cpattern Value[v]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[v]
 Path v
 [{
@@ -21,6 +22,7 @@ Complete src/CompletionPattern.res 13:18
 posCursor:[13:18] posNoWhite:[13:17] Found pattern:[13:16->13:22]
 posCursor:[13:18] posNoWhite:[13:17] Found pattern:[13:17->13:18]
 Completable: Cpattern Value[v]=t->tuple($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[v]
 Path v
 [{
@@ -36,6 +38,7 @@ posCursor:[16:25] posNoWhite:[16:24] Found pattern:[16:16->16:30]
 posCursor:[16:25] posNoWhite:[16:24] Found pattern:[16:23->16:29]
 posCursor:[16:25] posNoWhite:[16:24] Found pattern:[16:24->16:25]
 Completable: Cpattern Value[v]=f->tuple($2), tuple($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[v]
 Path v
 [{
@@ -49,6 +52,7 @@ Path v
 Complete src/CompletionPattern.res 21:15
 XXX Not found!
 Completable: Cpattern Value[x]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x]
 Path x
 [{
@@ -68,6 +72,7 @@ Path x
 Complete src/CompletionPattern.res 24:17
 posCursor:[24:17] posNoWhite:[24:16] Found pattern:[24:16->24:17]
 Completable: Cpattern Value[x]=t
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x]
 Path x
 [{
@@ -81,6 +86,7 @@ Path x
 Complete src/CompletionPattern.res 46:15
 XXX Not found!
 Completable: Cpattern Value[f]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[f]
 Path f
 [{
@@ -97,6 +103,7 @@ Path f
 Complete src/CompletionPattern.res 49:17
 posCursor:[49:17] posNoWhite:[49:16] Found pattern:[49:16->49:18]
 Completable: Cpattern Value[f]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[f]
 Path f
 [{
@@ -128,6 +135,7 @@ Path f
 Complete src/CompletionPattern.res 52:24
 posCursor:[52:24] posNoWhite:[52:22] Found pattern:[52:16->52:35]
 Completable: Cpattern Value[f]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[f]
 Path f
 [{
@@ -148,6 +156,7 @@ Complete src/CompletionPattern.res 55:19
 posCursor:[55:19] posNoWhite:[55:18] Found pattern:[55:16->55:20]
 posCursor:[55:19] posNoWhite:[55:18] Found pattern:[55:17->55:19]
 Completable: Cpattern Value[f]=fi->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[f]
 Path f
 [{
@@ -163,6 +172,7 @@ posCursor:[58:19] posNoWhite:[58:18] Found pattern:[58:16->58:24]
 posCursor:[58:19] posNoWhite:[58:18] Found pattern:[58:17->58:20]
 posCursor:[58:19] posNoWhite:[58:18] Found pattern:[58:18->58:19]
 Completable: Cpattern Value[z]=o->tuple($0), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[z]
 Path z
 [{
@@ -176,6 +186,7 @@ Path z
 Complete src/CompletionPattern.res 61:22
 posCursor:[61:22] posNoWhite:[61:21] Found pattern:[61:16->61:25]
 Completable: Cpattern Value[f]->recordField(nest)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[f]
 Path f
 [{
@@ -193,6 +204,7 @@ Complete src/CompletionPattern.res 64:24
 posCursor:[64:24] posNoWhite:[64:23] Found pattern:[64:16->64:26]
 posCursor:[64:24] posNoWhite:[64:23] Found pattern:[64:23->64:25]
 Completable: Cpattern Value[f]->recordField(nest), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[f]
 Path f
 [{
@@ -208,6 +220,7 @@ posCursor:[70:22] posNoWhite:[70:21] Found expr:[69:2->72:13]
 posCursor:[70:22] posNoWhite:[70:21] Found expr:[70:5->72:13]
 posCursor:[70:22] posNoWhite:[70:21] Found pattern:[70:21->70:23]
 Completable: Cpattern Value[nest]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[nest]
 Path nest
 [{
@@ -221,6 +234,7 @@ Path nest
 Complete src/CompletionPattern.res 76:8
 posCursor:[76:8] posNoWhite:[76:7] Found pattern:[76:7->76:9]
 Completable: Cpattern Value[f]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[f]
 Path f
 [{
@@ -254,6 +268,7 @@ posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:7->79:18]
 posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:14->79:17]
 posCursor:[79:16] posNoWhite:[79:15] Found pattern:[79:15->79:16]
 Completable: Cpattern Value[f]=n->recordField(nest), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[f]
 Path f
 [{
@@ -270,6 +285,7 @@ Ppat_construct Two:[87:16->87:19]
 posCursor:[87:20] posNoWhite:[87:19] Found pattern:[87:19->87:21]
 Ppat_construct ():[87:19->87:21]
 Completable: Cpattern Value[z]->variantPayload::Two($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[z]
 Path z
 [{
@@ -291,6 +307,7 @@ posCursor:[90:21] posNoWhite:[90:20] Found pattern:[90:16->90:22]
 Ppat_construct Two:[90:16->90:19]
 posCursor:[90:21] posNoWhite:[90:20] Found pattern:[90:20->90:21]
 Completable: Cpattern Value[z]=t->variantPayload::Two($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[z]
 Path z
 [{
@@ -306,6 +323,7 @@ posCursor:[93:23] posNoWhite:[93:22] Found pattern:[93:16->93:25]
 Ppat_construct Three:[93:16->93:21]
 posCursor:[93:23] posNoWhite:[93:22] Found pattern:[93:22->93:24]
 Completable: Cpattern Value[z]->variantPayload::Three($0), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[z]
 Path z
 [{
@@ -340,6 +358,7 @@ Ppat_construct Three:[96:16->96:21]
 posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:21->96:29]
 posCursor:[96:27] posNoWhite:[96:26] Found pattern:[96:26->96:27]
 Completable: Cpattern Value[z]=t->variantPayload::Three($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[z]
 Path z
 [{
@@ -355,6 +374,7 @@ posCursor:[103:21] posNoWhite:[103:20] Found pattern:[103:16->103:22]
 posCursor:[103:21] posNoWhite:[103:20] Found pattern:[103:20->103:21]
 Ppat_construct ():[103:20->103:21]
 Completable: Cpattern Value[b]->polyvariantPayload::two($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[b]
 Path b
 [{
@@ -375,6 +395,7 @@ Complete src/CompletionPattern.res 106:22
 posCursor:[106:22] posNoWhite:[106:21] Found pattern:[106:16->106:23]
 posCursor:[106:22] posNoWhite:[106:21] Found pattern:[106:21->106:22]
 Completable: Cpattern Value[b]=t->polyvariantPayload::two($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[b]
 Path b
 [{
@@ -389,6 +410,7 @@ Complete src/CompletionPattern.res 109:24
 posCursor:[109:24] posNoWhite:[109:23] Found pattern:[109:16->109:26]
 posCursor:[109:24] posNoWhite:[109:23] Found pattern:[109:23->109:25]
 Completable: Cpattern Value[b]->polyvariantPayload::three($0), recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[b]
 Path b
 [{
@@ -422,6 +444,7 @@ posCursor:[112:28] posNoWhite:[112:27] Found pattern:[112:16->112:29]
 posCursor:[112:28] posNoWhite:[112:27] Found pattern:[112:22->112:29]
 posCursor:[112:28] posNoWhite:[112:27] Found pattern:[112:27->112:28]
 Completable: Cpattern Value[b]=t->polyvariantPayload::three($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[b]
 Path b
 [{
@@ -435,6 +458,7 @@ Path b
 Complete src/CompletionPattern.res 118:15
 XXX Not found!
 Completable: Cpattern Value[c]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[c]
 Path c
 [{
@@ -451,6 +475,7 @@ Path c
 Complete src/CompletionPattern.res 121:17
 posCursor:[121:17] posNoWhite:[121:16] Found pattern:[121:16->121:18]
 Completable: Cpattern Value[c]->array
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[c]
 Path c
 [{
@@ -473,6 +498,7 @@ Ppat_construct Some:[127:16->127:20]
 posCursor:[127:21] posNoWhite:[127:20] Found pattern:[127:20->127:22]
 Ppat_construct ():[127:20->127:22]
 Completable: Cpattern Value[o]->variantPayload::Some($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[o]
 Path o
 [{
@@ -493,6 +519,7 @@ Complete src/CompletionPattern.res 134:23
 posCursor:[134:23] posNoWhite:[134:22] Found pattern:[134:16->134:25]
 Ppat_construct Test:[134:16->134:20]
 Completable: Cpattern Value[p]->variantPayload::Test($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[p]
 Path p
 [{
@@ -514,6 +541,7 @@ posCursor:[137:29] posNoWhite:[137:28] Found pattern:[137:16->137:31]
 Ppat_construct Test:[137:16->137:20]
 posCursor:[137:29] posNoWhite:[137:28] Found pattern:[137:20->137:32]
 Completable: Cpattern Value[p]->variantPayload::Test($2)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[p]
 Path p
 [{
@@ -549,6 +577,7 @@ posCursor:[140:23] posNoWhite:[140:22] Found pattern:[140:16->140:31]
 Ppat_construct Test:[140:16->140:20]
 posCursor:[140:23] posNoWhite:[140:22] Found pattern:[140:20->140:32]
 Completable: Cpattern Value[p]->variantPayload::Test($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[p]
 Path p
 [{
@@ -570,6 +599,7 @@ posCursor:[143:35] posNoWhite:[143:34] Found pattern:[143:16->143:37]
 Ppat_construct Test:[143:16->143:20]
 posCursor:[143:35] posNoWhite:[143:34] Found pattern:[143:20->143:38]
 Completable: Cpattern Value[p]->variantPayload::Test($3)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[p]
 Path p
 [{
@@ -586,6 +616,7 @@ Path p
 Complete src/CompletionPattern.res 150:24
 posCursor:[150:24] posNoWhite:[150:23] Found pattern:[150:16->150:26]
 Completable: Cpattern Value[v]->polyvariantPayload::test($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[v]
 Path v
 [{
@@ -606,6 +637,7 @@ Complete src/CompletionPattern.res 153:30
 posCursor:[153:30] posNoWhite:[153:29] Found pattern:[153:16->153:32]
 posCursor:[153:30] posNoWhite:[153:29] Found pattern:[153:21->153:32]
 Completable: Cpattern Value[v]->polyvariantPayload::test($2)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[v]
 Path v
 [{
@@ -640,6 +672,7 @@ Complete src/CompletionPattern.res 156:24
 posCursor:[156:24] posNoWhite:[156:23] Found pattern:[156:16->156:32]
 posCursor:[156:24] posNoWhite:[156:23] Found pattern:[156:21->156:32]
 Completable: Cpattern Value[v]->polyvariantPayload::test($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[v]
 Path v
 [{
@@ -660,6 +693,7 @@ Complete src/CompletionPattern.res 159:36
 posCursor:[159:36] posNoWhite:[159:35] Found pattern:[159:16->159:38]
 posCursor:[159:36] posNoWhite:[159:35] Found pattern:[159:21->159:38]
 Completable: Cpattern Value[v]->polyvariantPayload::test($3)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[v]
 Path v
 [{
@@ -677,6 +711,7 @@ Complete src/CompletionPattern.res 164:17
 posCursor:[164:17] posNoWhite:[164:16] Found pattern:[164:16->164:18]
 Ppat_construct ():[164:16->164:18]
 Completable: Cpattern Value[s]->tuple($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[s]
 Path s
 [{
@@ -696,6 +731,7 @@ Path s
 Complete src/CompletionPattern.res 167:23
 posCursor:[167:23] posNoWhite:[167:21] Found pattern:[167:16->167:24]
 Completable: Cpattern Value[s]->tuple($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[s]
 Path s
 [{
@@ -729,6 +765,7 @@ Path s
 Complete src/CompletionPattern.res 170:22
 posCursor:[170:22] posNoWhite:[170:21] Found pattern:[170:16->170:28]
 Completable: Cpattern Value[s]->tuple($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[s]
 Path s
 [{
@@ -762,6 +799,7 @@ Path s
 Complete src/CompletionPattern.res 173:35
 XXX Not found!
 Completable: Cpattern Value[s]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[s]
 Path s
 [{
@@ -777,6 +815,7 @@ Path s
 Complete src/CompletionPattern.res 176:41
 posCursor:[176:41] posNoWhite:[176:40] Found pattern:[176:35->176:47]
 Completable: Cpattern Value[s]->tuple($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[s]
 Path s
 [{
@@ -810,6 +849,7 @@ Path s
 Complete src/CompletionPattern.res 179:21
 XXX Not found!
 Completable: Cpattern Value[z]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[z]
 Path z
 [{
@@ -843,6 +883,7 @@ posCursor:[182:32] posNoWhite:[182:31] Found pattern:[182:16->182:34]
 posCursor:[182:32] posNoWhite:[182:31] Found pattern:[182:22->182:34]
 Ppat_construct Two:[182:22->182:25]
 Completable: Cpattern Value[z]->variantPayload::Two($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[z]
 Path z
 [{
@@ -865,6 +906,7 @@ posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:22->185:50]
 Ppat_construct Three:[185:22->185:27]
 posCursor:[185:48] posNoWhite:[185:47] Found pattern:[185:27->185:53]
 Completable: Cpattern Value[z]->variantPayload::Three($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[z]
 Path z
 [{
@@ -885,6 +927,7 @@ Complete src/CompletionPattern.res 188:34
 posCursor:[188:34] posNoWhite:[188:33] Found pattern:[188:16->188:36]
 posCursor:[188:34] posNoWhite:[188:33] Found pattern:[188:23->188:36]
 Completable: Cpattern Value[b]->polyvariantPayload::two($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[b]
 Path b
 [{
@@ -906,6 +949,7 @@ posCursor:[191:50] posNoWhite:[191:49] Found pattern:[191:16->191:52]
 posCursor:[191:50] posNoWhite:[191:49] Found pattern:[191:23->191:52]
 posCursor:[191:50] posNoWhite:[191:49] Found pattern:[191:29->191:52]
 Completable: Cpattern Value[b]->polyvariantPayload::three($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[b]
 Path b
 [{
@@ -926,6 +970,7 @@ Complete src/CompletionPattern.res 194:24
 posCursor:[194:24] posNoWhite:[194:23] Found pattern:[194:16->194:29]
 posCursor:[194:24] posNoWhite:[194:23] Found pattern:[194:23->194:24]
 Completable: Cpattern Value[s]->tuple($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[s]
 Path s
 [{
@@ -959,6 +1004,7 @@ Path s
 Complete src/CompletionPattern.res 201:25
 posCursor:[201:25] posNoWhite:[201:24] Found pattern:[201:17->201:28]
 Completable: Cpattern Value[ff]->recordField(someFn)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[ff]
 Path ff
 []
@@ -966,6 +1012,7 @@ Path ff
 Complete src/CompletionPattern.res 206:16
 XXX Not found!
 Completable: Cpattern Value[xn]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[xn]
 Path xn
 [{

--- a/analysis/tests/src/expected/CompletionPipeChain.res.txt
+++ b/analysis/tests/src/expected/CompletionPipeChain.res.txt
@@ -1,6 +1,7 @@
 Complete src/CompletionPipeChain.res 27:16
 posCursor:[27:16] posNoWhite:[27:15] Found expr:[27:11->0:-1]
 Completable: Cpath Value[int]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[int]->
 ContextPath Value[int]
 Path int
@@ -37,6 +38,7 @@ Path Integer.
 Complete src/CompletionPipeChain.res 30:23
 posCursor:[30:23] posNoWhite:[30:22] Found expr:[30:11->0:-1]
 Completable: Cpath Value[toFlt](Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[toFlt](Nolabel)->
 ContextPath Value[toFlt](Nolabel)
 ContextPath Value[toFlt]
@@ -62,6 +64,7 @@ Path SuperFloat.
 Complete src/CompletionPipeChain.res 33:38
 posCursor:[33:38] posNoWhite:[33:37] Found expr:[33:11->0:-1]
 Completable: Cpath Value[Integer, increment](Nolabel, Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Integer, increment](Nolabel, Nolabel)->
 ContextPath Value[Integer, increment](Nolabel, Nolabel)
 ContextPath Value[Integer, increment]
@@ -99,6 +102,7 @@ Path Integer.
 Complete src/CompletionPipeChain.res 36:38
 posCursor:[36:38] posNoWhite:[36:37] Found expr:[36:11->0:-1]
 Completable: Cpath Value[Integer, increment](Nolabel, Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Integer, increment](Nolabel, Nolabel)->
 ContextPath Value[Integer, increment](Nolabel, Nolabel)
 ContextPath Value[Integer, increment]
@@ -136,6 +140,7 @@ Path Integer.
 Complete src/CompletionPipeChain.res 39:47
 posCursor:[39:47] posNoWhite:[39:46] Found expr:[39:11->0:-1]
 Completable: Cpath Value[Integer, decrement](Nolabel, Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Integer, decrement](Nolabel, Nolabel)->
 ContextPath Value[Integer, decrement](Nolabel, Nolabel)
 ContextPath Value[Integer, decrement]
@@ -173,6 +178,7 @@ Path Integer.
 Complete src/CompletionPipeChain.res 42:69
 posCursor:[42:69] posNoWhite:[42:68] Found expr:[42:11->0:-1]
 Completable: Cpath Value[Integer, decrement](Nolabel, Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Integer, decrement](Nolabel, Nolabel)->
 ContextPath Value[Integer, decrement](Nolabel, Nolabel)
 ContextPath Value[Integer, decrement]
@@ -210,6 +216,7 @@ Path Integer.
 Complete src/CompletionPipeChain.res 45:62
 posCursor:[45:62] posNoWhite:[45:61] Found expr:[45:11->0:-1]
 Completable: Cpath Value[SuperFloat, fromInteger](Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[SuperFloat, fromInteger](Nolabel)->
 ContextPath Value[SuperFloat, fromInteger](Nolabel)
 ContextPath Value[SuperFloat, fromInteger]
@@ -235,6 +242,7 @@ Path SuperFloat.
 Complete src/CompletionPipeChain.res 48:63
 posCursor:[48:63] posNoWhite:[48:62] Found expr:[48:11->48:63]
 Completable: Cpath Value[SuperFloat, fromInteger](Nolabel)->t
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[SuperFloat, fromInteger](Nolabel)->t
 ContextPath Value[SuperFloat, fromInteger](Nolabel)
 ContextPath Value[SuperFloat, fromInteger]
@@ -254,6 +262,7 @@ Path SuperFloat.t
 Complete src/CompletionPipeChain.res 51:82
 posCursor:[51:82] posNoWhite:[51:81] Found expr:[51:11->0:-1]
 Completable: Cpath Value[CompletionSupport, Test, make](Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[CompletionSupport, Test, make](Nolabel)->
 ContextPath Value[CompletionSupport, Test, make](Nolabel)
 ContextPath Value[CompletionSupport, Test, make]
@@ -285,6 +294,7 @@ Path CompletionSupport.Test.
 Complete src/CompletionPipeChain.res 54:78
 posCursor:[54:78] posNoWhite:[54:77] Found expr:[54:11->0:-1]
 Completable: Cpath Value[CompletionSupport, Test, addSelf](Nolabel, Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[CompletionSupport, Test, addSelf](Nolabel, Nolabel)->
 ContextPath Value[CompletionSupport, Test, addSelf](Nolabel, Nolabel)
 ContextPath Value[CompletionSupport, Test, addSelf]
@@ -316,6 +326,7 @@ Path CompletionSupport.Test.
 Complete src/CompletionPipeChain.res 58:5
 posCursor:[58:5] posNoWhite:[58:4] Found expr:[57:8->0:-1]
 Completable: Cpath Value[Js, Array2, forEach](Nolabel, Nolabel)->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Js, Array2, forEach](Nolabel, Nolabel)->
 ContextPath Value[Js, Array2, forEach](Nolabel, Nolabel)
 ContextPath Value[Js, Array2, forEach]
@@ -328,6 +339,7 @@ CPPipe pathFromEnv: found:true
 Complete src/CompletionPipeChain.res 62:6
 posCursor:[62:6] posNoWhite:[62:5] Found expr:[61:8->62:6]
 Completable: Cpath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)->t
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)->t
 ContextPath Value[Belt, Array, reduce](Nolabel, Nolabel, Nolabel)
 ContextPath Value[Belt, Array, reduce]
@@ -351,6 +363,7 @@ Path Belt.Int.t
 Complete src/CompletionPipeChain.res 70:12
 posCursor:[70:12] posNoWhite:[70:11] Found expr:[70:3->0:-1]
 Completable: Cpath Value[aliased]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[aliased]->
 ContextPath Value[aliased]
 Path aliased
@@ -381,6 +394,7 @@ Path CompletionSupport.Test.
 Complete src/CompletionPipeChain.res 73:15
 posCursor:[73:15] posNoWhite:[73:14] Found expr:[73:3->0:-1]
 Completable: Cpath Value[notAliased]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[notAliased]->
 ContextPath Value[notAliased]
 Path notAliased
@@ -416,6 +430,7 @@ posCursor:[82:30] posNoWhite:[82:29] Found expr:[79:4->90:14]
 posCursor:[82:30] posNoWhite:[82:29] Found expr:[82:7->90:14]
 posCursor:[82:30] posNoWhite:[82:29] Found expr:[82:7->82:30]
 Completable: Cpath Value[props].support.root->ren
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[props].support.root->ren
 ContextPath Value[props].support.root
 ContextPath Value[props].support
@@ -443,6 +458,7 @@ posCursor:[88:16] posNoWhite:[88:15] Found expr:[85:4->90:14]
 posCursor:[88:16] posNoWhite:[88:15] Found expr:[88:7->90:14]
 posCursor:[88:16] posNoWhite:[88:15] Found expr:[88:7->88:16]
 Completable: Cpath Value[root]->ren
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[root]->ren
 ContextPath Value[root]
 Path root

--- a/analysis/tests/src/expected/CompletionPipeSubmodules.res.txt
+++ b/analysis/tests/src/expected/CompletionPipeSubmodules.res.txt
@@ -1,6 +1,7 @@
 Complete src/CompletionPipeSubmodules.res 12:20
 posCursor:[12:20] posNoWhite:[12:19] Found expr:[12:11->20:8]
 Completable: Cpath Value[A, B1, xx]->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[A, B1, xx]->
 ContextPath Value[A, B1, xx]
 Path A.B1.xx
@@ -25,6 +26,7 @@ Path A.B1.
 Complete src/CompletionPipeSubmodules.res 16:18
 posCursor:[16:18] posNoWhite:[16:17] Found expr:[16:11->20:8]
 Completable: Cpath Value[A, x].v->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[A, x].v->
 ContextPath Value[A, x].v
 ContextPath Value[A, x]
@@ -50,6 +52,7 @@ Path A.B1.
 Complete src/CompletionPipeSubmodules.res 38:20
 posCursor:[38:20] posNoWhite:[38:19] Found expr:[38:11->0:-1]
 Completable: Cpath Value[E, e].v.v->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[E, e].v.v->
 ContextPath Value[E, e].v.v
 ContextPath Value[E, e].v
@@ -70,6 +73,7 @@ Path C.
 Complete src/CompletionPipeSubmodules.res 42:21
 posCursor:[42:21] posNoWhite:[42:20] Found expr:[42:11->0:-1]
 Completable: Cpath Value[E, e].v.v2->
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[E, e].v.v2->
 ContextPath Value[E, e].v.v2
 ContextPath Value[E, e].v

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -1,6 +1,7 @@
 Complete src/CompletionTypeAnnotation.res 9:22
 XXX Not found!
 Completable: Cexpression Type[someRecord]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[someRecord]
 Path someRecord
 [{
@@ -17,6 +18,7 @@ Path someRecord
 Complete src/CompletionTypeAnnotation.res 12:24
 XXX Not found!
 Completable: Cexpression Type[someRecord]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[someRecord]
 Path someRecord
 [{
@@ -36,6 +38,7 @@ Path someRecord
 Complete src/CompletionTypeAnnotation.res 15:23
 XXX Not found!
 Completable: Cexpression Type[someVariant]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[someVariant]
 Path someVariant
 [{
@@ -59,6 +62,7 @@ Path someVariant
 Complete src/CompletionTypeAnnotation.res 18:25
 XXX Not found!
 Completable: Cexpression Type[someVariant]=O
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[someVariant]
 Path someVariant
 [{
@@ -87,6 +91,7 @@ Path someVariant
 Complete src/CompletionTypeAnnotation.res 21:27
 XXX Not found!
 Completable: Cexpression Type[somePolyVariant]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[somePolyVariant]
 Path somePolyVariant
 [{
@@ -110,6 +115,7 @@ Path somePolyVariant
 Complete src/CompletionTypeAnnotation.res 24:30
 XXX Not found!
 Completable: Cexpression Type[somePolyVariant]=#o
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[somePolyVariant]
 Path somePolyVariant
 [{
@@ -125,6 +131,7 @@ Path somePolyVariant
 Complete src/CompletionTypeAnnotation.res 29:20
 XXX Not found!
 Completable: Cexpression Type[someFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[someFunc]
 Path someFunc
 [{
@@ -141,6 +148,7 @@ Path someFunc
 Complete src/CompletionTypeAnnotation.res 34:21
 XXX Not found!
 Completable: Cexpression Type[someTuple]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[someTuple]
 Path someTuple
 [{
@@ -156,6 +164,7 @@ Path someTuple
 Complete src/CompletionTypeAnnotation.res 37:28
 XXX Not found!
 Completable: Cexpression Type[someTuple]->tuple($1)
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[someTuple]
 Path someTuple
 [{
@@ -189,6 +198,7 @@ Path someTuple
 Complete src/CompletionTypeAnnotation.res 40:31
 XXX Not found!
 Completable: Cexpression option<Type[someVariant]>
+Package opens Pervasives.JsxModules.place holder
 ContextPath option<Type[someVariant]>
 ContextPath Type[someVariant]
 Path someVariant
@@ -227,6 +237,7 @@ Path someVariant
 Complete src/CompletionTypeAnnotation.res 43:37
 XXX Not found!
 Completable: Cexpression option<Type[someVariant]>->variantPayload::Some($0)
+Package opens Pervasives.JsxModules.place holder
 ContextPath option<Type[someVariant]>
 ContextPath Type[someVariant]
 Path someVariant
@@ -251,6 +262,7 @@ Path someVariant
 Complete src/CompletionTypeAnnotation.res 46:30
 XXX Not found!
 Completable: Cexpression array<Type[someVariant]>
+Package opens Pervasives.JsxModules.place holder
 ContextPath array<Type[someVariant]>
 ContextPath Type[someVariant]
 Path someVariant
@@ -268,6 +280,7 @@ Path someVariant
 Complete src/CompletionTypeAnnotation.res 49:32
 XXX Not found!
 Completable: Cexpression array<Type[someVariant]>->array
+Package opens Pervasives.JsxModules.place holder
 ContextPath array<Type[someVariant]>
 ContextPath Type[someVariant]
 Path someVariant
@@ -292,6 +305,7 @@ Path someVariant
 Complete src/CompletionTypeAnnotation.res 52:38
 XXX Not found!
 Completable: Cexpression array<option<Type[someVariant]>>
+Package opens Pervasives.JsxModules.place holder
 ContextPath array<option<Type[someVariant]>>
 ContextPath option<Type[someVariant]>
 ContextPath Type[someVariant]
@@ -310,6 +324,7 @@ Path someVariant
 Complete src/CompletionTypeAnnotation.res 55:45
 XXX Not found!
 Completable: Cexpression option<array<Type[someVariant]>>->variantPayload::Some($0), array
+Package opens Pervasives.JsxModules.place holder
 ContextPath option<array<Type[someVariant]>>
 ContextPath array<Type[someVariant]>
 ContextPath Type[someVariant]

--- a/analysis/tests/src/expected/Cross.res.txt
+++ b/analysis/tests/src/expected/Cross.res.txt
@@ -97,6 +97,7 @@ Complete src/Cross.res 36:28
 posCursor:[36:28] posNoWhite:[36:27] Found expr:[36:3->36:28]
 Pexp_ident DefinitionWithInterface.a:[36:3->36:28]
 Completable: Cpath Value[DefinitionWithInterface, a]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[DefinitionWithInterface, a]
 Path DefinitionWithInterface.a
 []

--- a/analysis/tests/src/expected/Debug.res.txt
+++ b/analysis/tests/src/expected/Debug.res.txt
@@ -9,6 +9,7 @@ posCursor:[14:8] posNoWhite:[14:7] Found expr:[14:5->14:8]
 Pexp_ident eqN:[14:5->14:8]
 Completable: Cpath Value[eqN]
 Raw opens: 1 Js.place holder
+Package opens Pervasives.JsxModules.place holder
 Resolved opens 1 js.ml
 ContextPath Value[eqN]
 Path eqN

--- a/analysis/tests/src/expected/Destructuring.res.txt
+++ b/analysis/tests/src/expected/Destructuring.res.txt
@@ -1,6 +1,7 @@
 Complete src/Destructuring.res 4:11
 posCursor:[4:11] posNoWhite:[4:9] Found pattern:[4:4->4:12]
 Completable: Cpattern Value[x]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x]
 Path x
 [{
@@ -14,6 +15,7 @@ Path x
 Complete src/Destructuring.res 7:8
 posCursor:[7:8] posNoWhite:[7:7] Found pattern:[7:7->7:9]
 Completable: Cpattern Value[x]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x]
 Path x
 [{
@@ -35,6 +37,7 @@ posCursor:[11:13] posNoWhite:[11:11] Found expr:[10:8->14:1]
 posCursor:[11:13] posNoWhite:[11:11] Found expr:[11:2->13:6]
 posCursor:[11:13] posNoWhite:[11:11] Found pattern:[11:6->11:14]
 Completable: Cpattern Value[x]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x]
 Path x
 [{
@@ -50,6 +53,7 @@ posCursor:[17:10] posNoWhite:[17:9] Found expr:[16:9->20:1]
 posCursor:[17:10] posNoWhite:[17:9] Found expr:[17:5->19:11]
 posCursor:[17:10] posNoWhite:[17:9] Found pattern:[17:9->17:11]
 Completable: Cpattern Value[x]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x]
 Path x
 [{
@@ -69,6 +73,7 @@ Path x
 Complete src/Destructuring.res 31:8
 posCursor:[31:8] posNoWhite:[31:7] Found pattern:[31:7->31:9]
 Completable: Cpattern Value[x]->recordBody
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x]
 Path x
 [{

--- a/analysis/tests/src/expected/Div.res.txt
+++ b/analysis/tests/src/expected/Div.res.txt
@@ -6,6 +6,7 @@ Complete src/Div.res 3:17
 posCursor:[3:17] posNoWhite:[3:16] Found expr:[3:4->3:17]
 JSX <div:[3:4->3:7] dangerous[3:8->3:17]=...[3:8->3:17]> _children:None
 Completable: Cjsx([div], dangerous, [dangerous])
+Package opens Pervasives.JsxModules.place holder
 [{
     "label": "dangerouslySetInnerHTML",
     "kind": 4,

--- a/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -1,6 +1,7 @@
 Complete src/ExhaustiveSwitch.res 8:24
 XXX Not found!
 Completable: CexhaustiveSwitch Value[withSomeVarian]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[withSomeVarian]
 Path withSomeVarian
 [{
@@ -23,6 +24,7 @@ Path withSomeVarian
 Complete src/ExhaustiveSwitch.res 11:21
 XXX Not found!
 Completable: CexhaustiveSwitch Value[withSomePol]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[withSomePol]
 Path withSomePol
 [{
@@ -45,6 +47,7 @@ Path withSomePol
 Complete src/ExhaustiveSwitch.res 14:17
 XXX Not found!
 Completable: CexhaustiveSwitch Value[someBoo]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someBoo]
 Path someBoo
 [{
@@ -67,6 +70,7 @@ Path someBoo
 Complete src/ExhaustiveSwitch.res 17:16
 XXX Not found!
 Completable: CexhaustiveSwitch Value[someOp]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someOp]
 Path someOp
 [{

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -86,6 +86,7 @@ Hover src/Hover.res 122:3
 Nothing at that position. Now trying to use completion.
 Attribute id:live:[122:0->122:5] label:live
 Completable: Cdecorator(live)
+Package opens Pervasives.JsxModules.place holder
 {"contents": {"kind": "markdown", "value": "The `@live` decorator is for reanalyze, a static analysis tool for ReScript that can do dead code analysis.\n\n`@live` tells the dead code analysis that the value should be considered live, even though it might appear to be dead. This is typically used in case of FFI where there are indirect ways to access values. It can be added to everything that could otherwise be considered unused by the dead code analysis - values, functions, arguments, records, individual record fields, and so on.\n\n[Read more and see examples in the documentation](https://rescript-lang.org/syntax-lookup#live-decorator).\n\nHint: Did you know you can run an interactive code analysis in your project by running the command `> ReScript: Start Code Analyzer`? Try it!"}}
 
 Hover src/Hover.res 125:4
@@ -116,6 +117,7 @@ Complete src/Hover.res 170:16
 posCursor:[170:16] posNoWhite:[170:15] Found expr:[170:5->170:16]
 Pexp_field [170:5->170:15] _:[176:2->170:16]
 Completable: Cpath Value[x1].content.""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x1].content.""
 ContextPath Value[x1].content
 ContextPath Value[x1]
@@ -132,6 +134,7 @@ Complete src/Hover.res 173:16
 posCursor:[173:16] posNoWhite:[173:15] Found expr:[173:5->173:16]
 Pexp_field [173:5->173:15] _:[176:2->173:16]
 Completable: Cpath Value[x2].content.""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x2].content.""
 ContextPath Value[x2].content
 ContextPath Value[x2]
@@ -148,6 +151,7 @@ Complete src/Hover.res 182:16
 posCursor:[182:16] posNoWhite:[182:15] Found expr:[182:5->182:16]
 Pexp_field [182:5->182:15] _:[187:0->182:16]
 Completable: Cpath Value[y1].content.""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[y1].content.""
 ContextPath Value[y1].content
 ContextPath Value[y1]
@@ -164,6 +168,7 @@ Complete src/Hover.res 185:16
 posCursor:[185:16] posNoWhite:[185:15] Found expr:[185:5->185:16]
 Pexp_field [185:5->185:15] _:[187:0->185:16]
 Completable: Cpath Value[y2].content.""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[y2].content.""
 ContextPath Value[y2].content
 ContextPath Value[y2]
@@ -187,8 +192,10 @@ Nothing at that position. Now trying to use completion.
 posCursor:[210:13] posNoWhite:[210:12] Found expr:[210:11->210:14]
 Pexp_ident usr:[210:11->210:14]
 Completable: Cpath Value[usr]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[usr]
 Path usr
+Package opens Pervasives.JsxModules.place holder
 {"contents": {"kind": "markdown", "value": "```rescript\nuseR\n```\n\n---\n\n```\n \n```\n```rescript\ntype useR = {x: int, y: list<option<r<float>>>}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C200%2C0%5D)\n\n\n---\n\n```\n \n```\n```rescript\ntype r<'a> = {i: 'a, f: float}\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C101%2C0%5D)\n"}}
 
 Hover src/Hover.res 230:20
@@ -202,9 +209,11 @@ Nothing at that position. Now trying to use completion.
 posCursor:[245:6] posNoWhite:[245:5] Found expr:[245:3->245:14]
 Pexp_field [245:3->245:4] someField:[245:5->245:14]
 Completable: Cpath Value[x].someField
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x].someField
 ContextPath Value[x]
 Path x
+Package opens Pervasives.JsxModules.place holder
 {"contents": {"kind": "markdown", "value": "```rescript\nbool\n```\n\n Mighty fine field here. "}}
 
 Hover src/Hover.res 248:19
@@ -218,8 +227,10 @@ Nothing at that position. Now trying to use completion.
 posCursor:[257:23] posNoWhite:[257:22] Found expr:[257:22->257:25]
 Pexp_ident fff:[257:22->257:25]
 Completable: Cpath Value[fff]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[fff]
 Path fff
+Package opens Pervasives.JsxModules.place holder
 ContextPath string
 {"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
 
@@ -228,8 +239,10 @@ Nothing at that position. Now trying to use completion.
 posCursor:[260:33] posNoWhite:[260:32] Found expr:[260:31->260:40]
 Pexp_ident someField:[260:31->260:40]
 Completable: Cpath Value[someField]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someField]
 Path someField
+Package opens Pervasives.JsxModules.place holder
 ContextPath CPatternPath(Value[x])->recordField(someField)
 ContextPath Value[x]
 Path x

--- a/analysis/tests/src/expected/Jsx2.res.txt
+++ b/analysis/tests/src/expected/Jsx2.res.txt
@@ -7,6 +7,7 @@ Complete src/Jsx2.res 8:15
 posCursor:[8:15] posNoWhite:[8:14] Found expr:[8:4->8:15]
 JSX <M:[8:4->8:5] second[8:6->8:12]=...[8:13->8:15]> _children:None
 Completable: Cexpression CJsxPropValue [M] second=fi
+Package opens Pervasives.JsxModules.place holder
 ContextPath CJsxPropValue [M] second
 Path M.make
 []
@@ -15,6 +16,7 @@ Complete src/Jsx2.res 11:20
 posCursor:[11:20] posNoWhite:[11:19] Found expr:[11:4->11:20]
 JSX <M:[11:4->11:5] second[11:6->11:12]=...[11:13->11:18] f[11:19->11:20]=...[11:19->11:20]> _children:None
 Completable: Cjsx([M], f, [second, f])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "first",
@@ -34,6 +36,7 @@ Complete src/Jsx2.res 14:13
 posCursor:[14:13] posNoWhite:[14:12] Found expr:[14:12->14:13]
 JSX <M:[14:12->14:13] > _children:None
 Completable: Cpath Module[M]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[M]
 Path M
 [{
@@ -66,6 +69,7 @@ Complete src/Jsx2.res 22:19
 posCursor:[22:19] posNoWhite:[22:18] Found expr:[22:4->22:19]
 JSX <M:[22:4->22:5] prop[22:6->22:10]=...[22:12->22:16] k[22:18->22:19]=...[22:18->22:19]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -79,6 +83,7 @@ Complete src/Jsx2.res 25:17
 posCursor:[25:17] posNoWhite:[25:16] Found expr:[25:4->25:17]
 JSX <M:[25:4->25:5] prop[25:6->25:10]=...[25:11->25:15] k[25:16->25:17]=...[25:16->25:17]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -92,6 +97,7 @@ Complete src/Jsx2.res 28:21
 posCursor:[28:21] posNoWhite:[28:20] Found expr:[28:4->28:21]
 JSX <M:[28:4->28:5] prop[28:6->28:10]=...[28:11->28:19] k[28:20->28:21]=...[28:20->28:21]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -105,6 +111,7 @@ Complete src/Jsx2.res 31:24
 posCursor:[31:24] posNoWhite:[31:23] Found expr:[31:4->31:24]
 JSX <M:[31:4->31:5] prop[31:6->31:10]=...[31:11->31:22] k[31:23->31:24]=...[31:23->31:24]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -118,6 +125,7 @@ Complete src/Jsx2.res 34:18
 posCursor:[34:18] posNoWhite:[34:17] Found expr:[34:4->34:18]
 JSX <M:[34:4->34:5] prop[34:6->34:10]=...[34:12->34:16] k[34:17->34:18]=...[34:17->34:18]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -131,6 +139,7 @@ Complete src/Jsx2.res 37:16
 posCursor:[37:16] posNoWhite:[37:15] Found expr:[37:4->37:16]
 JSX <M:[37:4->37:5] prop[37:6->37:10]=...[37:11->37:14] k[37:15->37:16]=...[37:15->37:16]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -144,6 +153,7 @@ Complete src/Jsx2.res 40:17
 posCursor:[40:17] posNoWhite:[40:16] Found expr:[40:4->40:17]
 JSX <M:[40:4->40:5] prop[40:6->40:10]=...[40:11->40:15] k[40:16->40:17]=...[40:16->40:17]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -157,6 +167,7 @@ Complete src/Jsx2.res 43:18
 posCursor:[43:18] posNoWhite:[43:17] Found expr:[43:4->43:18]
 JSX <M:[43:4->43:5] prop[43:6->43:10]=...[43:11->43:16] k[43:17->43:18]=...[43:17->43:18]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -170,6 +181,7 @@ Complete src/Jsx2.res 46:16
 posCursor:[46:16] posNoWhite:[46:15] Found expr:[46:4->46:16]
 JSX <M:[46:4->46:5] prop[46:6->46:10]=...[46:11->46:14] k[46:15->46:16]=...[46:15->46:16]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -183,6 +195,7 @@ Complete src/Jsx2.res 49:27
 posCursor:[49:27] posNoWhite:[49:26] Found expr:[49:4->49:27]
 JSX <M:[49:4->49:5] prop[49:6->49:10]=...[49:11->49:25] k[49:26->49:27]=...[49:26->49:27]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -196,6 +209,7 @@ Complete src/Jsx2.res 52:38
 posCursor:[52:38] posNoWhite:[52:37] Found expr:[52:4->52:38]
 JSX <M:[52:4->52:5] prop[52:6->52:10]=...[52:11->52:36] k[52:37->52:38]=...[52:37->52:38]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -209,6 +223,7 @@ Complete src/Jsx2.res 55:25
 posCursor:[55:25] posNoWhite:[55:24] Found expr:[55:4->55:25]
 JSX <M:[55:4->55:5] prop[55:6->55:10]=...[55:11->55:23] k[55:24->55:25]=...[55:24->55:25]> _children:None
 Completable: Cjsx([M], k, [prop, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -227,6 +242,7 @@ Complete src/Jsx2.res 68:10
 posCursor:[68:10] posNoWhite:[68:9] Found expr:[68:4->68:10]
 JSX <Ext:[68:4->68:7] al[68:8->68:10]=...[68:8->68:10]> _children:None
 Completable: Cjsx([Ext], al, [al])
+Package opens Pervasives.JsxModules.place holder
 Path Ext.make
 [{
     "label": "align",
@@ -240,6 +256,7 @@ Complete src/Jsx2.res 71:11
 posCursor:[71:11] posNoWhite:[71:10] Found expr:[71:4->71:11]
 JSX <M:[71:4->71:5] first[71:6->71:11]=...[71:6->71:11]> _children:None
 Completable: Cjsx([M], first, [first])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 []
 
@@ -247,6 +264,7 @@ Complete src/Jsx2.res 74:16
 posCursor:[74:16] posNoWhite:[74:15] Found expr:[74:4->74:16]
 JSX <M:[74:4->74:5] first[74:6->74:11]=...[74:12->74:14] k[74:15->74:16]=...[74:15->74:16]> _children:None
 Completable: Cjsx([M], k, [first, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -260,6 +278,7 @@ Complete src/Jsx2.res 77:23
 posCursor:[77:23] posNoWhite:[77:22] Found expr:[77:4->77:23]
 JSX <M:[77:4->77:5] first[77:6->77:11]=...[77:19->77:21] k[77:22->77:23]=...[77:22->77:23]> _children:None
 Completable: Cjsx([M], k, [first, k])
+Package opens Pervasives.JsxModules.place holder
 Path M.make
 [{
     "label": "key",
@@ -290,6 +309,7 @@ Complete src/Jsx2.res 89:16
 posCursor:[89:16] posNoWhite:[89:15] Found expr:[89:4->89:16]
 JSX <WithChildren:[89:4->89:16] > _children:None
 Completable: Cpath Module[WithChildren]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[WithChildren]
 Path WithChildren
 [{
@@ -304,6 +324,7 @@ Complete src/Jsx2.res 91:18
 posCursor:[91:18] posNoWhite:[91:17] Found expr:[91:4->91:18]
 JSX <WithChildren:[91:4->91:16] n[91:17->91:18]=...[91:17->91:18]> _children:None
 Completable: Cjsx([WithChildren], n, [n])
+Package opens Pervasives.JsxModules.place holder
 Path WithChildren.make
 [{
     "label": "name",
@@ -318,6 +339,7 @@ posCursor:[94:18] posNoWhite:[94:17] Found pattern:[94:7->94:18]
 posCursor:[94:18] posNoWhite:[94:17] Found type:[94:11->94:18]
 Ptyp_constr React.e:[94:11->94:18]
 Completable: Cpath Type[React, e]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[React, e]
 Path React.e
 [{
@@ -333,6 +355,7 @@ posCursor:[96:20] posNoWhite:[96:19] Found pattern:[96:7->99:6]
 posCursor:[96:20] posNoWhite:[96:19] Found type:[96:11->99:6]
 Ptyp_constr ReactDOMR:[96:11->99:6]
 Completable: Cpath Type[ReactDOMR]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[ReactDOMR]
 Path ReactDOMR
 [{
@@ -349,6 +372,7 @@ Pexp_apply ...[102:15->102:16] (...[102:13->102:14], ...[102:17->102:21])
 posCursor:[102:21] posNoWhite:[102:20] Found expr:[102:17->102:21]
 Pexp_field [102:17->102:18] th:[102:19->102:21]
 Completable: Cpath Value[x].th
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[x].th
 ContextPath Value[x]
 Path x
@@ -358,6 +382,7 @@ Complete src/Jsx2.res 106:28
 posCursor:[106:28] posNoWhite:[106:27] Found expr:[106:11->106:28]
 Pexp_ident DefineSomeFields.:[106:11->106:28]
 Completable: Cpath Value[DefineSomeFields, ""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[DefineSomeFields, ""]
 Path DefineSomeFields.
 [{
@@ -374,6 +399,7 @@ Pexp_apply ...[108:13->108:14] (...[108:11->108:12], ...[108:15->108:36])
 posCursor:[108:36] posNoWhite:[108:35] Found expr:[108:15->108:36]
 Pexp_field [108:15->108:16] DefineSomeFields.th:[108:17->108:36]
 Completable: Cpath Module[DefineSomeFields].th
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[DefineSomeFields].th
 Path DefineSomeFields.th
 [{
@@ -396,6 +422,7 @@ JSX <div:[121:3->121:6] x[122:5->122:6]=...[122:7->122:20] name[124:4->124:8]=..
 posCursor:[122:20] posNoWhite:[122:19] Found expr:[122:7->122:20]
 Pexp_ident Outer.Inner.h:[122:7->122:20]
 Completable: Cpath Value[Outer, Inner, h]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Outer, Inner, h]
 Path Outer.Inner.h
 [{
@@ -412,6 +439,7 @@ JSX <div:[128:3->128:6] x[129:5->129:6]=...[129:7->131:8]> _children:None
 posCursor:[129:19] posNoWhite:[129:18] Found expr:[129:7->131:8]
 Pexp_ident Outer.Inner.:[129:7->131:8]
 Completable: Cpath Value[Outer, Inner, ""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Outer, Inner, ""]
 Path Outer.Inner.
 [{
@@ -431,6 +459,7 @@ Complete src/Jsx2.res 150:21
 posCursor:[150:21] posNoWhite:[150:20] Found expr:[150:12->150:32]
 JSX <Nested.Co:[150:12->150:21] name[150:22->150:26]=...[150:27->150:29]> _children:150:30
 Completable: Cpath Module[Nested, Co]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[Nested, Co]
 Path Nested.Co
 [{
@@ -445,6 +474,7 @@ Complete src/Jsx2.res 153:19
 posCursor:[153:19] posNoWhite:[153:18] Found expr:[153:12->153:25]
 JSX <Nested.:[153:12->153:24] > _children:None
 Completable: Cpath Module[Nested, ""]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[Nested, ""]
 Path Nested.
 [{
@@ -463,6 +493,7 @@ posCursor:[162:12] posNoWhite:[162:11] Found expr:[162:6->162:21]
 posCursor:[162:12] posNoWhite:[162:11] Found expr:[162:6->162:20]
 JSX <Comp:[162:6->162:10] age[162:11->162:14]=...[162:15->162:17]> _children:162:18
 Completable: Cjsx([Comp], age, [age])
+Package opens Pervasives.JsxModules.place holder
 Path Comp.make
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 
@@ -477,6 +508,7 @@ posCursor:[167:16] posNoWhite:[167:15] Found expr:[167:10->167:25]
 posCursor:[167:16] posNoWhite:[167:15] Found expr:[167:10->167:24]
 JSX <Comp:[167:10->167:14] age[167:15->167:18]=...[167:19->167:21]> _children:167:22
 Completable: Cjsx([Comp], age, [age])
+Package opens Pervasives.JsxModules.place holder
 Path Comp.make
 {"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
 

--- a/analysis/tests/src/expected/Jsx2.resi.txt
+++ b/analysis/tests/src/expected/Jsx2.resi.txt
@@ -10,6 +10,7 @@ Complete src/Jsx2.resi 7:19
 posCursor:[7:19] posNoWhite:[7:18] Found type:[7:12->7:19]
 Ptyp_constr React.e:[7:12->7:19]
 Completable: Cpath Type[React, e]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[React, e]
 Path React.e
 [{
@@ -24,6 +25,7 @@ Complete src/Jsx2.resi 10:18
 posCursor:[10:18] posNoWhite:[10:17] Found type:[10:11->10:18]
 Ptyp_constr React.e:[10:11->10:18]
 Completable: Cpath Type[React, e]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[React, e]
 Path React.e
 [{

--- a/analysis/tests/src/expected/JsxV4.res.txt
+++ b/analysis/tests/src/expected/JsxV4.res.txt
@@ -5,6 +5,7 @@ Complete src/JsxV4.res 11:20
 posCursor:[11:20] posNoWhite:[11:19] Found expr:[11:4->11:20]
 JSX <M4:[11:4->11:6] first[11:7->11:12]=...[11:13->11:18] f[11:19->11:20]=...[11:19->11:20]> _children:None
 Completable: Cjsx([M4], f, [first, f])
+Package opens Pervasives.JsxModules.place holder
 Path M4.make
 [{
     "label": "fun",

--- a/analysis/tests/src/expected/RecordCompletion.res.txt
+++ b/analysis/tests/src/expected/RecordCompletion.res.txt
@@ -1,6 +1,7 @@
 Complete src/RecordCompletion.res 8:9
 posCursor:[8:9] posNoWhite:[8:8] Found expr:[8:3->8:9]
 Completable: Cpath Value[t].n->m
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[t].n->m
 ContextPath Value[t].n
 ContextPath Value[t]
@@ -24,6 +25,7 @@ Path Js.Array2.m
 Complete src/RecordCompletion.res 11:13
 posCursor:[11:13] posNoWhite:[11:12] Found expr:[11:3->11:13]
 Completable: Cpath Value[t2].n2.n->m
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[t2].n2.n->m
 ContextPath Value[t2].n2.n
 ContextPath Value[t2].n2
@@ -49,6 +51,7 @@ Complete src/RecordCompletion.res 19:7
 posCursor:[19:7] posNoWhite:[19:6] Found expr:[19:3->19:7]
 Pexp_field [19:3->19:4] R.:[19:5->19:7]
 Completable: Cpath Module[R].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[R].""
 Path R.
 [{
@@ -63,6 +66,7 @@ Complete src/RecordCompletion.res 22:7
 posCursor:[22:7] posNoWhite:[22:6] Found expr:[22:3->22:10]
 Pexp_field [22:3->22:4] R.xx:[22:5->22:10]
 Completable: Cpath Module[R].""
+Package opens Pervasives.JsxModules.place holder
 ContextPath Module[R].""
 Path R.
 [{

--- a/analysis/tests/src/expected/RecoveryOnProp.res.txt
+++ b/analysis/tests/src/expected/RecoveryOnProp.res.txt
@@ -11,6 +11,7 @@ posCursor:[6:26] posNoWhite:[6:25] Found pattern:[6:20->8:5]
 posCursor:[6:26] posNoWhite:[6:25] Found type:[6:23->8:5]
 Ptyp_constr Res:[6:23->8:5]
 Completable: Cpath Type[Res]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Type[Res]
 Path Res
 [{

--- a/analysis/tests/src/expected/SignatureHelp.res.txt
+++ b/analysis/tests/src/expected/SignatureHelp.res.txt
@@ -4,6 +4,7 @@ Pexp_apply ...[16:11->16:19] (...[46:0->16:20])
 posCursor:[16:19] posNoWhite:[16:18] Found expr:[16:11->16:19]
 Pexp_ident someFunc:[16:11->16:19]
 Completable: Cpath Value[someFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someFunc]
 Path someFunc
 argAtCursor: unlabelled<0>
@@ -26,6 +27,7 @@ Pexp_apply ...[19:11->19:19] (...[19:20->19:21])
 posCursor:[19:19] posNoWhite:[19:18] Found expr:[19:11->19:19]
 Pexp_ident someFunc:[19:11->19:19]
 Completable: Cpath Value[someFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someFunc]
 Path someFunc
 argAtCursor: unlabelled<0>
@@ -48,6 +50,7 @@ Pexp_apply ...[22:11->22:19] (...[22:20->22:23], ~two22:26->22:29=...[22:26->22:
 posCursor:[22:19] posNoWhite:[22:18] Found expr:[22:11->22:19]
 Pexp_ident someFunc:[22:11->22:19]
 Completable: Cpath Value[someFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someFunc]
 Path someFunc
 argAtCursor: ~two
@@ -70,6 +73,7 @@ Pexp_apply ...[25:11->25:19] (...[25:20->25:23], ~two25:26->25:29=...[25:30->25:
 posCursor:[25:19] posNoWhite:[25:18] Found expr:[25:11->25:19]
 Pexp_ident someFunc:[25:11->25:19]
 Completable: Cpath Value[someFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someFunc]
 Path someFunc
 argAtCursor: ~two
@@ -92,6 +96,7 @@ Pexp_apply ...[28:11->28:19] (...[28:20->28:23], ~two28:26->28:29=...[28:30->28:
 posCursor:[28:19] posNoWhite:[28:18] Found expr:[28:11->28:19]
 Pexp_ident someFunc:[28:11->28:19]
 Completable: Cpath Value[someFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someFunc]
 Path someFunc
 argAtCursor: ~four
@@ -114,6 +119,7 @@ Pexp_apply ...[31:11->31:19] (...[31:20->31:23], ~two31:26->31:29=...[31:30->31:
 posCursor:[31:19] posNoWhite:[31:18] Found expr:[31:11->31:19]
 Pexp_ident someFunc:[31:11->31:19]
 Completable: Cpath Value[someFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someFunc]
 Path someFunc
 argAtCursor: ~four
@@ -136,6 +142,7 @@ Pexp_apply ...[34:11->34:20] (...[46:0->34:21])
 posCursor:[34:20] posNoWhite:[34:19] Found expr:[34:11->34:20]
 Pexp_ident otherFunc:[34:11->34:20]
 Completable: Cpath Value[otherFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[otherFunc]
 Path otherFunc
 argAtCursor: unlabelled<0>
@@ -156,6 +163,7 @@ Pexp_apply ...[37:11->37:20] (...[37:21->37:26])
 posCursor:[37:20] posNoWhite:[37:19] Found expr:[37:11->37:20]
 Pexp_ident otherFunc:[37:11->37:20]
 Completable: Cpath Value[otherFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[otherFunc]
 Path otherFunc
 argAtCursor: unlabelled<0>
@@ -176,6 +184,7 @@ Pexp_apply ...[40:11->40:20] (...[40:21->40:26], ...[40:28->40:31], ...[40:33->4
 posCursor:[40:20] posNoWhite:[40:19] Found expr:[40:11->40:20]
 Pexp_ident otherFunc:[40:11->40:20]
 Completable: Cpath Value[otherFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[otherFunc]
 Path otherFunc
 argAtCursor: unlabelled<2>
@@ -196,6 +205,7 @@ Pexp_apply ...[43:11->43:29] (~age43:31->43:34=...[43:31->43:34])
 posCursor:[43:29] posNoWhite:[43:28] Found expr:[43:11->43:29]
 Pexp_ident Completion.Lib.foo:[43:11->43:29]
 Completable: Cpath Value[Completion, Lib, foo]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[Completion, Lib, foo]
 Path Completion.Lib.foo
 argAtCursor: ~age
@@ -216,6 +226,7 @@ Pexp_apply ...[50:11->50:23] (...[56:0->50:24])
 posCursor:[50:23] posNoWhite:[50:22] Found expr:[50:11->50:23]
 Pexp_ident iAmSoSpecial:[50:11->50:23]
 Completable: Cpath Value[iAmSoSpecial]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[iAmSoSpecial]
 Path iAmSoSpecial
 argAtCursor: unlabelled<0>
@@ -237,6 +248,7 @@ Pexp_apply ...[53:20->53:29] (...[53:30->53:31])
 posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:20->53:29]
 Pexp_ident otherFunc:[53:20->53:29]
 Completable: Cpath Value[otherFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[otherFunc]
 Path otherFunc
 argAtCursor: unlabelled<1>
@@ -257,6 +269,7 @@ Pexp_apply ...[62:11->62:13] (...[62:14->62:16])
 posCursor:[62:13] posNoWhite:[62:12] Found expr:[62:11->62:13]
 Pexp_ident fn:[62:11->62:13]
 Completable: Cpath Value[fn]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[fn]
 Path fn
 argAtCursor: unlabelled<1>
@@ -277,6 +290,7 @@ Pexp_apply ...[65:11->65:13] (...[65:14->65:16], ...[65:20->65:24])
 posCursor:[65:13] posNoWhite:[65:12] Found expr:[65:11->65:13]
 Pexp_ident fn:[65:11->65:13]
 Completable: Cpath Value[fn]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[fn]
 Path fn
 argAtCursor: unlabelled<1>
@@ -297,6 +311,7 @@ Pexp_apply ...[68:11->68:13] (...[68:14->68:16], ...[68:18->68:25])
 posCursor:[68:13] posNoWhite:[68:12] Found expr:[68:11->68:13]
 Pexp_ident fn:[68:11->68:13]
 Completable: Cpath Value[fn]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[fn]
 Path fn
 argAtCursor: unlabelled<2>
@@ -319,6 +334,7 @@ Pexp_apply ...[71:16->71:28] (...[71:29->71:30])
 posCursor:[71:28] posNoWhite:[71:27] Found expr:[71:16->71:28]
 Pexp_ident iAmSoSpecial:[71:16->71:28]
 Completable: Cpath Value[iAmSoSpecial]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[iAmSoSpecial]
 Path iAmSoSpecial
 argAtCursor: unlabelled<0>
@@ -343,6 +359,7 @@ Pexp_apply ...[74:31->74:39] (...[74:40->74:41])
 posCursor:[74:39] posNoWhite:[74:38] Found expr:[74:31->74:39]
 Pexp_ident someFunc:[74:31->74:39]
 Completable: Cpath Value[someFunc]
+Package opens Pervasives.JsxModules.place holder
 ContextPath Value[someFunc]
 Path someFunc
 argAtCursor: unlabelled<0>


### PR DESCRIPTION
See https://github.com/rescript-lang/rescript-compiler/pull/6091 where the jsx modules are moved inside Pervasives, to provide 2 different copies for curried and uncurried mode.