### PR TITLE
Code action: Wrap in Some

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Add support for syntax highlighting in `%raw` and `%ffi` extension points. https://github.com/rescript-lang/rescript-vscode/pull/774
 - Add completion to top level decorators. https://github.com/rescript-lang/rescript-vscode/pull/799
+- Add code action for wrapping patterns where option is expected with `Some`. https://github.com/rescript-lang/rescript-vscode/pull/806
 
 #### :nail_care: Polish
 

--- a/server/src/codeActions.ts
+++ b/server/src/codeActions.ts
@@ -277,8 +277,6 @@ let wrapInSome: codeActionExtractor = ({
         "but a pattern was expected which matches values of type"
       );
 
-      console.log({ typ });
-
       if (typ.trim() === "") {
         // Type is on the next line
         typ = (restOfMessage[lineIndexWithType + 1] ?? "").trim();


### PR DESCRIPTION
Allows for easily wrapping a pattern where an option is expected in `Some`. Useful as you change patterns from non-options to options, and need to update all parts of the pattern to be wrapped in `Some`.

Based on https://github.com/rescript-lang/rescript-vscode/pull/804 so that needs merging first.