### PR TITLE
[Poc]: Doc extraction continuation (PR 732)

### DIFF
--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -120,6 +120,7 @@ let main () =
       ~pos:(int_of_string line_start, int_of_string line_end)
       ~maxLength ~debug:false
   | [_; "codeLens"; path] -> Commands.codeLens ~path ~debug:false
+  | [_; "extractDocs"; path] -> DocExtraction.extractDocs ~path ~debug:false
   | [_; "codeAction"; path; line; col; currentFile] ->
     Commands.codeAction ~path
       ~pos:(int_of_string line, int_of_string col)

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -343,6 +343,9 @@ let test ~path =
             let currentFile = createCurrentFile () in
             signatureHelp ~path ~pos:(line, col) ~currentFile ~debug:true;
             Sys.remove currentFile
+          | "dex" ->
+            print_endline ("Documentation extraction " ^ path);
+            DocExtraction.extractDocs ~path ~debug:true
           | "int" ->
             print_endline ("Create Interface " ^ path);
             let cmiFile =

--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -129,8 +129,7 @@ end
 let stringifyDocstrings docstrings =
   let open Protocol in
   docstrings
-  |> List.map (fun docstring ->
-         docstring |> String.trim |> Json.escape |> wrapInQuotes)
+  |> List.map (fun docstring -> docstring |> String.trim |> wrapInQuotes)
   |> array
 
 let stringifyLinkables ?(indentation = 0)
@@ -181,7 +180,7 @@ let stringifyDetail ?(indentation = 0) ~originalEnv (detail : docItemDetail) =
     stringifyObject ~startOnNewline:true ~indentation
       [
         ("kind", Some (wrapInQuotes "variant"));
-        ( "fieldDocs",
+        ( "constructorDocs",
           Some
             (constructorDocs
             |> List.map (fun constructorDoc ->

--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -1,0 +1,179 @@
+let formatCode content =
+  let {Res_driver.parsetree = signature; comments} =
+    Res_driver.parseInterfaceFromSource ~forPrinter:true
+      ~displayFilename:"<missing-file>" ~source:content
+  in
+  Res_printer.printInterface ~width:!Res_cli.ResClflags.width ~comments
+    signature
+  |> String.trim
+
+type docItemDetail =
+  | Record of {fieldDocs: (string * string list) list}
+  | Variant of {constructorDocs: (string * string list) list}
+type docItem =
+  | Value of {docstring: string list; signature: string; name: string}
+  | Type of {
+      docstring: string list;
+      signature: string;
+      name: string;
+      detail: docItemDetail option;
+    }
+  | Module of docsForModule
+and docsForModule = {docstring: string list; name: string; items: docItem list}
+
+let stringifyDocstrings docstrings =
+  let open Protocol in
+  docstrings
+  |> List.map (fun docstring ->
+         docstring |> String.trim |> Json.escape |> wrapInQuotes)
+  |> array
+
+let stringifyDetail ?(indentation = 0) (detail : docItemDetail) =
+  let open Protocol in
+  match detail with
+  | Record {fieldDocs} ->
+    stringifyObject ~startOnNewline:true ~indentation
+      [
+        ("kind", Some (wrapInQuotes "record"));
+        ( "fieldDocs",
+          Some
+            (fieldDocs
+            |> List.map (fun (fieldName, docstrings) ->
+                   stringifyObject ~indentation:(indentation + 1)
+                     [
+                       ("fieldName", Some (wrapInQuotes fieldName));
+                       ("docstrings", Some (stringifyDocstrings docstrings));
+                     ])
+            |> array) );
+      ]
+  | Variant {constructorDocs} ->
+    stringifyObject ~startOnNewline:true ~indentation
+      [
+        ("kind", Some (wrapInQuotes "variant"));
+        ( "fieldDocs",
+          Some
+            (constructorDocs
+            |> List.map (fun (constructorName, docstrings) ->
+                   stringifyObject ~startOnNewline:true
+                     ~indentation:(indentation + 1)
+                     [
+                       ("constructorName", Some (wrapInQuotes constructorName));
+                       ("docstrings", Some (stringifyDocstrings docstrings));
+                     ])
+            |> array) );
+      ]
+
+let rec stringifyDocItem ?(indentation = 0) (item : docItem) =
+  let open Protocol in
+  match item with
+  | Value {docstring; signature; name} ->
+    stringifyObject ~startOnNewline:true ~indentation
+      [
+        ("kind", Some (wrapInQuotes "value"));
+        ("name", Some (name |> Json.escape |> wrapInQuotes));
+        ( "signature",
+          Some (signature |> String.trim |> Json.escape |> wrapInQuotes) );
+        ("docstrings", Some (stringifyDocstrings docstring));
+      ]
+  | Type {docstring; signature; name; detail} ->
+    stringifyObject ~startOnNewline:true ~indentation
+      [
+        ("kind", Some (wrapInQuotes "type"));
+        ("name", Some (name |> Json.escape |> wrapInQuotes));
+        ("signature", Some (signature |> Json.escape |> wrapInQuotes));
+        ("docstrings", Some (stringifyDocstrings docstring));
+        ( "detail",
+          match detail with
+          | None -> None
+          | Some detail ->
+            Some (stringifyDetail ~indentation:(indentation + 1) detail) );
+      ]
+  | Module m ->
+    stringifyObject ~startOnNewline:true ~indentation
+      [
+        ("kind", Some (wrapInQuotes "module"));
+        ("item", Some (stringifyDocsForModule ~indentation:(indentation + 1) m));
+      ]
+
+and stringifyDocsForModule ?(indentation = 0) (d : docsForModule) =
+  let open Protocol in
+  stringifyObject ~startOnNewline:true ~indentation
+    [
+      ("name", Some (wrapInQuotes d.name));
+      ("docstrings", Some (stringifyDocstrings d.docstring));
+      ( "items",
+        Some
+          (d.items
+          |> List.map (stringifyDocItem ~indentation:(indentation + 1))
+          |> array) );
+    ]
+
+let extractDocs ~path ~debug =
+  if debug then Printf.printf "extracting docs for %s\n" path;
+  match Cmt.loadFullCmtFromPath ~path with
+  | None -> ()
+  | Some full ->
+    let file = full.file in
+    let structure = file.structure in
+    let env = SharedTypes.QueryEnv.fromFile file in
+    let rec extractDocs (structure : SharedTypes.Module.structure) =
+      {
+        docstring = structure.docstring |> List.map String.trim;
+        name = structure.name;
+        items =
+          structure.items
+          |> List.filter_map (fun (item : SharedTypes.Module.item) ->
+                 match item.kind with
+                 | Value typ ->
+                   Some
+                     (Value
+                        {
+                          docstring = item.docstring |> List.map String.trim;
+                          signature =
+                            "let " ^ item.name ^ ": " ^ Shared.typeToString typ
+                            |> formatCode;
+                          name = item.name;
+                        })
+                 | Type (typ, _) ->
+                   Some
+                     (Type
+                        {
+                          docstring = item.docstring |> List.map String.trim;
+                          signature =
+                            typ.decl
+                            |> Shared.declToString item.name
+                            |> formatCode;
+                          name = item.name;
+                          detail =
+                            (match
+                               TypeUtils.extractTypeFromResolvedType ~env ~full
+                                 typ
+                             with
+                            | Some (Trecord {fields}) ->
+                              Some
+                                (Record
+                                   {
+                                     fieldDocs =
+                                       fields
+                                       |> List.map
+                                            (fun (field : SharedTypes.field) ->
+                                              (field.fname.txt, field.docstring));
+                                   })
+                            | Some (Tvariant {constructors}) ->
+                              Some
+                                (Variant
+                                   {
+                                     constructorDocs =
+                                       constructors
+                                       |> List.map
+                                            (fun (c : SharedTypes.Constructor.t)
+                                            -> (c.cname.txt, c.docstring));
+                                   })
+                            | _ -> None);
+                        })
+                 | Module (Structure m) -> Some (Module (extractDocs m))
+                 | _ -> None);
+      }
+    in
+    let docs = extractDocs structure in
+    print_endline (stringifyDocsForModule docs)

--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -1,9 +1,16 @@
-type fieldDoc = {fieldName: string; docstrings: string list; signature: string}
+type fieldDoc = {
+  fieldName: string;
+  docstrings: string list;
+  signature: string;
+  optional: bool;
+  deprecated: string option;
+}
 
 type constructorDoc = {
   constructorName: string;
   docstrings: string list;
   signature: string;
+  deprecated: string option;
 }
 
 type docsForModuleAlias = {
@@ -22,12 +29,16 @@ type docItem =
       docstring: string list;
       signature: string;
       name: string;
+      loc: Warnings.loc;
+      deprecated: string option;
     }
   | Type of {
       id: string;
       docstring: string list;
       signature: string;
       name: string;
+      loc: Warnings.loc;
+      deprecated: string option;
       detail: docItemDetail option;
           (** Additional documentation for constructors and record fields, if available. *)
     }
@@ -36,6 +47,7 @@ type docItem =
 and docsForModule = {
   id: string;
   docstring: string list;
+  deprecated: string option;
   name: string;
   items: docItem list;
 }
@@ -69,6 +81,15 @@ let stringifyDetail ?(indentation = 0) (detail : docItemDetail) =
                    stringifyObject ~indentation:(indentation + 1)
                      [
                        ("fieldName", Some (wrapInQuotes fieldDoc.fieldName));
+                       ( "deprecated",
+                         Some
+                           (string_of_bool (Option.is_some fieldDoc.deprecated))
+                       );
+                       ( "deprecatedMessage",
+                         match fieldDoc.deprecated with
+                         | Some msg -> Some (wrapInQuotes msg)
+                         | None -> None );
+                       ("optional", Some (string_of_bool fieldDoc.optional));
                        ( "docstrings",
                          Some (stringifyDocstrings fieldDoc.docstrings) );
                        ("signature", Some (wrapInQuotes fieldDoc.signature));
@@ -88,6 +109,14 @@ let stringifyDetail ?(indentation = 0) (detail : docItemDetail) =
                      [
                        ( "constructorName",
                          Some (wrapInQuotes constructorDoc.constructorName) );
+                       ( "deprecated",
+                         Some
+                           (string_of_bool
+                              (Option.is_some constructorDoc.deprecated)) );
+                       ( "deprecatedMessage",
+                         match constructorDoc.deprecated with
+                         | Some msg -> Some (wrapInQuotes msg)
+                         | None -> None );
                        ( "docstrings",
                          Some (stringifyDocstrings constructorDoc.docstrings) );
                        ( "signature",
@@ -96,25 +125,48 @@ let stringifyDetail ?(indentation = 0) (detail : docItemDetail) =
             |> array) );
       ]
 
+let stringifyLoc loc ~indentation =
+  let open Protocol in
+  let line, col = Loc.start loc in
+  let path = loc.loc_start.pos_fname in
+  stringifyObject ~startOnNewline:false ~indentation:(indentation + 1)
+    [
+      ("path", Some (wrapInQuotes path));
+      ("line", Some (string_of_int (line + 1)));
+      ("col", Some (string_of_int (col + 1)));
+    ]
+
 let rec stringifyDocItem ?(indentation = 0) ~originalEnv (item : docItem) =
   let open Protocol in
   match item with
-  | Value {id; docstring; signature; name} ->
+  | Value {id; docstring; signature; name; loc; deprecated} ->
     stringifyObject ~startOnNewline:true ~indentation
       [
         ("id", Some (wrapInQuotes id));
         ("kind", Some (wrapInQuotes "value"));
         ("name", Some (name |> Json.escape |> wrapInQuotes));
+        ("deprecated", Some (string_of_bool (Option.is_some deprecated)));
+        ( "deprecatedMessage",
+          match deprecated with
+          | Some msg -> Some (wrapInQuotes msg)
+          | None -> None );
+        ("location", Some (stringifyLoc loc ~indentation));
         ( "signature",
           Some (signature |> String.trim |> Json.escape |> wrapInQuotes) );
         ("docstrings", Some (stringifyDocstrings docstring));
       ]
-  | Type {id; docstring; signature; name; detail} ->
+  | Type {id; docstring; signature; name; loc; deprecated; detail} ->
     stringifyObject ~startOnNewline:true ~indentation
       [
         ("id", Some (wrapInQuotes id));
         ("kind", Some (wrapInQuotes "type"));
         ("name", Some (name |> Json.escape |> wrapInQuotes));
+        ("deprecated", Some (string_of_bool (Option.is_some deprecated)));
+        ( "deprecatedMessage",
+          match deprecated with
+          | Some msg -> Some (wrapInQuotes msg)
+          | None -> None );
+        ("location", Some (stringifyLoc loc ~indentation));
         ("signature", Some (signature |> Json.escape |> wrapInQuotes));
         ("docstrings", Some (stringifyDocstrings docstring));
         ( "detail",
@@ -147,6 +199,11 @@ and stringifyDocsForModule ?(indentation = 0) ~originalEnv (d : docsForModule) =
   stringifyObject ~startOnNewline:true ~indentation
     [
       ("name", Some (wrapInQuotes d.name));
+      ("deprecated", Some (string_of_bool (Option.is_some d.deprecated)));
+      ( "deprecatedMessage",
+        match d.deprecated with
+        | Some msg -> Some (wrapInQuotes msg)
+        | None -> None );
       ("docstrings", Some (stringifyDocstrings d.docstring));
       ( "items",
         Some
@@ -169,7 +226,9 @@ let typeDetail typ ~env ~full =
                     {
                       fieldName = field.fname.txt;
                       docstrings = field.docstring;
+                      optional = field.optional;
                       signature = Shared.typeToString field.typ;
+                      deprecated = field.deprecated;
                     });
          })
   | Some (Tvariant {constructors}) ->
@@ -183,6 +242,7 @@ let typeDetail typ ~env ~full =
                       constructorName = c.cname.txt;
                       docstrings = c.docstring;
                       signature = CompletionBackEnd.showConstructor c;
+                      deprecated = c.deprecated;
                     });
          })
   | _ -> None
@@ -225,6 +285,7 @@ let extractDocs ~path ~debug =
         id = modulePath |> ident;
         docstring = structure.docstring |> List.map String.trim;
         name = structure.name;
+        deprecated = structure.deprecated;
         items =
           structure.items
           |> List.filter_map (fun (item : Module.item) ->
@@ -239,6 +300,8 @@ let extractDocs ~path ~debug =
                             "let " ^ item.name ^ ": " ^ Shared.typeToString typ
                             |> formatCode;
                           name = item.name;
+                          loc = item.loc;
+                          deprecated = item.deprecated;
                         })
                  | Type (typ, _) ->
                    Some
@@ -251,6 +314,8 @@ let extractDocs ~path ~debug =
                             |> Shared.declToString item.name
                             |> formatCode;
                           name = item.name;
+                          loc = item.loc;
+                          deprecated = item.deprecated;
                           detail = typeDetail typ ~full ~env;
                         })
                  | Module (Ident p) ->

