### PR TITLE
Add syntax highlighting for raw JS code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :rocket: New Feature
+
+- Add support for syntax highlighting in `%raw` and `%ffi` extension points. https://github.com/rescript-lang/rescript-vscode/pull/774
+
 ## 1.18.0
 
 #### :rocket: New Feature

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -511,46 +511,49 @@
   },
   "patterns": [
     {
-      "include": "#storage"
-    },
-    {
-      "include": "#ffi"
-    },
-    {
-      "include": "#constant"
-    },
-    {
-      "include": "#commentLine"
-    },
-    {
-      "include": "#commentBlock"
-    },
-    {
-      "include": "#character"
-    },
-    {
-      "include": "#typeParameter"
-    },
-    {
-      "include": "#string"
-    },
-    {
       "include": "#attribute"
-    },
-    {
-      "include": "#function"
-    },
-    {
-      "include": "#list"
     },
     {
       "include": "#bracketAccess"
     },
     {
+      "include": "#character"
+    },
+    {
+      "include": "#commentBlock"
+    },
+    {
+      "include": "#commentLine"
+    },
+    {
+      "include": "#constant"
+    },
+    {
+      "include": "#constructor"
+    },
+    {
+      "include": "#defaultIdIsVariable"
+    },
+    {
+      "include": "#ffi"
+    },
+    {
+      "include": "#function"
+    },
+    {
       "include": "#jsx"
     },
     {
-      "include": "#operator"
+      "include": "#keyword"
+    },
+    {
+      "include": "#list"
+    },
+    {
+      "include": "#moduleAccess"
+    },
+    {
+      "include": "#moduleDeclaration"
     },
     {
       "include": "#number"
@@ -559,22 +562,19 @@
       "include": "#openOrIncludeModule"
     },
     {
-      "include": "#moduleDeclaration"
-    },
-    {
-      "include": "#moduleAccess"
-    },
-    {
-      "include": "#constructor"
-    },
-    {
-      "include": "#keyword"
+      "include": "#operator"
     },
     {
       "include": "#punctuations"
     },
     {
-      "include": "#defaultIdIsVariable"
+      "include": "#storage"
+    },
+    {
+      "include": "#string"
+    },
+    {
+      "include": "#typeParameter"
     }
   ]
 }

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -481,11 +481,40 @@
           ]
         }
       ]
+    },
+    "ffi": {
+      "name": "source.embedded.javascript",
+      "begin": "(%|%%)(raw|ffi)(\\()(`)",
+      "end": "(`)(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.decorator"
+        },
+        "2": {
+          "name": "entity.name.function"
+        },
+        "4": {
+          "name": "punctuation.definition.string.template.begin.embedded-js"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.template.end.embedded-js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
     }
   },
   "patterns": [
     {
       "include": "#storage"
+    },
+    {
+      "include": "#ffi"
     },
     {
       "include": "#constant"


### PR DESCRIPTION
<img width="524" alt="image" src="https://github.com/rescript-lang/rescript-vscode/assets/18074327/f5015064-2386-4a6e-8d01-716ed2fc50c2">

<img width="508" alt="image" src="https://github.com/rescript-lang/rescript-vscode/assets/18074327/5b3275b0-657b-4857-be4d-edff3b811cdd">


implements https://github.com/rescript-lang/rescript-compiler/issues/6214