### PR TITLE
Improve generation of function template variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :rocket: New Feature
 
 - Docstring template Code Action. https://github.com/rescript-lang/rescript-vscode/pull/764
+- Improve unlabelled argument names in completion function templates. https://github.com/rescript-lang/rescript-vscode/pull/754
 
 ## 1.16.0
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1355,7 +1355,9 @@ let rec completeTypedValue ~full ~prefix ~completionContext ~mode
         match Path.head p |> Ident.name with
         | "unit" -> "()"
         | "ReactEvent" | "JsxEvent" -> "event"
-        | _ -> "v" ^ indexText)
+        | _ ->
+          TypeUtils.templateVarNameForTyp ~env ~package:full.package argTyp
+          ^ indexText)
     in
     let mkFnArgs ~asSnippet =
       match args with

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1356,22 +1356,25 @@ let rec completeTypedValue ~full ~prefix ~completionContext ~mode
         | "unit" -> "()"
         | "ReactEvent" | "JsxEvent" -> "event"
         | _ ->
+          let defaultVarName = "v" ^ indexText in
           let txt =
             match
               TypeUtils.templateVarNameForTyp ~env ~package:full.package argTyp
             with
             | Some txt -> txt
             | None -> (
-              match p |> Utils.expandPath |> Utils.lastElements with
-              | [] | ["t"] -> "v"
+              match p |> Utils.expandPath |> List.rev |> Utils.lastElements with
+              | [] | ["t"] -> defaultVarName
               | [someName; "t"] | [_; someName] | [someName] -> (
                 match someName with
                 | "string" | "int" | "float" | "array" | "option" | "bool" ->
-                  "v"
-                | someName -> someName |> Utils.lowercaseFirstChar)
-              | _ -> "v")
+                  defaultVarName
+                | someName when String.length someName < 30 ->
+                  someName |> Utils.lowercaseFirstChar
+                | _ -> defaultVarName)
+              | _ -> defaultVarName)
           in
-          txt ^ indexText)
+          txt)
     in
     let mkFnArgs ~asSnippet =
       match args with

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1356,8 +1356,22 @@ let rec completeTypedValue ~full ~prefix ~completionContext ~mode
         | "unit" -> "()"
         | "ReactEvent" | "JsxEvent" -> "event"
         | _ ->
-          TypeUtils.templateVarNameForTyp ~env ~package:full.package argTyp
-          ^ indexText)
+          let txt =
+            match
+              TypeUtils.templateVarNameForTyp ~env ~package:full.package argTyp
+            with
+            | Some txt -> txt
+            | None -> (
+              match p |> Utils.expandPath |> Utils.lastElements with
+              | [] | ["t"] -> "v"
+              | [someName; "t"] | [_; someName] | [someName] -> (
+                match someName with
+                | "string" | "int" | "float" | "array" | "option" | "bool" ->
+                  "v"
+                | someName -> someName |> Utils.lowercaseFirstChar)
+              | _ -> "v")
+          in
+          txt ^ indexText)
     in
     let mkFnArgs ~asSnippet =
       match args with

--- a/analysis/src/CompletionExpressions.ml
+++ b/analysis/src/CompletionExpressions.ml
@@ -216,3 +216,39 @@ and traverseExprTupleItems tupleItems ~nextExprPath ~resultFromFoundItemNum ~pos
            if pos >= Loc.start e.Parsetree.pexp_loc then posNum := index);
     if !posNum > -1 then Some ("", resultFromFoundItemNum !posNum) else None
   | v, _ -> v