--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -1,3 +1,33 @@
+type linkableType = {
+  name: string;
+  path: Path.t;
+  env: SharedTypes.QueryEnv.t;
+  loc: Location.t;
+}
+
+type docItemDetail =
+  | Record of {fieldDocs: (string * string list) list}
+  | Variant of {constructorDocs: (string * string list) list}
+type docItem =
+  | Value of {
+      docstring: string list;
+      signature: string;
+      name: string;
+      linkables: linkableType list;
+          (** Relevant types to link to, found in relation to this value. *)
+    }
+  | Type of {
+      docstring: string list;
+      signature: string;
+      name: string;
+      detail: docItemDetail option;
+          (** Additional documentation for constructors and record fields, if available. *)
+      linkables: linkableType list;
+          (** Relevant types to link to, found in relation to this type. *)
+    }
+  | Module of docsForModule
+and docsForModule = {docstring: string list; name: string; items: docItem list}
+
 let formatCode content =
   let {Res_driver.parsetree = signature; comments} =
     Res_driver.parseInterfaceFromSource ~forPrinter:true
@@ -7,25 +37,87 @@ let formatCode content =
     signature
   |> String.trim
 
-type docItemDetail =
-  | Record of {fieldDocs: (string * string list) list}
-  | Variant of {constructorDocs: (string * string list) list}
-type docItem =
-  | Value of {docstring: string list; signature: string; name: string}
-  | Type of {
-      docstring: string list;
-      signature: string;
-      name: string;
-      detail: docItemDetail option;
-    }
-  | Module of docsForModule
-and docsForModule = {docstring: string list; name: string; items: docItem list}
+module Linkables = struct
+  (* TODO: Extend this by going into function arguments, tuples etc... *)
+  let labelDeclarationsTypes lds =
+    lds |> List.map (fun (ld : Types.label_declaration) -> ld.ld_type)
+
+  let rec linkablesFromDecl (decl : Types.type_declaration) ~env ~full =
+    match decl.type_kind with
+    | Type_record (lds, _) -> (env, lds |> labelDeclarationsTypes)
+    | Type_variant cds ->
+      ( env,
+        cds
+        |> List.map (fun (cd : Types.constructor_declaration) ->
+               let fromArgs =
+                 match cd.cd_args with
+                 | Cstr_tuple ts -> ts
+                 | Cstr_record lds -> lds |> labelDeclarationsTypes
+               in
+               match cd.cd_res with
+               | None -> fromArgs
+               | Some t -> t :: fromArgs)
+        |> List.flatten )
+    | _ -> (
+      match decl.type_manifest with
+      | None -> (env, [])
+      | Some typ -> linkablesFromTyp typ ~env ~full)
+
+  and linkablesFromTyp ~env ~(full : SharedTypes.full) typ =
+    match typ |> Shared.digConstructor with
+    | Some path -> (
+      match References.digConstructor ~env ~package:full.package path with
+      | None -> (env, [typ])
+      | Some (env1, {item = {decl}}) -> linkablesFromDecl decl ~env:env1 ~full)
+    | None -> (env, [typ])
+
+  type linkableSource =
+    | Typ of SharedTypes.Type.t
+    | TypeExpr of Types.type_expr
+
+  let findLinkables ~env ~(full : SharedTypes.full) (typ : linkableSource) =
+    (* Expand definitions of types mentioned in typ.
+       If typ itself is a record or variant, search its body *)
+    let envToSearch, typesToSearch =
+      match typ with
+      | Typ t -> linkablesFromDecl ~env t.decl ~full
+      | TypeExpr t -> linkablesFromTyp t ~env ~full
+    in
+    let fromConstructorPath ~env path =
+      match References.digConstructor ~env ~package:full.package path with
+      | None -> None
+      | Some (env, {name = {txt}; extentLoc}) ->
+        if Utils.isUncurriedInternal path then None
+        else Some {name = txt; env; loc = extentLoc; path}
+    in
+    let constructors = Shared.findTypeConstructors typesToSearch in
+    constructors |> List.filter_map (fromConstructorPath ~env:envToSearch)
+end
 
 let stringifyDocstrings docstrings =
   let open Protocol in
   docstrings
   |> List.map (fun docstring ->
          docstring |> String.trim |> Json.escape |> wrapInQuotes)
+  |> array
+
+let stringifyLinkables ?(indentation = 0)
+    ~(originalEnv : SharedTypes.QueryEnv.t) (linkables : linkableType list) =
+  let open Protocol in
+  linkables
+  |> List.map (fun l ->
+         stringifyObject ~indentation:(indentation + 1)
+           [
+             ( "path",
+               Some
+                 (l.path |> SharedTypes.pathIdentToString |> Json.escape
+                |> wrapInQuotes) );
+             ("moduleName", Some (l.env.file.moduleName |> wrapInQuotes));
+             ( "external",
+               Some
+                 (Printf.sprintf "%b" (originalEnv.file.uri <> l.env.file.uri))
+             );
+           ])
   |> array
 
 let stringifyDetail ?(indentation = 0) (detail : docItemDetail) =
@@ -63,10 +155,10 @@ let stringifyDetail ?(indentation = 0) (detail : docItemDetail) =
             |> array) );
       ]
 
-let rec stringifyDocItem ?(indentation = 0) (item : docItem) =
+let rec stringifyDocItem ?(indentation = 0) ~originalEnv (item : docItem) =
   let open Protocol in
   match item with
-  | Value {docstring; signature; name} ->
+  | Value {docstring; signature; name; linkables} ->
     stringifyObject ~startOnNewline:true ~indentation
       [
         ("kind", Some (wrapInQuotes "value"));
@@ -74,14 +166,22 @@ let rec stringifyDocItem ?(indentation = 0) (item : docItem) =
         ( "signature",
           Some (signature |> String.trim |> Json.escape |> wrapInQuotes) );
         ("docstrings", Some (stringifyDocstrings docstring));
+        ( "linkables",
+          Some
+            (stringifyLinkables ~originalEnv ~indentation:(indentation + 1)
+               linkables) );
       ]
