### PR TITLE
Neovim client: fix semantic tokens

### DIFF
--- a/analysis/src/SemanticTokens.ml
+++ b/analysis/src/SemanticTokens.ml
@@ -24,7 +24,7 @@ module Token = struct
     | Variable  (** let x = *)
     | Type  (** type t = *)
     | JsxTag  (** the < and > in <div> *)
-    | Class  (** module M = *)
+    | Namespace  (** module M = *)
     | EnumMember  (** variant A or poly variant #A *)
     | Property  (** {x:...} *)
     | JsxLowercase  (** div in <div> *)
@@ -34,7 +34,7 @@ module Token = struct
     | Variable -> "1"
     | Type -> "2"
     | JsxTag -> "3"
-    | Class -> "4"
+    | Namespace -> "4"
     | EnumMember -> "5"
     | Property -> "6"
     | JsxLowercase -> "7"
@@ -44,7 +44,7 @@ module Token = struct
     | Variable -> "Variable"
     | Type -> "Type"
     | JsxTag -> "JsxTag"
-    | Class -> "Class"
+    | Namespace -> "Namespace"
     | EnumMember -> "EnumMember"
     | Property -> "Property"
     | JsxLowercase -> "JsxLowercase"
@@ -115,7 +115,7 @@ let emitFromLoc ~loc ~type_ emitter =
 
 let emitLongident ?(backwards = false) ?(jsx = false)
     ?(lowerCaseToken = if jsx then Token.JsxLowercase else Token.Variable)
-    ?(upperCaseToken = Token.Class) ?(lastToken = None) ?(posEnd = None) ~pos
+    ?(upperCaseToken = Token.Namespace) ?(lastToken = None) ?(posEnd = None) ~pos
     ~lid ~debug emitter =
   let rec flatten acc lid =
     match lid with

--- a/analysis/tests/src/expected/Highlight.res.txt
+++ b/analysis/tests/src/expected/Highlight.res.txt
@@ -1,15 +1,15 @@
 Highlight src/Highlight.res
 structure items:38 diagnostics:0 
-Lident: M 0:7 Class
-Lident: C 1:9 Class
-Lident: Component 1:13 Class
+Lident: M 0:7 Namespace
+Lident: C 1:9 Namespace
+Lident: Component 1:13 Namespace
 Variable: _c [4:4->4:6]
 JsxTag <: 4:9
-Lident: Component 4:10 Class
+Lident: Component 4:10 Namespace
 Variable: _mc [6:4->6:7]
 JsxTag <: 6:10
-Ldot: M 6:11 Class
-Lident: C 6:13 Class
+Ldot: M 6:11 Namespace
+Lident: C 6:13 Namespace
 Variable: _d [8:4->8:6]
 JsxTag <: 8:9
 Lident: div 8:10 JsxLowercase
@@ -19,18 +19,18 @@ Lident: div 11:3 JsxLowercase
 Lident: div 16:4 JsxLowercase
 JsxTag >: 11:6
 JsxTag >: 16:7
-Ldot: React 12:5 Class
+Ldot: React 12:5 Namespace
 Lident: string 12:11 Variable
 JsxTag <: 13:4
 Lident: div 13:5 JsxLowercase
 Lident: div 13:34 JsxLowercase
 JsxTag >: 13:8
 JsxTag >: 13:37
-Ldot: React 13:11 Class
+Ldot: React 13:11 Namespace
 Lident: string 13:17 Variable
-Ldot: React 14:5 Class
+Ldot: React 14:5 Namespace
 Lident: string 14:11 Variable
-Ldot: React 15:5 Class
+Ldot: React 15:5 Namespace
 Lident: string 15:11 Variable
 Lident: pair 18:5 Type
 Lident: looooooooooooooooooooooooooooooooooooooong_int 20:5 Type
@@ -48,19 +48,19 @@ Lident: looooooooooooooooooooooooooooooooooooooong_string 27:4 Type
 Binary operator < [31:12->31:13]
 Binary operator > [31:22->31:23]
 Lident: MT 33:12 Type
-Lident: DDF 34:9 Class
-Lident: DDF 39:7 Class
-Lident: DDF 40:9 Class
+Lident: DDF 34:9 Namespace
+Lident: DDF 39:7 Namespace
+Lident: DDF 40:9 Namespace
 Lident: MT 39:12 Type
-Lident: XX 45:7 Class
-Lident: YY 46:9 Class
+Lident: XX 45:7 Namespace
+Lident: YY 46:9 Namespace
 Lident: t 47:9 Type
 Lident: int 47:13 Type
-Ldot: XX 51:5 Class
-Lident: YY 51:8 Class
+Ldot: XX 51:5 Namespace
+Lident: YY 51:8 Namespace
 Lident: tt 53:5 Type
 Lident: t 53:10 Type
-Lident: T 57:7 Class
+Lident: T 57:7 Namespace
 Lident: someRecord 58:7 Type
 Lident: someField 59:4 Property
 Lident: int 59:15 Type
@@ -73,7 +73,7 @@ Lident: B 64:22 EnumMember
 Lident: C 64:26 EnumMember
 Variable: foo [67:4->67:7]
 Variable: x [67:10->67:11]
-Ldot: T 67:17 Class
+Ldot: T 67:17 Namespace
 Lident: someField 67:19 Property
 Lident: x 67:15 Variable
 Variable: add [69:4->69:7]
@@ -89,16 +89,16 @@ JsxTag >: 73:24
 JsxTag >: 73:39
 JsxTag <: 73:26
 Lident: div 73:27 JsxLowercase
-Lident: SomeComponent 75:7 Class
-Lident: Nested 76:9 Class
+Lident: SomeComponent 75:7 Namespace
+Lident: Nested 76:9 Namespace
 Variable: make [78:8->78:12]
 Variable: children [78:16->78:25]
 Lident: children 79:10 Variable
 JsxTag <: 84:8
-Ldot: SomeComponent 84:9 Class
-Lident: Nested 84:23 Class
-Ldot: SomeComponent 84:41 Class
-Lident: Nested 84:55 Class
+Ldot: SomeComponent 84:9 Namespace
+Lident: Nested 84:23 Namespace
+Ldot: SomeComponent 84:41 Namespace
+Lident: Nested 84:55 Namespace
 JsxTag >: 84:29
 JsxTag >: 84:61
 JsxTag <: 84:31
@@ -113,31 +113,31 @@ Lident: to 94:9 Variable
 Lident: to 94:14 Variable
 Lident: to 94:20 Variable
 Lident: to 94:25 Variable
-Lident: ToAsProp 98:7 Class
+Lident: ToAsProp 98:7 Namespace
 Variable: make [100:6->100:10]
 Variable: to [100:14->100:17]
-Ldot: React 101:8 Class
+Ldot: React 101:8 Namespace
 Lident: int 101:14 Variable
 Lident: to 101:18 Variable
 JsxTag <: 104:8
-Lident: ToAsProp 104:9 Class
+Lident: ToAsProp 104:9 Namespace
 Variable: true [107:4->107:11]
 Lident: true 108:8->108:15 Variable
 Variable: enumInModule [110:4->110:16]
-Ldot: T 110:19 Class
+Ldot: T 110:19 Namespace
 Lident: A 110:21 EnumMember
 Lident: typeInModule 112:5 Type
-Ldot: XX 112:20 Class
-Ldot: YY 112:23 Class
+Ldot: XX 112:20 Namespace
+Ldot: YY 112:23 Namespace
 Lident: t 112:26 Type
-Lident: QQ 114:7 Class
+Lident: QQ 114:7 Namespace
 Lident: somePolyEnumType 115:7 Type
 Lident: list 118:29 Type
 TypeArg: [118:34->118:37]
 Lident: int 118:34 Type
 Variable: x [123:8->123:9]
 Lident: x 124:9 Variable
-Ldot: QQ 126:8 Class
+Ldot: QQ 126:8 Namespace
 Lident: somePolyEnumType 126:11 Type
 Lident: abc 133:9->133:14 Property
 

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
 		"semanticTokenScopes": [
 			{
 				"scopes": {
-					"jsx-lowercase": ["entity.name.tag"],
-					"jsx-tag": ["punctuation.definition.tag"],
-					"support-type-primitive": ["support.type.primitive"]
+					"interface": ["entity.name.tag"],
+					"class": ["punctuation.definition.tag"],
+					"type": ["support.type.primitive"]
 				}
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 			{
 				"scopes": {
 					"interface": ["entity.name.tag"],
-					"class": ["punctuation.definition.tag"],
+					"modifier": ["punctuation.definition.tag"],
 					"type": ["support.type.primitive"]
 				}
 			}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1127,7 +1127,7 @@ function onMessage(msg: p.Message) {
                 "operator",
                 "variable",
                 "type",
-                "class", // emit jsx-tag < and > in <div> as class
+                "modifier", // emit jsx-tag < and > in <div> as modifier
                 "namespace",
                 "enumMember",
                 "property",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1126,12 +1126,12 @@ function onMessage(msg: p.Message) {
               tokenTypes: [
                 "operator",
                 "variable",
-                "support-type-primitive",
-                "jsx-tag",
-                "class",
+                "type",
+                "class", // emit jsx-tag < and > in <div> as class
+                "namespace",
                 "enumMember",
                 "property",
-                "jsx-lowercase",
+                "interface", // emit jsxlowercase, div in <div> as interface
               ],
               tokenModifiers: [],
             },


### PR DESCRIPTION
Neovim 0.9 add support for semantic tokens.

When opening a file and editing I get the following error: `E5248: Invalid character in group name`

I saw that the server registers tokens that are not in the specification: `support-type-primitive`, `jsx-tag` and `jsx-lowercase`.

This PR change name of tokens:
- `support-type-primitive` -> `type`
- `jsx-tag` -> `class` (`class` was used as module name, now it's `namespace`)
- `jsx-lowercase` -> `interface` (`div`, `h1`)

One question: Why emit a token for `jsx-tag`, the `<` and `>` in `<div>`? Couldn't this be done via regex?

Forum post: https://forum.rescript-lang.org/t/neovim-vim-rescript-lsp-semantic-tokens-issue-and-maintenance/4387
