### PR TITLE
revamp insert missing cases code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Add support for syntax highlighting in `%raw` and `%ffi` extension points. https://github.com/rescript-lang/rescript-vscode/pull/774
 - Add completion to top level decorators. https://github.com/rescript-lang/rescript-vscode/pull/799
 
+#### :nail_care: Polish
+
+- Revamp "Insert missing cases" code action to make it apply in more cases and be much more robust. https://github.com/rescript-lang/rescript-vscode/pull/804
+
 #### :bug: Bug Fix
 
 - Fix invalid range for `definition`. https://github.com/rescript-lang/rescript-vscode/pull/781

--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -124,6 +124,19 @@ let main () =
     Commands.codeAction ~path
       ~pos:(int_of_string line, int_of_string col)
       ~currentFile ~debug:false
+  | [_; "codemod"; path; line; col; typ; hint] ->
+    let typ =
+      match typ with
+      | "add-missing-cases" -> Codemod.AddMissingCases
+      | _ -> raise (Failure "unsupported type")
+    in
+    let res =
+      Codemod.transform ~path
+        ~pos:(int_of_string line, int_of_string col)
+        ~debug:false ~typ ~hint
+      |> Json.escape
+    in
+    Printf.printf "\"%s\"" res
   | [_; "diagnosticSyntax"; path] -> Commands.diagnosticSyntax ~path
   | _ :: "reanalyze" :: _ ->
     let len = Array.length Sys.argv in

--- a/analysis/src/Codemod.ml
+++ b/analysis/src/Codemod.ml
@@ -1,0 +1,52 @@
+type transformType = AddMissingCases
+
+let rec collectPatterns p =
+  match p.Parsetree.ppat_desc with
+  | Ppat_or (p1, p2) -> collectPatterns p1 @ [p2]
+  | _ -> [p]
+
+let mkFailWithExp () =
+  Ast_helper.Exp.apply
+    (Ast_helper.Exp.ident {txt = Lident "failwith"; loc = Location.none})
+    [(Nolabel, Ast_helper.Exp.constant (Pconst_string ("TODO", None)))]
+
+let transform ~path ~pos ~debug ~typ ~hint =
+  let structure, printExpr, _ = Xform.parseImplementation ~filename:path in
+  match typ with
+  | AddMissingCases -> (
+    let source = "let " ^ hint ^ " = ()" in
+    let {Res_driver.parsetree = hintStructure} =
+      Res_driver.parseImplementationFromSource ~forPrinter:false
+        ~displayFilename:"<none>" ~source
+    in
+    match hintStructure with
+    | [{pstr_desc = Pstr_value (_, [{pvb_pat = pattern}])}] -> (
+      let cases =
+        collectPatterns pattern
+        |> List.map (fun (p : Parsetree.pattern) ->
+               Ast_helper.Exp.case p (mkFailWithExp ()))
+      in
+      let result = ref None in
+      let mkIterator ~pos ~result =
+        let expr (iterator : Ast_iterator.iterator) (exp : Parsetree.expression)
+            =
+          match exp.pexp_desc with
+          | Pexp_match (e, existingCases)
+            when Pos.ofLexing exp.pexp_loc.loc_start = pos ->
+            result :=
+              Some {exp with pexp_desc = Pexp_match (e, existingCases @ cases)}
+          | _ -> Ast_iterator.default_iterator.expr iterator exp
+        in
+        {Ast_iterator.default_iterator with expr}
+      in
+      let iterator = mkIterator ~pos ~result in
+      iterator.structure iterator structure;
+      match !result with
+      | None ->
+        if debug then print_endline "Found no result";
+        exit 1
+      | Some switchExpr ->
+        printExpr ~range:(Xform.rangeOfLoc switchExpr.pexp_loc) switchExpr)
+    | _ ->
+      if debug then print_endline "Mismatch in expected structure";
+      exit 1)

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -392,6 +392,14 @@ let test ~path =
                                  Printf.printf "%s\nnewText:\n%s<--here\n%s%s\n"
                                    (Protocol.stringifyRange range)
                                    indent indent newText)))
+          | "c-a" ->
+            let hint = String.sub rest 3 (String.length rest - 3) in
+            print_endline
+              ("Codemod AddMissingCases" ^ path ^ " " ^ string_of_int line ^ ":"
+             ^ string_of_int col);
+            Codemod.transform ~path ~pos:(line, col) ~debug:true
+              ~typ:AddMissingCases ~hint
+            |> print_endline
           | "dia" -> diagnosticSyntax ~path
           | "hin" ->
             (* Get all inlay Hint between line 1 and n.

--- a/analysis/tests/bsconfig.json
+++ b/analysis/tests/bsconfig.json
@@ -9,7 +9,7 @@
       "subdirs": true
     }
   ],
-  "bsc-flags": ["-w -33-44"],
+  "bsc-flags": ["-w -33-44-8"],
   "bs-dependencies": ["@rescript/react"],
   "jsx": { "version": 3 }
 }

--- a/analysis/tests/src/Codemod.res
+++ b/analysis/tests/src/Codemod.res
@@ -1,0 +1,9 @@
+type someTyp = [#valid | #invalid]
+
+let ff = (v1: someTyp, v2: someTyp) => {
+  let x = switch (v1, v2) {
+  //      ^c-a (#valid, #valid) | (#invalid, _)
+  | (#valid, #invalid) => ()
+  }
+  x
+}

--- a/analysis/tests/src/expected/Codemod.res.txt
+++ b/analysis/tests/src/expected/Codemod.res.txt
@@ -1,0 +1,8 @@
+Codemod AddMissingCasessrc/Codemod.res 3:10
+switch (v1, v2) {
+          //      ^c-a (#valid, #valid) | (#invalid, _)
+          | (#valid, #invalid) => ()
+          | (#valid, #valid) => failwith("TODO")
+          | (#invalid, _) => failwith("TODO")
+          }
+


### PR DESCRIPTION
This revamps the current "Insert missing cases" code action by leveraging actual AST transforms to produce the updated switch code instead of relying on unstable and ad hoc string parsing. This is now possible thanks to the compiler printing the cases in ReScript syntax rather than OCaml syntax.

Example:
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/0f029a81-0dda-47b9-8172-d3365b794d5c)
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/eb8d5f7a-a5d8-44d4-ba5c-3f4f478c0fb6)
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/08ee3cfe-58af-437f-813f-51fb3522d1aa)