-  | Type {docstring; signature; name; detail} ->
+  | Type {docstring; signature; name; detail; linkables} ->
     stringifyObject ~startOnNewline:true ~indentation
       [
         ("kind", Some (wrapInQuotes "type"));
         ("name", Some (name |> Json.escape |> wrapInQuotes));
         ("signature", Some (signature |> Json.escape |> wrapInQuotes));
         ("docstrings", Some (stringifyDocstrings docstring));
+        ( "linkables",
+          Some
+            (stringifyLinkables ~originalEnv ~indentation:(indentation + 1)
+               linkables) );
         ( "detail",
           match detail with
           | None -> None
@@ -92,10 +192,13 @@ let rec stringifyDocItem ?(indentation = 0) (item : docItem) =
     stringifyObject ~startOnNewline:true ~indentation
       [
         ("kind", Some (wrapInQuotes "module"));
-        ("item", Some (stringifyDocsForModule ~indentation:(indentation + 1) m));
+        ( "item",
+          Some
+            (stringifyDocsForModule ~originalEnv ~indentation:(indentation + 1)
+               m) );
       ]
 
-and stringifyDocsForModule ?(indentation = 0) (d : docsForModule) =
+and stringifyDocsForModule ?(indentation = 0) ~originalEnv (d : docsForModule) =
   let open Protocol in
   stringifyObject ~startOnNewline:true ~indentation
     [
@@ -104,7 +207,8 @@ and stringifyDocsForModule ?(indentation = 0) (d : docsForModule) =
       ( "items",
         Some
           (d.items
-          |> List.map (stringifyDocItem ~indentation:(indentation + 1))
+          |> List.map
+               (stringifyDocItem ~originalEnv ~indentation:(indentation + 1))
           |> array) );
     ]
 
@@ -133,11 +237,15 @@ let extractDocs ~path ~debug =
                             "let " ^ item.name ^ ": " ^ Shared.typeToString typ
                             |> formatCode;
                           name = item.name;
+                          linkables =
+                            TypeExpr typ |> Linkables.findLinkables ~env ~full;
                         })
                  | Type (typ, _) ->
                    Some
                      (Type
                         {
+                          linkables =
+                            Typ typ |> Linkables.findLinkables ~env ~full;
                           docstring = item.docstring |> List.map String.trim;
                           signature =
                             typ.decl
@@ -176,4 +284,4 @@ let extractDocs ~path ~debug =
       }
     in
     let docs = extractDocs structure in
-    print_endline (stringifyDocsForModule docs)
+    print_endline (stringifyDocsForModule ~originalEnv:env docs)

--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -121,17 +121,20 @@ let stringifyLinkables ?(indentation = 0)
   let open Protocol in
   linkables
   |> List.map (fun l ->
+         let isExternal = originalEnv.file.uri <> l.env.file.uri in
          stringifyObject ~indentation:(indentation + 1)
            [
+             ( "linkId",
+               Some
+                 ((if isExternal then "" else l.env.file.moduleName ^ ".")
+                  ^ (l.path |> SharedTypes.pathIdentToString)
+                 |> Json.escape |> wrapInQuotes) );
              ( "path",
                Some
                  (l.path |> SharedTypes.pathIdentToString |> Json.escape
                 |> wrapInQuotes) );
              ("moduleName", Some (l.env.file.moduleName |> wrapInQuotes));
-             ( "external",
-               Some
-                 (Printf.sprintf "%b" (originalEnv.file.uri <> l.env.file.uri))
-             );
+             ("external", Some (Printf.sprintf "%b" isExternal));
            ])
   |> array
 

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -54,7 +54,13 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         newDeclared
       | _ -> declared
     in
-    [{Module.kind = Module.Value declared.item; name = declared.name.txt}]
+    [
+      {
+        Module.kind = Module.Value declared.item;
+        name = declared.name.txt;
+        docstring = declared.docstring;
+      };
+    ]
   | Sig_type
       ( ident,
         ({type_loc; type_kind; type_manifest; type_attributes} as decl),
@@ -121,7 +127,13 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         (Exported.add exported Exported.Type)
         Stamps.addType
     in
-    [{Module.kind = Type (declared.item, recStatus); name = declared.name.txt}]
+    [
+      {
+        Module.kind = Type (declared.item, recStatus);
+        name = declared.name.txt;
+        docstring = declared.docstring;
+      };
+    ]
   | Sig_module (ident, {md_type; md_attributes; md_loc}, _) ->
     let name = Ident.name ident in
     let declared =
@@ -132,7 +144,13 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         (Exported.add exported Exported.Module)
         Stamps.addModule
     in
-    [{Module.kind = Module declared.item; name = declared.name.txt}]
+    [
+      {
+        Module.kind = Module declared.item;
+        name = declared.name.txt;
+        docstring = declared.docstring;
+      };
+    ]
   | _ -> []
 
 and forTypeSignature ~name ~env signature =
@@ -293,6 +311,7 @@ let forTypeDeclaration ~env ~(exported : Exported.t)
   {
     Module.kind = Module.Type (declared.item, recStatus);
     name = declared.name.txt;
+    docstring = declared.docstring;
   }
 
 let rec forSignatureItem ~env ~(exported : Exported.t)
@@ -306,7 +325,13 @@ let rec forSignatureItem ~env ~(exported : Exported.t)
         (Exported.add exported Exported.Value)
         Stamps.addValue
     in
-    [{Module.kind = Module.Value declared.item; name = declared.name.txt}]
+    [
+      {
+        Module.kind = Module.Value declared.item;
+        name = declared.name.txt;
+        docstring = declared.docstring;
+      };
+    ]
   | Tsig_type (recFlag, decls) ->
     decls
     |> List.mapi (fun i decl ->
@@ -330,7 +355,13 @@ let rec forSignatureItem ~env ~(exported : Exported.t)
         (Exported.add exported Exported.Module)
         Stamps.addModule
     in
-    [{Module.kind = Module declared.item; name = declared.name.txt}]
+    [
+      {
+        Module.kind = Module declared.item;
+        name = declared.name.txt;
+        docstring = declared.docstring;
+      };
+    ]
   | Tsig_recmodule modDecls ->
     modDecls
     |> List.map (fun modDecl ->
@@ -400,7 +431,11 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
             Stamps.addValue
         in
         items :=
-          {Module.kind = Module.Value declared.item; name = declared.name.txt}
+          {
+            Module.kind = Module.Value declared.item;
+            name = declared.name.txt;
+            docstring = declared.docstring;
+          }
           :: !items
       | Tpat_tuple pats | Tpat_array pats | Tpat_construct (_, _, pats) ->
         pats |> List.iter (fun p -> handlePattern [] p)
@@ -429,7 +464,13 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
         (Exported.add exported Exported.Module)
         Stamps.addModule
     in
-    [{Module.kind = Module declared.item; name = declared.name.txt}]
+    [
+      {
+        Module.kind = Module declared.item;
+        name = declared.name.txt;
+        docstring = declared.docstring;
+      };
+    ]
   | Tstr_recmodule modDecls ->
     modDecls
     |> List.map (fun modDecl ->
@@ -453,7 +494,13 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
         (Exported.add exported Exported.Module)
         Stamps.addModule
     in
-    [{Module.kind = Module modTypeItem; name = declared.name.txt}]
+    [
+      {
+        Module.kind = Module modTypeItem;
+        name = declared.name.txt;
+        docstring = declared.docstring;
+      };
+    ]
   | Tstr_include {incl_mod; incl_type} ->
     let env =
       match getModulePath incl_mod.mod_desc with
@@ -475,7 +522,13 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
         (Exported.add exported Exported.Value)
         Stamps.addValue
     in
-    [{Module.kind = Value declared.item; name = declared.name.txt}]
+    [
+      {
+        Module.kind = Value declared.item;
+        name = declared.name.txt;
+        docstring = declared.docstring;
+      };
+    ]
   | Tstr_type (recFlag, decls) ->
     decls
     |> List.mapi (fun i decl ->

--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -59,6 +59,8 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         Module.kind = Module.Value declared.item;
         name = declared.name.txt;
         docstring = declared.docstring;
+        loc;
+        deprecated = declared.deprecated;
       };
     ]
   | Sig_type
@@ -132,6 +134,8 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         Module.kind = Type (declared.item, recStatus);
         name = declared.name.txt;
         docstring = declared.docstring;
+        loc = type_loc;
+        deprecated = declared.deprecated;
       };
     ]
   | Sig_module (ident, {md_type; md_attributes; md_loc}, _) ->
@@ -149,6 +153,8 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
         Module.kind = Module declared.item;
         name = declared.name.txt;
         docstring = declared.docstring;
+        loc = md_loc;
+        deprecated = declared.deprecated;
       };
     ]
   | _ -> []
@@ -160,7 +166,7 @@ and forTypeSignature ~name ~env signature =
       (fun item items -> forTypeSignatureItem ~env ~exported item @ items)
       signature []
   in
-  {Module.name; docstring = []; exported; items}
+  {Module.name; docstring = []; exported; items; deprecated = None}
 
 and forTypeModule ~name ~env moduleType =
   match moduleType with
@@ -312,6 +318,8 @@ let forTypeDeclaration ~env ~(exported : Exported.t)
     Module.kind = Module.Type (declared.item, recStatus);
     name = declared.name.txt;
     docstring = declared.docstring;
+    loc = typ_loc;
+    deprecated = declared.deprecated;
   }
 
 let rec forSignatureItem ~env ~(exported : Exported.t)
@@ -330,6 +338,8 @@ let rec forSignatureItem ~env ~(exported : Exported.t)
         Module.kind = Module.Value declared.item;
         name = declared.name.txt;
         docstring = declared.docstring;
+        loc = name.loc;
+        deprecated = declared.deprecated;
       };
     ]
   | Tsig_type (recFlag, decls) ->
@@ -360,6 +370,8 @@ let rec forSignatureItem ~env ~(exported : Exported.t)
         Module.kind = Module declared.item;
         name = declared.name.txt;
         docstring = declared.docstring;
+        loc = name.loc;
+        deprecated = declared.deprecated;
       };
     ]
   | Tsig_recmodule modDecls ->
@@ -395,7 +407,8 @@ let forSignature ~name ~env sigItems =
     | _ -> []
   in
   let docstring = attrsToDocstring attributes in
-  {Module.name; docstring; exported; items}
+  let deprecated = ProcessAttributes.findDeprecatedAttribute attributes in
+  {Module.name; docstring; exported; items; deprecated}
 
 let forTreeModuleType ~name ~env {Typedtree.mty_desc} =
   match mty_desc with
@@ -435,6 +448,8 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
             Module.kind = Module.Value declared.item;
             name = declared.name.txt;
             docstring = declared.docstring;
+            loc = pat.pat_loc;
+            deprecated = declared.deprecated;
           }
           :: !items
       | Tpat_tuple pats | Tpat_array pats | Tpat_construct (_, _, pats) ->
@@ -469,6 +484,8 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
         Module.kind = Module declared.item;
         name = declared.name.txt;
         docstring = declared.docstring;
+        loc = name.loc;
+        deprecated = declared.deprecated;
       };
     ]
   | Tstr_recmodule modDecls ->
@@ -499,6 +516,8 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
         Module.kind = Module modTypeItem;
         name = declared.name.txt;
         docstring = declared.docstring;