+
+let prettyPrintFnTemplateArgName ?currentIndex ~env ~full
+    (argTyp : Types.type_expr) =
+  let indexText =
+    match currentIndex with
+    | None -> ""
+    | Some i -> string_of_int i
+  in
+  let defaultVarName = "v" ^ indexText in
+  let argTyp, suffix, env =
+    TypeUtils.digToRelevantTemplateNameType ~env ~package:full.package argTyp
+  in
+  match TypeUtils.templateVarNameForTyp ~env ~package:full.package argTyp with
+  | Some txt -> txt
+  | None -> (
+    match argTyp |> TypeUtils.pathFromTypeExpr with
+    | None -> defaultVarName
+    | Some p -> (
+      match p |> Utils.expandPath |> List.rev |> Utils.lastElements with
+      | [] | ["t"] -> defaultVarName
+      | ["unit"] -> "()"
+      (* Special treatment for JsxEvent, since that's a common enough thing
+         used in event handlers. *)
+      | ["JsxEvent"; "synthetic"] -> "event"
+      | ["synthetic"] when env.file.moduleName = "JsxEvent" -> "event"
+      (* Ignore `t` types, and go for its module name instead. *)
+      | [someName; "t"] | [_; someName] | [someName] -> (
+        match someName with
+        | "string" | "int" | "float" | "array" | "option" | "bool" ->
+          defaultVarName
+        | someName when String.length someName < 30 ->
+          (* We cap how long the name can be, so we don't end up with super
+             long type names. *)
+          (someName |> Utils.lowercaseFirstChar) ^ suffix
+        | _ -> defaultVarName)
+      | _ -> defaultVarName))

--- a/analysis/src/CompletionExpressions.ml
+++ b/analysis/src/CompletionExpressions.ml
@@ -225,30 +225,33 @@ let prettyPrintFnTemplateArgName ?currentIndex ~env ~full
     | Some i -> string_of_int i
   in
   let defaultVarName = "v" ^ indexText in
-  let argTyp, suffix, env =
+  let argTyp, suffix, _env =
     TypeUtils.digToRelevantTemplateNameType ~env ~package:full.package argTyp
   in
-  match TypeUtils.templateVarNameForTyp ~env ~package:full.package argTyp with
-  | Some txt -> txt
-  | None -> (
-    match argTyp |> TypeUtils.pathFromTypeExpr with
-    | None -> defaultVarName
-    | Some p -> (
-      match p |> Utils.expandPath |> List.rev |> Utils.lastElements with
-      | [] | ["t"] -> defaultVarName
-      | ["unit"] -> "()"
-      (* Special treatment for JsxEvent, since that's a common enough thing
-         used in event handlers. *)
-      | ["JsxEvent"; "synthetic"] -> "event"
-      | ["synthetic"] when env.file.moduleName = "JsxEvent" -> "event"
-      (* Ignore `t` types, and go for its module name instead. *)
-      | [someName; "t"] | [_; someName] | [someName] -> (
-        match someName with
-        | "string" | "int" | "float" | "array" | "option" | "bool" ->
-          defaultVarName
-        | someName when String.length someName < 30 ->
-          (* We cap how long the name can be, so we don't end up with super
-             long type names. *)
-          (someName |> Utils.lowercaseFirstChar) ^ suffix
-        | _ -> defaultVarName)
-      | _ -> defaultVarName))
+  match argTyp |> TypeUtils.pathFromTypeExpr with
+  | None -> defaultVarName
+  | Some p -> (
+    let trailingElementsOfPath =
+      p |> Utils.expandPath |> List.rev |> Utils.lastElements
+    in
+    match trailingElementsOfPath with
+    | [] | ["t"] -> defaultVarName
+    | ["unit"] -> "()"
+    (* Special treatment for JsxEvent, since that's a common enough thing
+       used in event handlers. *)
+    | ["JsxEvent"; "synthetic"] -> "event"
+    | ["synthetic"] -> "event"
+    (* Ignore `t` types, and go for its module name instead. *)
+    | [someName; "t"] | [_; someName] | [someName] -> (
+      match someName with
+      | "string" | "int" | "float" | "array" | "option" | "bool" ->
+        defaultVarName
+      | someName when String.length someName < 30 ->
+        if someName = "synthetic" then
+          Printf.printf "synthetic! %s\n"
+            (trailingElementsOfPath |> SharedTypes.ident);
+        (* We cap how long the name can be, so we don't end up with super
+           long type names. *)
+        (someName |> Utils.lowercaseFirstChar) ^ suffix
+      | _ -> defaultVarName)
+    | _ -> defaultVarName)

