### PR TITLE
Use uncurried mode setting for outcome printer

### DIFF
--- a/analysis/src/Cmt.ml
+++ b/analysis/src/Cmt.ml
@@ -33,4 +33,10 @@ let fullsFromModule ~package ~moduleName =
 
 let loadFullCmtFromPath ~path =
   let uri = Uri.fromPath path in
-  fullFromUri ~uri
+  let full = fullFromUri ~uri in
+  match full with
+  | None -> None
+  | Some full ->
+    (* Turn on uncurried for the outcome printer *)
+    if full.package.uncurried then Config.uncurried := Uncurried;
+    Some full

--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -34,7 +34,6 @@ let newBsPackage ~rootPath =
                Option.bind ns Json.bool
              in
              let uncurried = uncurried = Some true in
-             if uncurried then Config.uncurried := Uncurried;
              let sourceDirectories =
                FindFiles.getSourceDirectories ~includeDev:true ~baseDir:rootPath
                  config

--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -29,6 +29,12 @@ let newBsPackage ~rootPath =
         | Some libBs ->
           Some
             (let namespace = FindFiles.getNamespace config in
+             let uncurried =
+               let ns = config |> Json.get "uncurried" in
+               Option.bind ns Json.bool
+             in
+             let uncurried = uncurried = Some true in
+             if uncurried then Config.uncurried := Uncurried;
              let sourceDirectories =
                FindFiles.getSourceDirectories ~includeDev:true ~baseDir:rootPath
                  config
@@ -144,6 +150,7 @@ let newBsPackage ~rootPath =
                      resultModulePath = ["Belt"; "Result"];
                      exnModulePath = ["Js"; "Exn"];
                    });
+               uncurried;
              })))
     | None -> None)
 

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -471,6 +471,7 @@ type package = {
   namespace: string option;
   builtInCompletionModules: builtInCompletionModules;
   opens: path list;
+  uncurried: bool;
 }
 
 let allFilesInPackage package =

--- a/analysis/tests/package-lock.json
+++ b/analysis/tests/package-lock.json
@@ -11,6 +11,26 @@
         "@rescript/react": "^0.11.0-rc.3"
       }
     },
+    "../../../rescript-compiler": {
+      "name": "rescript",
+      "version": "11.0.0-alpha.6",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "bin": {
+        "bsc": "bsc",
+        "bstracing": "lib/bstracing",
+        "rescript": "rescript"
+      },
+      "devDependencies": {
+        "mocha": "^10.1.0",
+        "nyc": "^15.0.0",
+        "prettier": "^2.7.1",
+        "rollup": "^0.49.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rescript/react": {
       "version": "0.11.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.11.0-rc.3.tgz",
@@ -69,15 +89,8 @@
       }
     },
     "node_modules/rescript": {
-      "version": "11.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.0-alpha.1.tgz",
-      "integrity": "sha512-+01rdTX9FCOZrEJFVrk2XRgrIlGLf93EKsNwoW5iq0jQiKcYGCdHeSbJvVYF+cximgm+CmWhSkR42l+Il6t12A==",
-      "hasInstallScript": true,
-      "bin": {
-        "bsc": "bsc",
-        "bstracing": "lib/bstracing",
-        "rescript": "rescript"
-      }
+      "resolved": "../../../rescript-compiler",
+      "link": true
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -137,9 +150,13 @@
       }
     },
     "rescript": {
-      "version": "11.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.0-alpha.1.tgz",
-      "integrity": "sha512-+01rdTX9FCOZrEJFVrk2XRgrIlGLf93EKsNwoW5iq0jQiKcYGCdHeSbJvVYF+cximgm+CmWhSkR42l+Il6t12A=="
+      "version": "file:../../../rescript-compiler",
+      "requires": {
+        "mocha": "^10.1.0",
+        "nyc": "^15.0.0",
+        "prettier": "^2.7.1",
+        "rollup": "^0.49.2"
+      }
     },
     "scheduler": {
       "version": "0.23.0",

--- a/analysis/vendor/res_syntax/res_outcome_printer.ml
+++ b/analysis/vendor/res_syntax/res_outcome_printer.ml
@@ -322,7 +322,6 @@ and printOutArrowType ~uncurried typ =
   let uncurried =
     if !Config.uncurried <> Legacy then not uncurried else uncurried
   in
-  (* let uncurried = false && uncurried in *)
   let typArgs, typ = collectArrowArgs typ [] in
   let args =
     Doc.join

--- a/analysis/vendor/res_syntax/res_outcome_printer.ml
+++ b/analysis/vendor/res_syntax/res_outcome_printer.ml
@@ -319,6 +319,10 @@ let rec printOutTypeDoc (outType : Outcometree.out_type) =
       ]
 
 and printOutArrowType ~uncurried typ =
+  let uncurried =
+    if !Config.uncurried <> Legacy then not uncurried else uncurried
+  in
+  (* let uncurried = false && uncurried in *)
   let typArgs, typ = collectArrowArgs typ [] in
   let args =
     Doc.join


### PR DESCRIPTION
On hover,  uncurried type will now show without dot (in uncurried mode).