+        loc = name.loc;
+        deprecated = declared.deprecated;
       };
     ]
   | Tstr_include {incl_mod; incl_type} ->
@@ -527,6 +546,8 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
         Module.kind = Value declared.item;
         name = declared.name.txt;
         docstring = declared.docstring;
+        loc = vd.val_loc;
+        deprecated = declared.deprecated;
       };
     ]
   | Tstr_type (recFlag, decls) ->
@@ -587,7 +608,8 @@ and forStructure ~name ~env strItems =
     | _ -> []
   in
   let docstring = attrsToDocstring attributes in
-  {Module.name; docstring; exported; items}
+  let deprecated = ProcessAttributes.findDeprecatedAttribute attributes in
+  {Module.name; docstring; exported; items; deprecated}
 
 let fileForCmtInfos ~moduleName ~uri
     ({cmt_modname; cmt_annots} : Cmt_format.cmt_infos) =

--- a/analysis/src/Protocol.ml
+++ b/analysis/src/Protocol.ml
@@ -98,16 +98,19 @@ let stringifyMarkupContent (m : markupContent) =
   Printf.sprintf {|{"kind": "%s", "value": "%s"}|} m.kind (Json.escape m.value)
 
 (** None values are not emitted in the output. *)
-let stringifyObject properties =
-  {|{
+let stringifyObject ?(startOnNewline = false) ?(indentation = 1) properties =
+  let indentationStr = String.make (indentation * 2) ' ' in
+  (if startOnNewline then "\n" ^ indentationStr else "")
+  ^ {|{
 |}
   ^ (properties
     |> List.filter_map (fun (key, value) ->
            match value with
            | None -> None
-           | Some v -> Some (Printf.sprintf {|    "%s": %s|} key v))
+           | Some v ->
+             Some (Printf.sprintf {|%s  "%s": %s|} indentationStr key v))
     |> String.concat ",\n")
-  ^ "\n  }"
+  ^ "\n" ^ indentationStr ^ "}"
 
 let wrapInQuotes s = "\"" ^ Json.escape s ^ "\""
 

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -122,7 +122,7 @@ module Module = struct
     | Type of Type.t * Types.rec_status
     | Module of t
 
-  and item = {kind: kind; name: string}
+  and item = {kind: kind; name: string; docstring: string list}
 
   and structure = {
     name: string;

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -122,13 +122,20 @@ module Module = struct
     | Type of Type.t * Types.rec_status
     | Module of t
 
-  and item = {kind: kind; name: string; docstring: string list}
+  and item = {
+    kind: kind;
+    name: string;
+    docstring: string list;
+    loc: Warnings.loc;
+    deprecated: string option;
+  }
 
   and structure = {
     name: string;
     docstring: string list;
     exported: Exported.t;
     items: item list;
+    deprecated: string option
   }
 
   and t = Ident of Path.t | Structure of structure | Constraint of t * t
@@ -253,6 +260,7 @@ module File = struct
           docstring = [];
           exported = Exported.init ();
           items = [];
+          deprecated = None
         };
     }
 end

--- a/analysis/tests/src/DocExtraction2.res
+++ b/analysis/tests/src/DocExtraction2.res
@@ -1,0 +1,12 @@
+type t = string
+
+let getStr = () => "123"
+
+let make = getStr
+
+module InnerModule = {
+  type t = unit
+  let make = () => ()
+}
+
+// ^dex

--- a/analysis/tests/src/DocExtraction2.resi
+++ b/analysis/tests/src/DocExtraction2.resi
@@ -1,0 +1,19 @@
+/*** Module level doc here.*/
+
+/** Type t is pretty cool.*/
+type t
+
+/** Makerz of stuffz. */
+let make: unit => t
+
+module InnerModule: {
+  /*** This inner module is nice...*/
+
+  /** This type is also t. */
+  type t
+
+  /** Maker of tea.*/
+  let make: unit => t
+}
+
+// ^dex

--- a/analysis/tests/src/DocExtractionRes.res
+++ b/analysis/tests/src/DocExtractionRes.res
@@ -36,6 +36,9 @@ module SomeInnerModule = {
 module AnotherModule = {
   /*** Mighty fine module here too!*/
 
+  /** This links another module. Neat. */
+  module LinkedModule = SomeInnerModule
+
   /**
   Testing what this looks like.*/
   type callback = SomeInnerModule.status => unit

--- a/analysis/tests/src/DocExtractionRes.res
+++ b/analysis/tests/src/DocExtractionRes.res
@@ -1,0 +1,44 @@
+/***Module level documentation goes here. */
+
+/** This type represents stuff. */
+type t = {
+  /** The name of the stuff.*/
+  name: string,
+  /** Whether stuff is online.*/
+  online: bool,
+}
+
+/** Create stuff.
+
+```rescript example
+let stuff = make("My name")
+```
+*/
+let make = name => {
+  name,
+  online: true,
+}
+
+/** Stuff goes offline.*/
+let asOffline = (t: t) => {...t, online: false}
+
+module SomeInnerModule = {
+  /*** Another module level docstring here.*/
+  type status =
+    | /** If this is started or not */ Started(t) | /** Stopped? */ Stopped | /** Now idle.*/ Idle
+
+  /** These are all the valid inputs.*/
+  type validInputs = [#something | #"needs-escaping" | #withPayload(int)]
+
+  type callback = (t, ~status: status) => unit
+}
+
+module AnotherModule = {
+  /*** Mighty fine module here too!*/
+
+  /**
+  Testing what this looks like.*/
+  type callback = SomeInnerModule.status => unit
+}
+
+// ^dex

--- a/analysis/tests/src/DocExtractionRes.res
+++ b/analysis/tests/src/DocExtractionRes.res
@@ -51,4 +51,38 @@ module AnotherModule = {
   type domRoot = unit => Client.Root.t
 }
 
+module ModuleWithThingsThatShouldNotBeExported: {
+  /*** BROKEN: This docstring isn't picked up Doesn't seem to be parsed at all, no attributes found.*/
+
+  /** The type t is stuff. */
+  type t
+
+  /** The maker of stuff!*/
+  let make: unit => t
+} = {
+  /*** Mighty fine module here too!*/
+  type t = string
+  type x = int
+  type f = bool
+
+  let m1 = (x: x) => {
+    x + 1
+  }
+
+  let m2 = (f: f) =>
+    if f {
+      true
+    } else {
+      false
+    }
+
+  let make = () => {
+    if m2(true) && m1(1) > 2 {
+      "1"
+    } else {
+      "2"
+    }
+  }
+}
+
 // ^dex

--- a/analysis/tests/src/DocExtractionRes.res
+++ b/analysis/tests/src/DocExtractionRes.res
@@ -28,7 +28,7 @@ module SomeInnerModule = {
     | /** If this is started or not */ Started(t) | /** Stopped? */ Stopped | /** Now idle.*/ Idle
 
   /** These are all the valid inputs.*/
-  type validInputs = [#something | #"needs-escaping" | #withPayload(int)]
+  type validInputs = [#something | #"needs-escaping" | #withPayload(int) | #status(status)]
 
   type callback = (t, ~status: status) => unit
 }
@@ -39,6 +39,16 @@ module AnotherModule = {
   /**
   Testing what this looks like.*/
   type callback = SomeInnerModule.status => unit
+
+  let isGoodStatus = (status: SomeInnerModule.status) => status == Stopped
+
+  /** Trying how it looks with an inline record in a variant. */
+  type someVariantWithInlineRecords = | /** This has inline records...*/ SomeStuff({offline: bool})
+
+  open ReactDOM
+
+  /**Callback to get the DOM root...*/
+  type domRoot = unit => Client.Root.t
 }
 
 // ^dex

--- a/analysis/tests/src/expected/DocExtraction2.res.txt
+++ b/analysis/tests/src/expected/DocExtraction2.res.txt
@@ -21,6 +21,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
     "signature": "let make: unit => t",
     "docstrings": ["Makerz of stuffz."],
     "linkables": [{
+        "linkId": "DocExtraction2.t",
         "path": "t",
         "moduleName": "DocExtraction2",
         "external": false
@@ -49,6 +50,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
         "signature": "let make: unit => t",
         "docstrings": ["Maker of tea."],
         "linkables": [{
+            "linkId": "DocExtraction2.t",
             "path": "t",
             "moduleName": "DocExtraction2",
             "external": false

--- a/analysis/tests/src/expected/DocExtraction2.res.txt
+++ b/analysis/tests/src/expected/DocExtraction2.res.txt
@@ -11,20 +11,14 @@ preferring found resi file for impl: src/DocExtraction2.resi
     "kind": "type",
     "name": "t",
     "signature": "type t",
-    "docstrings": ["Type t is pretty cool."],
-    "linkables": []
+    "docstrings": ["Type t is pretty cool."]
   }, 
   {
     "id": "DocExtraction2.make",
     "kind": "value",
     "name": "make",
     "signature": "let make: unit => t",
-    "docstrings": ["Makerz of stuffz."],
-    "linkables": [{
-        "linkId": "DocExtraction2.t",
-        "name": "t",
-        "external": false
-      }]
+    "docstrings": ["Makerz of stuffz."]
   }, 
   {
     "id": "InnerModule.DocExtraction2",
@@ -39,20 +33,14 @@ preferring found resi file for impl: src/DocExtraction2.resi
         "kind": "type",
         "name": "t",
         "signature": "type t",
-        "docstrings": ["This type is also t."],
-        "linkables": []
+        "docstrings": ["This type is also t."]
       }, 
       {
         "id": "DocExtraction2.InnerModule.make",
         "kind": "value",
         "name": "make",
         "signature": "let make: unit => t",
-        "docstrings": ["Maker of tea."],
-        "linkables": [{
-            "linkId": "DocExtraction2.InnerModule.t",
-            "name": "t",
-            "external": false
-          }]
+        "docstrings": ["Maker of tea."]
       }]
     }
   }]

--- a/analysis/tests/src/expected/DocExtraction2.res.txt
+++ b/analysis/tests/src/expected/DocExtraction2.res.txt
@@ -1,0 +1,55 @@
+Documentation extraction src/DocExtraction2.res
+extracting docs for src/DocExtraction2.res
+preferring found resi file for impl: src/DocExtraction2.resi
+
+{
+  "name": "DocExtraction2",
+  "docstrings": ["Module level doc here."],
+  "items": [
+  {
+    "kind": "type",
+    "name": "t",
+    "signature": "type t",
+    "docstrings": ["Type t is pretty cool."],
+    "linkables": []
+  }, 
+  {
+    "kind": "value",
+    "name": "make",
+    "signature": "let make: unit => t",
+    "docstrings": ["Makerz of stuffz."],
+    "linkables": [{
+        "path": "t",
+        "moduleName": "DocExtraction2",
+        "external": false
+      }]
+  }, 
+  {
+    "kind": "module",
+    "item": 
+    {
+      "name": "InnerModule",
+      "docstrings": [],
+      "items": [
+      {
+        "kind": "type",
+        "name": "t",
+        "signature": "type t",
+        "docstrings": ["This type is also t."],
+        "linkables": []
+      }, 
+      {
+        "kind": "value",
+        "name": "make",
+        "signature": "let make: unit => t",
+        "docstrings": ["Maker of tea."],
+        "linkables": [{
+            "path": "t",
+            "moduleName": "DocExtraction2",
+            "external": false
+          }]
+      }]
+    }
+  }]
+}
+

--- a/analysis/tests/src/expected/DocExtraction2.res.txt
+++ b/analysis/tests/src/expected/DocExtraction2.res.txt
@@ -22,8 +22,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
     "docstrings": ["Makerz of stuffz."],
     "linkables": [{
         "linkId": "DocExtraction2.t",
-        "path": "t",
-        "moduleName": "DocExtraction2",
+        "name": "t",
         "external": false
       }]
   }, 
@@ -50,9 +49,8 @@ preferring found resi file for impl: src/DocExtraction2.resi
         "signature": "let make: unit => t",
         "docstrings": ["Maker of tea."],
         "linkables": [{
-            "linkId": "DocExtraction2.t",
-            "path": "t",
-            "moduleName": "DocExtraction2",
+            "linkId": "DocExtraction2.InnerModule.t",
+            "name": "t",
             "external": false
           }]
       }]

--- a/analysis/tests/src/expected/DocExtraction2.res.txt
+++ b/analysis/tests/src/expected/DocExtraction2.res.txt
@@ -7,6 +7,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
   "docstrings": ["Module level doc here."],
   "items": [
   {
+    "id": "DocExtraction2.t",
     "kind": "type",
     "name": "t",
     "signature": "type t",
@@ -14,6 +15,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
     "linkables": []
   }, 
   {
+    "id": "DocExtraction2.make",
     "kind": "value",
     "name": "make",
     "signature": "let make: unit => t",
@@ -25,6 +27,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
       }]
   }, 
   {
+    "id": "InnerModule.DocExtraction2",
     "kind": "module",
     "item": 
     {
@@ -32,6 +35,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
       "docstrings": [],
       "items": [
       {
+        "id": "DocExtraction2.InnerModule.t",
         "kind": "type",
         "name": "t",
         "signature": "type t",
@@ -39,6 +43,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
         "linkables": []
       }, 
       {
+        "id": "DocExtraction2.InnerModule.make",
         "kind": "value",
         "name": "make",
         "signature": "let make: unit => t",

--- a/analysis/tests/src/expected/DocExtraction2.resi.txt
+++ b/analysis/tests/src/expected/DocExtraction2.resi.txt
@@ -6,6 +6,7 @@ extracting docs for src/DocExtraction2.resi
   "docstrings": ["Module level doc here."],
   "items": [
   {
+    "id": "DocExtraction2.t",
     "kind": "type",
     "name": "t",
     "signature": "type t",
@@ -13,6 +14,7 @@ extracting docs for src/DocExtraction2.resi
     "linkables": []
   }, 
   {
+    "id": "DocExtraction2.make",
     "kind": "value",
     "name": "make",
     "signature": "let make: unit => t",
@@ -24,6 +26,7 @@ extracting docs for src/DocExtraction2.resi
       }]
   }, 
   {
+    "id": "InnerModule.DocExtraction2",
     "kind": "module",
     "item": 
     {
@@ -31,6 +34,7 @@ extracting docs for src/DocExtraction2.resi
       "docstrings": [],
       "items": [
       {
+        "id": "DocExtraction2.InnerModule.t",
         "kind": "type",
         "name": "t",
         "signature": "type t",
@@ -38,6 +42,7 @@ extracting docs for src/DocExtraction2.resi
         "linkables": []
       }, 
       {
+        "id": "DocExtraction2.InnerModule.make",
         "kind": "value",
         "name": "make",
         "signature": "let make: unit => t",

--- a/analysis/tests/src/expected/DocExtraction2.resi.txt
+++ b/analysis/tests/src/expected/DocExtraction2.resi.txt
@@ -20,6 +20,7 @@ extracting docs for src/DocExtraction2.resi
     "signature": "let make: unit => t",
     "docstrings": ["Makerz of stuffz."],
     "linkables": [{
+        "linkId": "DocExtraction2.t",
         "path": "t",
         "moduleName": "DocExtraction2",
         "external": false
@@ -48,6 +49,7 @@ extracting docs for src/DocExtraction2.resi
         "signature": "let make: unit => t",
         "docstrings": ["Maker of tea."],
         "linkables": [{
+            "linkId": "DocExtraction2.t",
             "path": "t",
             "moduleName": "DocExtraction2",
             "external": false

--- a/analysis/tests/src/expected/DocExtraction2.resi.txt
+++ b/analysis/tests/src/expected/DocExtraction2.resi.txt
@@ -1,0 +1,54 @@
+Documentation extraction src/DocExtraction2.resi
+extracting docs for src/DocExtraction2.resi
+
+{
+  "name": "DocExtraction2",
+  "docstrings": ["Module level doc here."],
+  "items": [
+  {
+    "kind": "type",
+    "name": "t",
+    "signature": "type t",
+    "docstrings": ["Type t is pretty cool."],
+    "linkables": []
+  }, 
+  {
+    "kind": "value",
+    "name": "make",
+    "signature": "let make: unit => t",
+    "docstrings": ["Makerz of stuffz."],
+    "linkables": [{
+        "path": "t",
+        "moduleName": "DocExtraction2",
+        "external": false
+      }]
+  }, 
+  {
+    "kind": "module",
+    "item": 
+    {
+      "name": "InnerModule",
+      "docstrings": [],
+      "items": [
+      {
+        "kind": "type",
+        "name": "t",
+        "signature": "type t",
+        "docstrings": ["This type is also t."],
+        "linkables": []
+      }, 
+      {
+        "kind": "value",
+        "name": "make",
+        "signature": "let make: unit => t",
+        "docstrings": ["Maker of tea."],
+        "linkables": [{
+            "path": "t",
+            "moduleName": "DocExtraction2",
+            "external": false
+          }]
+      }]
+    }
+  }]
+}
+

--- a/analysis/tests/src/expected/DocExtraction2.resi.txt
+++ b/analysis/tests/src/expected/DocExtraction2.resi.txt
@@ -10,20 +10,14 @@ extracting docs for src/DocExtraction2.resi
     "kind": "type",
     "name": "t",
     "signature": "type t",
-    "docstrings": ["Type t is pretty cool."],
-    "linkables": []
+    "docstrings": ["Type t is pretty cool."]
   }, 
   {
     "id": "DocExtraction2.make",
     "kind": "value",
     "name": "make",
     "signature": "let make: unit => t",
-    "docstrings": ["Makerz of stuffz."],
-    "linkables": [{
-        "linkId": "DocExtraction2.t",
-        "name": "t",
-        "external": false
-      }]
+    "docstrings": ["Makerz of stuffz."]
   }, 
   {
     "id": "InnerModule.DocExtraction2",
@@ -38,20 +32,14 @@ extracting docs for src/DocExtraction2.resi
         "kind": "type",
         "name": "t",
         "signature": "type t",
-        "docstrings": ["This type is also t."],
-        "linkables": []
+        "docstrings": ["This type is also t."]
       }, 
       {
         "id": "DocExtraction2.InnerModule.make",
         "kind": "value",
         "name": "make",
         "signature": "let make: unit => t",
-        "docstrings": ["Maker of tea."],
-        "linkables": [{
-            "linkId": "DocExtraction2.InnerModule.t",
-            "name": "t",
-            "external": false
-          }]
+        "docstrings": ["Maker of tea."]
       }]
     }
   }]

--- a/analysis/tests/src/expected/DocExtraction2.resi.txt
+++ b/analysis/tests/src/expected/DocExtraction2.resi.txt
@@ -21,8 +21,7 @@ extracting docs for src/DocExtraction2.resi
     "docstrings": ["Makerz of stuffz."],
     "linkables": [{
         "linkId": "DocExtraction2.t",
-        "path": "t",
-        "moduleName": "DocExtraction2",
+        "name": "t",
         "external": false
       }]
   }, 
@@ -49,9 +48,8 @@ extracting docs for src/DocExtraction2.resi
         "signature": "let make: unit => t",
         "docstrings": ["Maker of tea."],
         "linkables": [{
-            "linkId": "DocExtraction2.t",
-            "path": "t",
-            "moduleName": "DocExtraction2",
+            "linkId": "DocExtraction2.InnerModule.t",
+            "name": "t",
             "external": false
           }]
       }]

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -1,0 +1,97 @@
+Documentation extraction src/DocExtractionRes.res
+extracting docs for src/DocExtractionRes.res
+
+{
+  "name": "DocExtractionRes",
+  "docstrings": ["Module level documentation goes here."],
+  "items": [
+  {
+    "kind": "type",
+    "name": "t",
+    "signature": "type t = {name: string, online: bool}",
+    "docstrings": ["This type represents stuff."],
+    "detail": 
+    {
+      "kind": "record",
+      "fieldDocs": [{
+        "fieldName": "name",
+        "docstrings": ["The name of the stuff."]
+      }, {
+        "fieldName": "online",
+        "docstrings": ["Whether stuff is online."]
+      }]
+    }
+  }, 
+  {
+    "kind": "value",
+    "name": "make",
+    "signature": "let make: string => t",
+    "docstrings": ["Create stuff.\\n\\n```rescript example\\nlet stuff = make(\\\"My name\\\")\\n```"]
+  }, 
+  {
+    "kind": "value",
+    "name": "asOffline",
+    "signature": "let asOffline: t => t",
+    "docstrings": ["Stuff goes offline."]
+  }, 
+  {
+    "kind": "module",
+    "item": 
+    {
+      "name": "SomeInnerModule",
+      "docstrings": ["Another module level docstring here."],
+      "items": [
+      {
+        "kind": "type",
+        "name": "status",
+        "signature": "type status = Started(t) | Stopped | Idle",
+        "docstrings": [],
+        "detail": 
+        {
+          "kind": "variant",
+          "fieldDocs": [
+          {
+            "constructorName": "Started",
+            "docstrings": ["If this is started or not"]
+          }, 
+          {
+            "constructorName": "Stopped",
+            "docstrings": ["Stopped?"]
+          }, 
+          {
+            "constructorName": "Idle",
+            "docstrings": ["Now idle."]
+          }]
+        }
+      }, 
+      {
+        "kind": "type",
+        "name": "validInputs",
+        "signature": "type validInputs = [\\n  | #\\\"needs-escaping\\\"\\n  | #something\\n  | #withPayload(int)\\n]",
+        "docstrings": ["These are all the valid inputs."]
+      }, 
+      {
+        "kind": "type",
+        "name": "callback",
+        "signature": "type callback = (t, ~status: status) => unit",
+        "docstrings": []
+      }]
+    }
+  }, 
+  {
+    "kind": "module",
+    "item": 
+    {
+      "name": "AnotherModule",
+      "docstrings": ["Mighty fine module here too!"],
+      "items": [
+      {
+        "kind": "type",
+        "name": "callback",
+        "signature": "type callback = SomeInnerModule.status => unit",
+        "docstrings": ["Testing what this looks like."]
+      }]
+    }
+  }]
+}
+

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -10,6 +10,7 @@ extracting docs for src/DocExtractionRes.res
     "name": "t",
     "signature": "type t = {name: string, online: bool}",
     "docstrings": ["This type represents stuff."],
+    "linkables": [],
     "detail": 
     {
       "kind": "record",
@@ -26,13 +27,23 @@ extracting docs for src/DocExtractionRes.res
     "kind": "value",
     "name": "make",
     "signature": "let make: string => t",
-    "docstrings": ["Create stuff.\\n\\n```rescript example\\nlet stuff = make(\\\"My name\\\")\\n```"]
+    "docstrings": ["Create stuff.\\n\\n```rescript example\\nlet stuff = make(\\\"My name\\\")\\n```"],
+    "linkables": [{
+        "path": "t",
+        "moduleName": "DocExtractionRes",
+        "external": false
+      }]
   }, 
   {
     "kind": "value",
     "name": "asOffline",
     "signature": "let asOffline: t => t",
-    "docstrings": ["Stuff goes offline."]
+    "docstrings": ["Stuff goes offline."],
+    "linkables": [{
+        "path": "t",
+        "moduleName": "DocExtractionRes",
+        "external": false
+      }]
   }, 
   {
     "kind": "module",
@@ -46,6 +57,11 @@ extracting docs for src/DocExtractionRes.res
         "name": "status",
         "signature": "type status = Started(t) | Stopped | Idle",
         "docstrings": [],
+        "linkables": [{
+            "path": "t",
+            "moduleName": "DocExtractionRes",
+            "external": false
+          }],
         "detail": 
         {
           "kind": "variant",
@@ -67,14 +83,24 @@ extracting docs for src/DocExtractionRes.res
       {
         "kind": "type",
         "name": "validInputs",
-        "signature": "type validInputs = [\\n  | #\\\"needs-escaping\\\"\\n  | #something\\n  | #withPayload(int)\\n]",
-        "docstrings": ["These are all the valid inputs."]
+        "signature": "type validInputs = [\\n  | #\\\"needs-escaping\\\"\\n  | #something\\n  | #status(status)\\n  | #withPayload(int)\\n]",
+        "docstrings": ["These are all the valid inputs."],
+        "linkables": []
       }, 
       {
         "kind": "type",
         "name": "callback",
         "signature": "type callback = (t, ~status: status) => unit",
-        "docstrings": []
+        "docstrings": [],
+        "linkables": [{
+            "path": "t",
+            "moduleName": "DocExtractionRes",
+            "external": false
+          }, {
+            "path": "status",
+            "moduleName": "DocExtractionRes",
+            "external": false
+          }]
       }]
     }
   }, 
@@ -89,7 +115,50 @@ extracting docs for src/DocExtractionRes.res
         "kind": "type",
         "name": "callback",
         "signature": "type callback = SomeInnerModule.status => unit",
-        "docstrings": ["Testing what this looks like."]
+        "docstrings": ["Testing what this looks like."],
+        "linkables": [{
+            "path": "SomeInnerModule.status",
+            "moduleName": "DocExtractionRes",
+            "external": false
+          }]
+      }, 
+      {
+        "kind": "value",
+        "name": "isGoodStatus",
+        "signature": "let isGoodStatus: SomeInnerModule.status => bool",
+        "docstrings": [],
+        "linkables": [{
+            "path": "SomeInnerModule.status",
+            "moduleName": "DocExtractionRes",
+            "external": false
+          }]
+      }, 
+      {
+        "kind": "type",
+        "name": "someVariantWithInlineRecords",
+        "signature": "type someVariantWithInlineRecords = SomeStuff({offline: bool})",
+        "docstrings": ["Trying how it looks with an inline record in a variant."],
+        "linkables": [],
+        "detail": 
+        {
+          "kind": "variant",
+          "fieldDocs": [
+          {
+            "constructorName": "SomeStuff",
+            "docstrings": ["This has inline records..."]
+          }]
+        }
+      }, 
+      {
+        "kind": "type",
+        "name": "domRoot",
+        "signature": "type domRoot = unit => ReactDOM.Client.Root.t",
+        "docstrings": ["Callback to get the DOM root..."],
+        "linkables": [{
+            "path": "ReactDOM.Client.Root.t",
+            "moduleName": "ReactDOM",
+            "external": true
+          }]
       }]
     }
   }]

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -36,8 +36,7 @@ extracting docs for src/DocExtractionRes.res
     "docstrings": ["Create stuff.\\n\\n```rescript example\\nlet stuff = make(\\\"My name\\\")\\n```"],
     "linkables": [{
         "linkId": "DocExtractionRes.t",
-        "path": "t",
-        "moduleName": "DocExtractionRes",
+        "name": "t",
         "external": false
       }]
   }, 