--- a/analysis/src/ProcessAttributes.ml
+++ b/analysis/src/ProcessAttributes.ml
@@ -17,6 +17,23 @@ let rec findDocAttribute attributes =
     Some doc
   | _ :: rest -> findDocAttribute rest
 
+let rec findTemplateVarNameAttribute attributes =
+  let open Parsetree in
+  match attributes with
+  | [] -> None
+  | ( {Asttypes.txt = "editor.templateVariableName"},
+      PStr
+        [
+          {
+            pstr_desc =
+              Pstr_eval
+                ({pexp_desc = Pexp_constant (Pconst_string (name, _))}, _);
+          };
+        ] )
+    :: _ ->
+    Some name
+  | _ :: rest -> findTemplateVarNameAttribute rest
+
 let rec findDeprecatedAttribute attributes =
   let open Parsetree in
   match attributes with

--- a/analysis/src/ProcessAttributes.ml
+++ b/analysis/src/ProcessAttributes.ml
@@ -17,23 +17,6 @@ let rec findDocAttribute attributes =
     Some doc
   | _ :: rest -> findDocAttribute rest
 
-let rec findTemplateVarNameAttribute attributes =
-  let open Parsetree in
-  match attributes with
-  | [] -> None
-  | ( {Asttypes.txt = "editor.templateVariableName"},
-      PStr
-        [
-          {
-            pstr_desc =
-              Pstr_eval
-                ({pexp_desc = Pexp_constant (Pconst_string (name, _))}, _);
-          };
-        ] )
-    :: _ ->
-    Some name
-  | _ :: rest -> findTemplateVarNameAttribute rest
-
 let rec findDeprecatedAttribute attributes =
   let open Parsetree in
   match attributes with

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -65,6 +65,7 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         ~item:
           {
             Type.decl;
+            attributes = type_attributes;
             name = name.txt;
             kind =
               (match type_kind with
@@ -172,6 +173,7 @@ let forTypeDeclaration ~env ~(exported : Exported.t)
       ~item:
         {
           Type.decl = typ_type;
+          attributes = typ_attributes;
           name = name.txt;
           kind =
             (match typ_kind with

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -59,7 +59,12 @@ module Type = struct
     | Record of field list
     | Variant of Constructor.t list
 
-  type t = {kind: kind; decl: Types.type_declaration; name: string}
+  type t = {
+    kind: kind;
+    decl: Types.type_declaration;
+    name: string;
+    attributes: Parsetree.attributes;
+  }
 end
 
 module Exported = struct

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -202,6 +202,19 @@ let pathFromTypeExpr (t : Types.type_expr) =
     Some path
   | _ -> None
 
+let rec templateVarNameForTyp ~env ~package (t : Types.type_expr) =
+  match t.desc with
+  | Tlink t1 | Tsubst t1 | Tpoly (t1, []) ->
+    templateVarNameForTyp ~env ~package t1
+  | Tconstr (path, _, _) -> (
+    match References.digConstructor ~env ~package path with
+    | Some (_env, {item = {attributes}}) -> (
+      match ProcessAttributes.findTemplateVarNameAttribute attributes with
+      | None -> "v"
+      | Some name -> name)
+    | _ -> "v")
+  | _ -> "v"
+
 let rec resolveTypeForPipeCompletion ~env ~package ~lhsLoc ~full
     (t : Types.type_expr) =
   let builtin =

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -209,11 +209,9 @@ let rec templateVarNameForTyp ~env ~package (t : Types.type_expr) =
   | Tconstr (path, _, _) -> (
     match References.digConstructor ~env ~package path with
     | Some (_env, {item = {attributes}}) -> (
-      match ProcessAttributes.findTemplateVarNameAttribute attributes with
-      | None -> "v"
-      | Some name -> name)
-    | _ -> "v")
-  | _ -> "v"
+      ProcessAttributes.findTemplateVarNameAttribute attributes)
+    | _ -> None)
+  | _ -> None
 
 let rec resolveTypeForPipeCompletion ~env ~package ~lhsLoc ~full
     (t : Types.type_expr) =

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -202,17 +202,6 @@ let pathFromTypeExpr (t : Types.type_expr) =
     Some path
   | _ -> None
 
-let rec templateVarNameForTyp ~env ~package (t : Types.type_expr) =
-  match t.desc with
-  | Tlink t1 | Tsubst t1 | Tpoly (t1, []) ->
-    templateVarNameForTyp ~env ~package t1
-  | Tconstr (path, _, _) -> (
-    match References.digConstructor ~env ~package path with
-    | Some (_env, {item = {attributes}}) ->
-      ProcessAttributes.findTemplateVarNameAttribute attributes
-    | _ -> None)
-  | _ -> None
-
 let rec digToRelevantTemplateNameType ~env ~package ?(suffix = "")
     (t : Types.type_expr) =
   match t.desc with

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -207,7 +207,7 @@ end
 
 let rec lastElements list =
   match list with
-  | ([_] | [_; _] | []) as res -> res
+  | ([_; _] | [_] | []) as res -> res
   | _ :: tl -> lastElements tl
 
 let lowercaseFirstChar s =

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -204,3 +204,12 @@ module Option = struct
     | None -> None
     | Some v -> f v
 end
+
+let rec lastElements list =
+  match list with
+  | ([_] | [_; _] | []) as res -> res
+  | _ :: tl -> lastElements tl
+
+let lowercaseFirstChar s =
+  if String.length s = 0 then s
+  else String.mapi (fun i c -> if i = 0 then Char.lowercase_ascii c else c) s

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -197,7 +197,6 @@ ignore(fff)
 // fff.someOpt
 //            ^com
 
-@editor.templateVariableName("otherNameForType")
 type someTyp = {test: bool}
 
 let takesCb = cb => {
@@ -242,7 +241,6 @@ let takesCb5 = cb => {
 //          ^com
 
 module RecordSourceSelectorProxy = {
-  @editor.templateVariableName("store")
   type t
 }
 

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -227,6 +227,20 @@ let takesCb3 = cb => {
 // takesCb3()
 //          ^com
 
+let takesCb4 = cb => {
+  cb(Some({hi: true}))
+}
+
+// takesCb4()
+//          ^com
+
+let takesCb5 = cb => {
+  cb([Some({hi: true})])
+}
+
+// takesCb5()
+//          ^com
+
 module RecordSourceSelectorProxy = {
   @editor.templateVariableName("store")
   type t

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -196,3 +196,13 @@ ignore(fff)
 
 // fff.someOpt
 //            ^com
+
+@editor.templateVariableName("someTyp")
+type someTyp = {test: bool}
+
+let takesCb = cb => {
+  cb({test: true})
+}
+
+// takesCb()
+//         ^com

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -197,7 +197,7 @@ ignore(fff)
 // fff.someOpt
 //            ^com
 
-@editor.templateVariableName("someTyp")
+@editor.templateVariableName("otherNameForType")
 type someTyp = {test: bool}
 
 let takesCb = cb => {

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -206,3 +206,35 @@ let takesCb = cb => {
 
 // takesCb()
 //         ^com
+
+module Environment = {
+  type t = {hello: bool}
+}
+
+let takesCb2 = cb => {
+  cb({Environment.hello: true})
+}
+
+// takesCb2()
+//          ^com
+
+type apiCallResult = {hi: bool}
+
+let takesCb3 = cb => {
+  cb({hi: true})
+}
+
+// takesCb3()
+//          ^com
+
+module RecordSourceSelectorProxy = {
+  @editor.templateVariableName("store")
+  type t
+}
+
+@val
+external commitLocalUpdate: (~updater: RecordSourceSelectorProxy.t => unit) => unit =
+  "commitLocalUpdate"
+
+// commitLocalUpdate(~updater=)
+//                            ^com

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -951,3 +951,21 @@ Path fff
     "documentation": null
   }]
 
+Complete src/CompletionExpressions.res 206:11
+posCursor:[206:11] posNoWhite:[206:10] Found expr:[206:3->206:12]
+Pexp_apply ...[206:3->206:10] (...[206:11->206:12])
+Completable: Cexpression CArgument Value[takesCb]($0)
+ContextPath CArgument Value[takesCb]($0)
+ContextPath Value[takesCb]
+Path takesCb
+[{
+    "label": "someTyp => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "someTyp => 'a",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "${1:someTyp} => {$0}",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1005,9 +1005,45 @@ Path takesCb3
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 238:30
-posCursor:[238:30] posNoWhite:[238:29] Found expr:[238:3->238:31]
-Pexp_apply ...[238:3->238:20] (~updater238:22->238:29=...__ghost__[0:-1->0:-1])
+Complete src/CompletionExpressions.res 233:12
+posCursor:[233:12] posNoWhite:[233:11] Found expr:[233:3->233:13]
+Pexp_apply ...[233:3->233:11] (...[233:12->233:13])
+Completable: Cexpression CArgument Value[takesCb4]($0)
+ContextPath CArgument Value[takesCb4]($0)
+ContextPath Value[takesCb4]
+Path takesCb4
+[{
+    "label": "apiCallResult => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "option<apiCallResult> => 'a",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "${1:apiCallResult} => {$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 240:12
+posCursor:[240:12] posNoWhite:[240:11] Found expr:[240:3->240:13]
+Pexp_apply ...[240:3->240:11] (...[240:12->240:13])
+Completable: Cexpression CArgument Value[takesCb5]($0)
+ContextPath CArgument Value[takesCb5]($0)
+ContextPath Value[takesCb5]
+Path takesCb5
+[{
+    "label": "apiCallResults => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "array<option<apiCallResult>> => 'a",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "${1:apiCallResults} => {$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 252:30
+posCursor:[252:30] posNoWhite:[252:29] Found expr:[252:3->252:31]
+Pexp_apply ...[252:3->252:20] (~updater252:22->252:29=...__ghost__[0:-1->0:-1])
 Completable: Cexpression CArgument Value[commitLocalUpdate](~updater)
 ContextPath CArgument Value[commitLocalUpdate](~updater)
 ContextPath Value[commitLocalUpdate]

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -845,13 +845,13 @@ ContextPath CArgument Value[fnTakingCallback]($3)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
 [{
-    "label": "(~on, ~off=?, v1) => {}",
+    "label": "(~on, ~off=?, variant1) => {}",
     "kind": 12,
     "tags": [],
     "detail": "(~on: bool, ~off: bool=?, variant) => int",
     "documentation": null,
     "sortText": "A",
-    "insertText": "(~on, ~off=?, ${1:v1}) => {$0}",
+    "insertText": "(~on, ~off=?, ${1:variant1}) => {$0}",
     "insertTextFormat": 2
   }]
 
@@ -966,6 +966,60 @@ Path takesCb
     "documentation": null,
     "sortText": "A",
     "insertText": "${1:someTyp} => {$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 217:12
+posCursor:[217:12] posNoWhite:[217:11] Found expr:[217:3->217:13]
+Pexp_apply ...[217:3->217:11] (...[217:12->217:13])
+Completable: Cexpression CArgument Value[takesCb2]($0)
+ContextPath CArgument Value[takesCb2]($0)
+ContextPath Value[takesCb2]
+Path takesCb2
+[{
+    "label": "environment => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "Environment.t => 'a",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "${1:environment} => {$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 226:12
+posCursor:[226:12] posNoWhite:[226:11] Found expr:[226:3->226:13]
+Pexp_apply ...[226:3->226:11] (...[226:12->226:13])
+Completable: Cexpression CArgument Value[takesCb3]($0)
+ContextPath CArgument Value[takesCb3]($0)
+ContextPath Value[takesCb3]
+Path takesCb3
+[{
+    "label": "apiCallResult => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "apiCallResult => 'a",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "${1:apiCallResult} => {$0}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 238:30
+posCursor:[238:30] posNoWhite:[238:29] Found expr:[238:3->238:31]
+Pexp_apply ...[238:3->238:20] (~updater238:22->238:29=...__ghost__[0:-1->0:-1])
+Completable: Cexpression CArgument Value[commitLocalUpdate](~updater)
+ContextPath CArgument Value[commitLocalUpdate](~updater)
+ContextPath Value[commitLocalUpdate]
+Path commitLocalUpdate
+[{
+    "label": "store => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "RecordSourceSelectorProxy.t => unit",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "${1:store} => {$0}",
     "insertTextFormat": 2
   }]
 

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -959,13 +959,13 @@ ContextPath CArgument Value[takesCb]($0)
 ContextPath Value[takesCb]
 Path takesCb
 [{
-    "label": "someTyp => {}",
+    "label": "otherNameForType => {}",
     "kind": 12,
     "tags": [],
     "detail": "someTyp => 'a",
     "documentation": null,
     "sortText": "A",
-    "insertText": "${1:someTyp} => {$0}",
+    "insertText": "${1:otherNameForType} => {$0}",
     "insertTextFormat": 2
   }]
 

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -951,28 +951,32 @@ Path fff
     "documentation": null
   }]
 
-Complete src/CompletionExpressions.res 206:11
-posCursor:[206:11] posNoWhite:[206:10] Found expr:[206:3->206:12]
-Pexp_apply ...[206:3->206:10] (...[206:11->206:12])
+Complete src/CompletionExpressions.res 205:11
+posCursor:[205:11] posNoWhite:[205:10] Found expr:[205:3->205:12]
+Pexp_apply ...[205:3->205:10] (...[205:11->205:12])
 Completable: Cexpression CArgument Value[takesCb]($0)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
 ContextPath CArgument Value[takesCb]($0)
 ContextPath Value[takesCb]
 Path takesCb
 [{
-    "label": "otherNameForType => {}",
+    "label": "someTyp => {}",
     "kind": 12,
     "tags": [],
     "detail": "someTyp => 'a",
     "documentation": null,
     "sortText": "A",
-    "insertText": "${1:otherNameForType} => {$0}",
+    "insertText": "${1:someTyp} => {$0}",
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 217:12
-posCursor:[217:12] posNoWhite:[217:11] Found expr:[217:3->217:13]
-Pexp_apply ...[217:3->217:11] (...[217:12->217:13])
+Complete src/CompletionExpressions.res 216:12
+posCursor:[216:12] posNoWhite:[216:11] Found expr:[216:3->216:13]
+Pexp_apply ...[216:3->216:11] (...[216:12->216:13])
 Completable: Cexpression CArgument Value[takesCb2]($0)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
 ContextPath CArgument Value[takesCb2]($0)
 ContextPath Value[takesCb2]
 Path takesCb2
@@ -987,10 +991,12 @@ Path takesCb2
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 226:12
-posCursor:[226:12] posNoWhite:[226:11] Found expr:[226:3->226:13]
-Pexp_apply ...[226:3->226:11] (...[226:12->226:13])
+Complete src/CompletionExpressions.res 225:12
+posCursor:[225:12] posNoWhite:[225:11] Found expr:[225:3->225:13]
+Pexp_apply ...[225:3->225:11] (...[225:12->225:13])
 Completable: Cexpression CArgument Value[takesCb3]($0)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
 ContextPath CArgument Value[takesCb3]($0)
 ContextPath Value[takesCb3]
 Path takesCb3
@@ -1005,10 +1011,12 @@ Path takesCb3
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 233:12
-posCursor:[233:12] posNoWhite:[233:11] Found expr:[233:3->233:13]
-Pexp_apply ...[233:3->233:11] (...[233:12->233:13])
+Complete src/CompletionExpressions.res 232:12
+posCursor:[232:12] posNoWhite:[232:11] Found expr:[232:3->232:13]
+Pexp_apply ...[232:3->232:11] (...[232:12->232:13])
 Completable: Cexpression CArgument Value[takesCb4]($0)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
 ContextPath CArgument Value[takesCb4]($0)
 ContextPath Value[takesCb4]
 Path takesCb4
@@ -1023,10 +1031,12 @@ Path takesCb4
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 240:12
-posCursor:[240:12] posNoWhite:[240:11] Found expr:[240:3->240:13]
-Pexp_apply ...[240:3->240:11] (...[240:12->240:13])
+Complete src/CompletionExpressions.res 239:12
+posCursor:[239:12] posNoWhite:[239:11] Found expr:[239:3->239:13]
+Pexp_apply ...[239:3->239:11] (...[239:12->239:13])
 Completable: Cexpression CArgument Value[takesCb5]($0)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
 ContextPath CArgument Value[takesCb5]($0)
 ContextPath Value[takesCb5]
 Path takesCb5
@@ -1041,21 +1051,23 @@ Path takesCb5
     "insertTextFormat": 2
   }]
 
-Complete src/CompletionExpressions.res 252:30
-posCursor:[252:30] posNoWhite:[252:29] Found expr:[252:3->252:31]
-Pexp_apply ...[252:3->252:20] (~updater252:22->252:29=...__ghost__[0:-1->0:-1])
+Complete src/CompletionExpressions.res 250:30
+posCursor:[250:30] posNoWhite:[250:29] Found expr:[250:3->250:31]
+Pexp_apply ...[250:3->250:20] (~updater250:22->250:29=...__ghost__[0:-1->0:-1])
 Completable: Cexpression CArgument Value[commitLocalUpdate](~updater)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
 ContextPath CArgument Value[commitLocalUpdate](~updater)
 ContextPath Value[commitLocalUpdate]
 Path commitLocalUpdate
 [{
-    "label": "store => {}",
+    "label": "recordSourceSelectorProxy => {}",
     "kind": 12,
     "tags": [],
     "detail": "RecordSourceSelectorProxy.t => unit",
     "documentation": null,
     "sortText": "A",
-    "insertText": "${1:store} => {$0}",
+    "insertText": "${1:recordSourceSelectorProxy} => {$0}",
     "insertTextFormat": 2
   }]
 

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -845,13 +845,13 @@ ContextPath CArgument Value[fnTakingCallback]($3)
 ContextPath Value[fnTakingCallback]
 Path fnTakingCallback
 [{
-    "label": "(~on, ~off=?, variant1) => {}",
+    "label": "(~on, ~off=?, variant) => {}",
     "kind": 12,
     "tags": [],
     "detail": "(~on: bool, ~off: bool=?, variant) => int",
     "documentation": null,
     "sortText": "A",
-    "insertText": "(~on, ~off=?, ${1:variant1}) => {$0}",
+    "insertText": "(~on, ~off=?, ${1:variant}) => {$0}",
     "insertTextFormat": 2
   }]
 

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -185,13 +185,13 @@ ContextPath CJsxPropValue [div] onMouseEnter
 Path ReactDOM.domProps
 Path Pervasives.JsxDOM.domProps
 [{
-    "label": "v => {}",
+    "label": "event => {}",
     "kind": 12,
     "tags": [],
     "detail": "JsxEventC.Mouse.t => unit",
     "documentation": null,
     "sortText": "A",
-    "insertText": "{${1:v} => {$0}}",
+    "insertText": "{${1:event} => {$0}}",
     "insertTextFormat": 2
   }]
 


### PR DESCRIPTION
We're able to generate function template/snippets for callbacks since a while back. But, given that the type information has no name for unlabelled arguments, we've been forced to call most variables in the generated template `v` (with a few notable exceptions that we've special cased). 

This PR improves how we infer template variable names by looking at the type path. For example, the type `Environment.t` would be called `environment` in templates, whereas `Environment.envConfig` would be called `envConfig`.

This can help the DX quite a lot, because we can capture _some_ of the variable name intent, at least for more complex types.

Before:
![image](https://user-images.githubusercontent.com/1457626/229507881-5752d8a4-7af3-4e3e-a821-e5b7e8e4b69f.png)

After:
![image](https://user-images.githubusercontent.com/1457626/229507587-73d32dd0-5de0-4dce-8c8d-43acc528a1ac.png)

I think this will be quite useful, but interested in hearing more thoughts.