@@ -49,8 +48,7 @@ extracting docs for src/DocExtractionRes.res
     "docstrings": ["Stuff goes offline."],
     "linkables": [{
         "linkId": "DocExtractionRes.t",
-        "path": "t",
-        "moduleName": "DocExtractionRes",
+        "name": "t",
         "external": false
       }]
   }, 
@@ -70,8 +68,7 @@ extracting docs for src/DocExtractionRes.res
         "docstrings": [],
         "linkables": [{
             "linkId": "DocExtractionRes.t",
-            "path": "t",
-            "moduleName": "DocExtractionRes",
+            "name": "t",
             "external": false
           }],
         "detail": 
@@ -84,8 +81,7 @@ extracting docs for src/DocExtractionRes.res
             "signature": "Started(t)",
             "linkables": [{
               "linkId": "DocExtractionRes.t",
-              "path": "t",
-              "moduleName": "DocExtractionRes",
+              "name": "t",
               "external": false
             }]
           }, 
@@ -119,13 +115,11 @@ extracting docs for src/DocExtractionRes.res
         "docstrings": [],
         "linkables": [{
             "linkId": "DocExtractionRes.t",
-            "path": "t",
-            "moduleName": "DocExtractionRes",
+            "name": "t",
             "external": false
           }, {
-            "linkId": "DocExtractionRes.status",
-            "path": "status",
-            "moduleName": "DocExtractionRes",
+            "linkId": "DocExtractionRes.SomeInnerModule.status",
+            "name": "status",
             "external": false
           }]
       }]
@@ -147,8 +141,7 @@ extracting docs for src/DocExtractionRes.res
         "docstrings": ["Testing what this looks like."],
         "linkables": [{
             "linkId": "DocExtractionRes.SomeInnerModule.status",
-            "path": "SomeInnerModule.status",
-            "moduleName": "DocExtractionRes",
+            "name": "SomeInnerModule.status",
             "external": false
           }]
       }, 
@@ -160,8 +153,7 @@ extracting docs for src/DocExtractionRes.res
         "docstrings": [],
         "linkables": [{
             "linkId": "DocExtractionRes.SomeInnerModule.status",
-            "path": "SomeInnerModule.status",
-            "moduleName": "DocExtractionRes",
+            "name": "SomeInnerModule.status",
             "external": false
           }]
       }, 
@@ -192,8 +184,7 @@ extracting docs for src/DocExtractionRes.res
         "docstrings": ["Callback to get the DOM root..."],
         "linkables": [{
             "linkId": "ReactDOM.Client.Root.t",
-            "path": "ReactDOM.Client.Root.t",
-            "moduleName": "ReactDOM",
+            "name": "ReactDOM.Client.Root.t",
             "external": true
           }]
       }]
@@ -222,9 +213,8 @@ extracting docs for src/DocExtractionRes.res
         "signature": "let make: unit => t",
         "docstrings": ["The maker of stuff!"],
         "linkables": [{
-            "linkId": "DocExtractionRes.t",
-            "path": "t",
-            "moduleName": "DocExtractionRes",
+            "linkId": "DocExtractionRes.ModuleWithThingsThatShouldNotBeExported.t",
+            "name": "t",
             "external": false
           }]
       }]

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -33,6 +33,7 @@ extracting docs for src/DocExtractionRes.res
     "signature": "let make: string => t",
     "docstrings": ["Create stuff.\\n\\n```rescript example\\nlet stuff = make(\\\"My name\\\")\\n```"],
     "linkables": [{
+        "linkId": "DocExtractionRes.t",
         "path": "t",
         "moduleName": "DocExtractionRes",
         "external": false
@@ -45,6 +46,7 @@ extracting docs for src/DocExtractionRes.res
     "signature": "let asOffline: t => t",
     "docstrings": ["Stuff goes offline."],
     "linkables": [{
+        "linkId": "DocExtractionRes.t",
         "path": "t",
         "moduleName": "DocExtractionRes",
         "external": false
@@ -65,6 +67,7 @@ extracting docs for src/DocExtractionRes.res
         "signature": "type status = Started(t) | Stopped | Idle",
         "docstrings": [],
         "linkables": [{
+            "linkId": "DocExtractionRes.t",
             "path": "t",
             "moduleName": "DocExtractionRes",
             "external": false
@@ -105,10 +108,12 @@ extracting docs for src/DocExtractionRes.res
         "signature": "type callback = (t, ~status: status) => unit",
         "docstrings": [],
         "linkables": [{
+            "linkId": "DocExtractionRes.t",
             "path": "t",
             "moduleName": "DocExtractionRes",
             "external": false
           }, {
+            "linkId": "DocExtractionRes.status",
             "path": "status",
             "moduleName": "DocExtractionRes",
             "external": false
@@ -131,6 +136,7 @@ extracting docs for src/DocExtractionRes.res
         "signature": "type callback = SomeInnerModule.status => unit",
         "docstrings": ["Testing what this looks like."],
         "linkables": [{
+            "linkId": "DocExtractionRes.SomeInnerModule.status",
             "path": "SomeInnerModule.status",
             "moduleName": "DocExtractionRes",
             "external": false
@@ -143,6 +149,7 @@ extracting docs for src/DocExtractionRes.res
         "signature": "let isGoodStatus: SomeInnerModule.status => bool",
         "docstrings": [],
         "linkables": [{
+            "linkId": "DocExtractionRes.SomeInnerModule.status",
             "path": "SomeInnerModule.status",
             "moduleName": "DocExtractionRes",
             "external": false
@@ -173,6 +180,7 @@ extracting docs for src/DocExtractionRes.res
         "signature": "type domRoot = unit => ReactDOM.Client.Root.t",
         "docstrings": ["Callback to get the DOM root..."],
         "linkables": [{
+            "linkId": "ReactDOM.Client.Root.t",
             "path": "ReactDOM.Client.Root.t",
             "moduleName": "ReactDOM",
             "external": true
@@ -203,6 +211,7 @@ extracting docs for src/DocExtractionRes.res
         "signature": "let make: unit => t",
         "docstrings": ["The maker of stuff!"],
         "linkables": [{
+            "linkId": "DocExtractionRes.t",
             "path": "t",
             "moduleName": "DocExtractionRes",
             "external": false

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -18,11 +18,13 @@ extracting docs for src/DocExtractionRes.res
       "fieldDocs": [{
         "fieldName": "name",
         "docstrings": ["The name of the stuff."],
-        "signature": "string"
+        "signature": "string",
+        "linkables": []
       }, {
         "fieldName": "online",
         "docstrings": ["Whether stuff is online."],
-        "signature": "bool"
+        "signature": "bool",
+        "linkables": []
       }]
     }
   }, 
@@ -79,17 +81,25 @@ extracting docs for src/DocExtractionRes.res
           {
             "constructorName": "Started",
             "docstrings": ["If this is started or not"],
-            "signature": "Started(t)"
+            "signature": "Started(t)",
+            "linkables": [{
+              "linkId": "DocExtractionRes.t",
+              "path": "t",
+              "moduleName": "DocExtractionRes",
+              "external": false
+            }]
           }, 
           {
             "constructorName": "Stopped",
             "docstrings": ["Stopped?"],
-            "signature": "Stopped"
+            "signature": "Stopped",
+            "linkables": []
           }, 
           {
             "constructorName": "Idle",
             "docstrings": ["Now idle."],
-            "signature": "Idle"
+            "signature": "Idle",
+            "linkables": []
           }]
         }
       }, 
@@ -169,7 +179,8 @@ extracting docs for src/DocExtractionRes.res
           {
             "constructorName": "SomeStuff",
             "docstrings": ["This has inline records..."],
-            "signature": "SomeStuff"
+            "signature": "SomeStuff",
+            "linkables": []
           }]
         }
       }, 

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -99,6 +99,12 @@ extracting docs for src/DocExtractionRes.res
       "docstrings": ["Mighty fine module here too!"],
       "items": [
       {
+        "id": "DocExtractionRes.AnotherModule.SomeInnerModule",
+        "kind": "moduleAlias",
+        "docstrings": ["This links another module. Neat."],
+        "signature": "module LinkedModule = SomeInnerModule"
+      }, 
+      {
         "id": "DocExtractionRes.AnotherModule.callback",
         "kind": "type",
         "name": "callback",

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -33,7 +33,7 @@ extracting docs for src/DocExtractionRes.res
     "kind": "value",
     "name": "make",
     "signature": "let make: string => t",
-    "docstrings": ["Create stuff.\\n\\n```rescript example\\nlet stuff = make(\\\"My name\\\")\\n```"],
+    "docstrings": ["Create stuff.\n\n```rescript example\nlet stuff = make(\"My name\")\n```"],
     "linkables": [{
         "linkId": "DocExtractionRes.t",
         "name": "t",
@@ -74,7 +74,7 @@ extracting docs for src/DocExtractionRes.res
         "detail": 
         {
           "kind": "variant",
-          "fieldDocs": [
+          "constructorDocs": [
           {
             "constructorName": "Started",
             "docstrings": ["If this is started or not"],
@@ -167,7 +167,7 @@ extracting docs for src/DocExtractionRes.res
         "detail": 
         {
           "kind": "variant",
-          "fieldDocs": [
+          "constructorDocs": [
           {
             "constructorName": "SomeStuff",
             "docstrings": ["This has inline records..."],

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -161,6 +161,33 @@ extracting docs for src/DocExtractionRes.res
           }]
       }]
     }
+  }, 
+  {
+    "kind": "module",
+    "item": 
+    {
+      "name": "ModuleWithThingsThatShouldNotBeExported",
+      "docstrings": [],
+      "items": [
+      {
+        "kind": "type",
+        "name": "t",
+        "signature": "type t",
+        "docstrings": ["The type t is stuff."],
+        "linkables": []
+      }, 
+      {
+        "kind": "value",
+        "name": "make",
+        "signature": "let make: unit => t",
+        "docstrings": ["The maker of stuff!"],
+        "linkables": [{
+            "path": "t",
+            "moduleName": "DocExtractionRes",
+            "external": false
+          }]
+      }]
+    }
   }]
 }
 

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -11,20 +11,17 @@ extracting docs for src/DocExtractionRes.res
     "name": "t",
     "signature": "type t = {name: string, online: bool}",
     "docstrings": ["This type represents stuff."],
-    "linkables": [],
     "detail": 
     {
       "kind": "record",
       "fieldDocs": [{
         "fieldName": "name",
         "docstrings": ["The name of the stuff."],
-        "signature": "string",
-        "linkables": []
+        "signature": "string"
       }, {
         "fieldName": "online",
         "docstrings": ["Whether stuff is online."],
-        "signature": "bool",
-        "linkables": []
+        "signature": "bool"
       }]
     }
   }, 
@@ -33,24 +30,14 @@ extracting docs for src/DocExtractionRes.res
     "kind": "value",
     "name": "make",
     "signature": "let make: string => t",
-    "docstrings": ["Create stuff.\n\n```rescript example\nlet stuff = make(\"My name\")\n```"],
-    "linkables": [{
-        "linkId": "DocExtractionRes.t",
-        "name": "t",
-        "external": false
-      }]
+    "docstrings": ["Create stuff.\n\n```rescript example\nlet stuff = make(\"My name\")\n```"]
   }, 
   {
     "id": "DocExtractionRes.asOffline",
     "kind": "value",
     "name": "asOffline",
     "signature": "let asOffline: t => t",
-    "docstrings": ["Stuff goes offline."],
-    "linkables": [{
-        "linkId": "DocExtractionRes.t",
-        "name": "t",
-        "external": false
-      }]
+    "docstrings": ["Stuff goes offline."]
   }, 
   {
     "id": "SomeInnerModule.DocExtractionRes",
@@ -66,11 +53,6 @@ extracting docs for src/DocExtractionRes.res
         "name": "status",
         "signature": "type status = Started(t) | Stopped | Idle",
         "docstrings": [],
-        "linkables": [{
-            "linkId": "DocExtractionRes.t",
-            "name": "t",
-            "external": false
-          }],
         "detail": 
         {
           "kind": "variant",
@@ -78,24 +60,17 @@ extracting docs for src/DocExtractionRes.res
           {
             "constructorName": "Started",
             "docstrings": ["If this is started or not"],
-            "signature": "Started(t)",
-            "linkables": [{
-              "linkId": "DocExtractionRes.t",
-              "name": "t",
-              "external": false
-            }]
+            "signature": "Started(t)"
           }, 
           {
             "constructorName": "Stopped",
             "docstrings": ["Stopped?"],
-            "signature": "Stopped",
-            "linkables": []
+            "signature": "Stopped"
           }, 
           {
             "constructorName": "Idle",
             "docstrings": ["Now idle."],
-            "signature": "Idle",
-            "linkables": []
+            "signature": "Idle"
           }]
         }
       }, 
@@ -104,24 +79,14 @@ extracting docs for src/DocExtractionRes.res
         "kind": "type",
         "name": "validInputs",
         "signature": "type validInputs = [\\n  | #\\\"needs-escaping\\\"\\n  | #something\\n  | #status(status)\\n  | #withPayload(int)\\n]",
-        "docstrings": ["These are all the valid inputs."],
-        "linkables": []
+        "docstrings": ["These are all the valid inputs."]
       }, 
       {
         "id": "DocExtractionRes.SomeInnerModule.callback",
         "kind": "type",
         "name": "callback",
         "signature": "type callback = (t, ~status: status) => unit",
-        "docstrings": [],
-        "linkables": [{
-            "linkId": "DocExtractionRes.t",
-            "name": "t",
-            "external": false
-          }, {
-            "linkId": "DocExtractionRes.SomeInnerModule.status",
-            "name": "status",
-            "external": false
-          }]
+        "docstrings": []
       }]
     }
   }, 
@@ -138,24 +103,14 @@ extracting docs for src/DocExtractionRes.res
         "kind": "type",
         "name": "callback",
         "signature": "type callback = SomeInnerModule.status => unit",
-        "docstrings": ["Testing what this looks like."],
-        "linkables": [{
-            "linkId": "DocExtractionRes.SomeInnerModule.status",
-            "name": "SomeInnerModule.status",
-            "external": false
-          }]
+        "docstrings": ["Testing what this looks like."]
       }, 
       {
         "id": "DocExtractionRes.AnotherModule.isGoodStatus",
         "kind": "value",
         "name": "isGoodStatus",
         "signature": "let isGoodStatus: SomeInnerModule.status => bool",
-        "docstrings": [],
-        "linkables": [{
-            "linkId": "DocExtractionRes.SomeInnerModule.status",
-            "name": "SomeInnerModule.status",
-            "external": false
-          }]
+        "docstrings": []
       }, 
       {
         "id": "DocExtractionRes.AnotherModule.someVariantWithInlineRecords",
@@ -163,7 +118,6 @@ extracting docs for src/DocExtractionRes.res
         "name": "someVariantWithInlineRecords",
         "signature": "type someVariantWithInlineRecords = SomeStuff({offline: bool})",
         "docstrings": ["Trying how it looks with an inline record in a variant."],
-        "linkables": [],
         "detail": 
         {
           "kind": "variant",
@@ -171,8 +125,7 @@ extracting docs for src/DocExtractionRes.res
           {
             "constructorName": "SomeStuff",
             "docstrings": ["This has inline records..."],
-            "signature": "SomeStuff",
-            "linkables": []
+            "signature": "SomeStuff"
           }]
         }
       }, 
@@ -181,12 +134,7 @@ extracting docs for src/DocExtractionRes.res
         "kind": "type",
         "name": "domRoot",
         "signature": "type domRoot = unit => ReactDOM.Client.Root.t",
-        "docstrings": ["Callback to get the DOM root..."],
-        "linkables": [{
-            "linkId": "ReactDOM.Client.Root.t",
-            "name": "ReactDOM.Client.Root.t",
-            "external": true
-          }]
+        "docstrings": ["Callback to get the DOM root..."]
       }]
     }
   }, 
@@ -203,20 +151,14 @@ extracting docs for src/DocExtractionRes.res
         "kind": "type",
         "name": "t",
         "signature": "type t",
-        "docstrings": ["The type t is stuff."],
-        "linkables": []
+        "docstrings": ["The type t is stuff."]
       }, 
       {
         "id": "DocExtractionRes.ModuleWithThingsThatShouldNotBeExported.make",
         "kind": "value",
         "name": "make",
         "signature": "let make: unit => t",
-        "docstrings": ["The maker of stuff!"],
-        "linkables": [{
-            "linkId": "DocExtractionRes.ModuleWithThingsThatShouldNotBeExported.t",
-            "name": "t",
-            "external": false
-          }]
+        "docstrings": ["The maker of stuff!"]
       }]
     }
   }]

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -6,6 +6,7 @@ extracting docs for src/DocExtractionRes.res
   "docstrings": ["Module level documentation goes here."],
   "items": [
   {
+    "id": "DocExtractionRes.t",
     "kind": "type",
     "name": "t",
     "signature": "type t = {name: string, online: bool}",
@@ -16,14 +17,17 @@ extracting docs for src/DocExtractionRes.res
       "kind": "record",
       "fieldDocs": [{
         "fieldName": "name",
-        "docstrings": ["The name of the stuff."]
+        "docstrings": ["The name of the stuff."],
+        "signature": "string"
       }, {
         "fieldName": "online",
-        "docstrings": ["Whether stuff is online."]
+        "docstrings": ["Whether stuff is online."],
+        "signature": "bool"
       }]
     }
   }, 
   {
+    "id": "DocExtractionRes.make",
     "kind": "value",
     "name": "make",
     "signature": "let make: string => t",
@@ -35,6 +39,7 @@ extracting docs for src/DocExtractionRes.res
       }]
   }, 
   {
+    "id": "DocExtractionRes.asOffline",
     "kind": "value",
     "name": "asOffline",
     "signature": "let asOffline: t => t",
@@ -46,6 +51,7 @@ extracting docs for src/DocExtractionRes.res
       }]
   }, 
   {
+    "id": "SomeInnerModule.DocExtractionRes",
     "kind": "module",
     "item": 
     {
@@ -53,6 +59,7 @@ extracting docs for src/DocExtractionRes.res
       "docstrings": ["Another module level docstring here."],
       "items": [
       {
+        "id": "DocExtractionRes.SomeInnerModule.status",
         "kind": "type",
         "name": "status",
         "signature": "type status = Started(t) | Stopped | Idle",
@@ -68,19 +75,23 @@ extracting docs for src/DocExtractionRes.res
           "fieldDocs": [
           {
             "constructorName": "Started",
-            "docstrings": ["If this is started or not"]
+            "docstrings": ["If this is started or not"],
+            "signature": "Started(t)"
           }, 
           {
             "constructorName": "Stopped",
-            "docstrings": ["Stopped?"]
+            "docstrings": ["Stopped?"],
+            "signature": "Stopped"
           }, 
           {
             "constructorName": "Idle",
-            "docstrings": ["Now idle."]
+            "docstrings": ["Now idle."],
+            "signature": "Idle"
           }]
         }
       }, 
       {
+        "id": "DocExtractionRes.SomeInnerModule.validInputs",
         "kind": "type",
         "name": "validInputs",
         "signature": "type validInputs = [\\n  | #\\\"needs-escaping\\\"\\n  | #something\\n  | #status(status)\\n  | #withPayload(int)\\n]",
@@ -88,6 +99,7 @@ extracting docs for src/DocExtractionRes.res
         "linkables": []
       }, 
       {
+        "id": "DocExtractionRes.SomeInnerModule.callback",
         "kind": "type",
         "name": "callback",
         "signature": "type callback = (t, ~status: status) => unit",
@@ -105,6 +117,7 @@ extracting docs for src/DocExtractionRes.res
     }
   }, 
   {
+    "id": "AnotherModule.DocExtractionRes",
     "kind": "module",
     "item": 
     {
@@ -112,6 +125,7 @@ extracting docs for src/DocExtractionRes.res
       "docstrings": ["Mighty fine module here too!"],
       "items": [
       {
+        "id": "DocExtractionRes.AnotherModule.callback",
         "kind": "type",
         "name": "callback",
         "signature": "type callback = SomeInnerModule.status => unit",
@@ -123,6 +137,7 @@ extracting docs for src/DocExtractionRes.res
           }]
       }, 
       {
+        "id": "DocExtractionRes.AnotherModule.isGoodStatus",
         "kind": "value",
         "name": "isGoodStatus",
         "signature": "let isGoodStatus: SomeInnerModule.status => bool",
@@ -134,6 +149,7 @@ extracting docs for src/DocExtractionRes.res
           }]
       }, 
       {
+        "id": "DocExtractionRes.AnotherModule.someVariantWithInlineRecords",
         "kind": "type",
         "name": "someVariantWithInlineRecords",
         "signature": "type someVariantWithInlineRecords = SomeStuff({offline: bool})",
@@ -145,11 +161,13 @@ extracting docs for src/DocExtractionRes.res
           "fieldDocs": [
           {
             "constructorName": "SomeStuff",
-            "docstrings": ["This has inline records..."]
+            "docstrings": ["This has inline records..."],
+            "signature": "SomeStuff"
           }]
         }
       }, 
       {
+        "id": "DocExtractionRes.AnotherModule.domRoot",
         "kind": "type",
         "name": "domRoot",
         "signature": "type domRoot = unit => ReactDOM.Client.Root.t",
@@ -163,6 +181,7 @@ extracting docs for src/DocExtractionRes.res
     }
   }, 
   {
+    "id": "ModuleWithThingsThatShouldNotBeExported.DocExtractionRes",
     "kind": "module",
     "item": 
     {
@@ -170,6 +189,7 @@ extracting docs for src/DocExtractionRes.res
       "docstrings": [],
       "items": [
       {
+        "id": "DocExtractionRes.ModuleWithThingsThatShouldNotBeExported.t",
         "kind": "type",
         "name": "t",
         "signature": "type t",
@@ -177,6 +197,7 @@ extracting docs for src/DocExtractionRes.res
         "linkables": []
       }, 
       {
+        "id": "DocExtractionRes.ModuleWithThingsThatShouldNotBeExported.make",
         "kind": "value",
         "name": "make",
         "signature": "let make: unit => t",

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -6,6 +6,7 @@ import {
 } from "./commands/code_analysis";
 
 export { createInterface } from "./commands/create_interface";
+export { extractDocs } from "./commands/extract_docs";
 export { openCompiled } from "./commands/open_compiled";
 export { switchImplIntf } from "./commands/switch_impl_intf";
 

--- a/client/src/commands/extract_docs.ts
+++ b/client/src/commands/extract_docs.ts
@@ -1,0 +1,50 @@
+import * as p from "vscode-languageserver-protocol";
+import { LanguageClient, RequestType } from "vscode-languageclient/node";
+import { Position, Uri, window, workspace, WorkspaceEdit } from "vscode";
+import path = require("path");
+
+export const extractDocsRequest = new RequestType<
+  p.TextDocumentIdentifier,
+  string,
+  void
+>("textDocument/extractDocs");
+
+export const extractDocs = async (client: LanguageClient) => {
+  if (!client) {
+    return window.showInformationMessage("Language server not running");
+  }
+
+  const editor = window.activeTextEditor;
+
+  if (!editor) {
+    return window.showInformationMessage("No active editor");
+  }
+
+  try {
+    const docUri = editor.document.uri.toString();
+    const res = await client.sendRequest(extractDocsRequest, {
+      uri: docUri,
+    });
+
+    const newFile = Uri.parse(
+      "untitled:" +
+        path.join(
+          workspace.workspaceFolders[0].uri.fsPath,
+          `${path.basename(docUri)}.json`
+        )
+    );
+    workspace.openTextDocument(newFile).then((document) => {
+      const edit = new WorkspaceEdit();
+      edit.insert(newFile, new Position(0, 0), JSON.stringify(res, null, 2));
+      return workspace.applyEdit(edit).then((success) => {
+        if (success) {
+          window.showTextDocument(document);
+        } else {
+          window.showInformationMessage("Error!");
+        }
+      });
+    });
+  } catch (e) {
+    console.error("failed", e);
+  }
+};

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -201,6 +201,10 @@ export function activate(context: ExtensionContext) {
     customCommands.openCompiled(client);
   });
 
+  commands.registerCommand("rescript-vscode.extract_docs", () => {
+    customCommands.extractDocs(client);
+  });
+
   commands.registerCommand(
     "rescript-vscode.go_to_location",
     async (fileUri: string, startLine: number, startCol: number) => {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
 				"title": "ReScript: Create an interface file for this implementation file"
 			},
 			{
+				"command": "rescript-vscode.extract_docs",
+				"title": "ReScript: Extract documentation as JSON for file."
+			},
+			{
 				"command": "rescript-vscode.open_compiled",
 				"category": "ReScript",
 				"title": "Open the compiled JS file for this implementation file",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -152,6 +152,12 @@ let openCompiledFileRequest = new v.RequestType<
   void
 >("textDocument/openCompiled");
 
+let extractDocsRequest = new v.RequestType<
+  p.TextDocumentIdentifier,
+  p.TextDocumentIdentifier,
+  void
+>("textDocument/extractDocs");
+
 let getCurrentCompilerDiagnosticsForFile = (
   fileUri: string
 ): p.Diagnostic[] => {
@@ -965,6 +971,24 @@ function createInterface(msg: p.RequestMessage): p.Message {
   }
 }
 
+function extractDocs(msg: p.RequestMessage): p.Message {
+  let params = msg.params as p.TextDocumentIdentifier;
+  let filePath = fileURLToPath(params.uri);
+
+  let response = utils.runAnalysisCommand(
+    filePath,
+    ["extractDocs", filePath],
+    msg
+  );
+
+  let res: p.ResponseMessage = {
+    jsonrpc: c.jsonrpcVersion,
+    id: msg.id,
+    result: response.result,
+  };
+  return res;
+}
+
 function openCompiledFile(msg: p.RequestMessage): p.Message {
   let params = msg.params as p.TextDocumentIdentifier;
   let filePath = fileURLToPath(params.uri);
@@ -1230,6 +1254,8 @@ function onMessage(msg: p.Message) {
       send(createInterface(msg));
     } else if (msg.method === openCompiledFileRequest.method) {
       send(openCompiledFile(msg));
+    } else if (msg.method === extractDocsRequest.method) {
+      send(extractDocs(msg));
     } else if (msg.method === p.InlayHintRequest.method) {
       let params = msg.params as InlayHintParams;
       let extName = path.extname(params.textDocument.uri);


### PR DESCRIPTION
This PR add more information to output:

1. Emit an `optional` field for optional fields in records.
2. Emit a `location` field for the location of the function, module or type in the source file.
3. Emit two field when `@deprecated` or `@@deprecated` attribute is used. 
   - `deprecated` is a bool
   - `deprecatedMessage` is a string.


Continuation of #732 