### PR TITLE
Code actions for exhaustive switches

### DIFF
--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -120,9 +120,11 @@ let main () =
       ~pos:(int_of_string line_start, int_of_string line_end)
       ~maxLength ~debug:false
   | [_; "codeLens"; path] -> Commands.codeLens ~path ~debug:false
-  | [_; "codeAction"; path; line; col; currentFile] ->
+  | [_; "codeAction"; path; startLine; startCol; endLine; endCol; currentFile]
+    ->
     Commands.codeAction ~path
-      ~pos:(int_of_string line, int_of_string col)
+      ~startPos:(int_of_string startLine, int_of_string startCol)
+      ~endPos:(int_of_string endLine, int_of_string endCol)
       ~currentFile ~debug:false
   | [_; "codemod"; path; line; col; typ; hint] ->
     let typ =

--- a/analysis/src/Codemod.ml
+++ b/analysis/src/Codemod.ml
@@ -5,11 +5,6 @@ let rec collectPatterns p =
   | Ppat_or (p1, p2) -> collectPatterns p1 @ [p2]
   | _ -> [p]
 
-let mkFailWithExp () =
-  Ast_helper.Exp.apply
-    (Ast_helper.Exp.ident {txt = Lident "failwith"; loc = Location.none})
-    [(Nolabel, Ast_helper.Exp.constant (Pconst_string ("TODO", None)))]
-
 let transform ~path ~pos ~debug ~typ ~hint =
   let structure, printExpr, _ = Xform.parseImplementation ~filename:path in
   match typ with
@@ -24,7 +19,7 @@ let transform ~path ~pos ~debug ~typ ~hint =
       let cases =
         collectPatterns pattern
         |> List.map (fun (p : Parsetree.pattern) ->
-               Ast_helper.Exp.case p (mkFailWithExp ()))
+               Ast_helper.Exp.case p (TypeUtils.Codegen.mkFailWithExp ()))
       in
       let result = ref None in
       let mkIterator ~pos ~result =

--- a/analysis/src/Loc.ml
+++ b/analysis/src/Loc.ml
@@ -8,3 +8,7 @@ let toString (loc : t) =
   (if loc.loc_ghost then "__ghost__" else "") ^ (loc |> range |> Range.toString)
 
 let hasPos ~pos loc = start loc <= pos && pos < end_ loc
+
+(** Allows the character after the end to be included. Ie when the cursor is at the 
+    end of the word, like `someIdentifier<cursor>`. Useful in some scenarios. *)
+let hasPosInclusiveEnd ~pos loc = start loc <= pos && pos <= end_ loc

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -370,7 +370,7 @@ module ExhaustiveSwitch = struct
       | Some extractedType -> (
         let open TypeUtils.Codegen in
         let exhaustiveSwitch =
-          extractedTypeToExhaustiveCases2
+          extractedTypeToExhaustiveCases
             ~env:(SharedTypes.QueryEnv.fromFile full.file)
             ~full extractedType
         in
@@ -395,7 +395,7 @@ module ExhaustiveSwitch = struct
       | Some extractedType -> (
         let open TypeUtils.Codegen in
         let exhaustiveSwitch =
-          extractedTypeToExhaustiveCases2
+          extractedTypeToExhaustiveCases
             ~env:(SharedTypes.QueryEnv.fromFile full.file)
             ~full extractedType
         in

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -369,7 +369,11 @@ module ExhaustiveSwitch = struct
       | None -> ()
       | Some extractedType -> (
         let open TypeUtils.Codegen in
-        let exhaustiveSwitch = extractedTypeToExhaustiveCases extractedType in
+        let exhaustiveSwitch =
+          extractedTypeToExhaustiveCases2
+            ~env:(SharedTypes.QueryEnv.fromFile full.file)
+            ~full extractedType
+        in
         match exhaustiveSwitch with
         | None -> ()
         | Some cases ->
@@ -390,7 +394,11 @@ module ExhaustiveSwitch = struct
       | None -> ()
       | Some extractedType -> (
         let open TypeUtils.Codegen in
-        let exhaustiveSwitch = extractedTypeToExhaustiveCases extractedType in
+        let exhaustiveSwitch =
+          extractedTypeToExhaustiveCases2
+            ~env:(SharedTypes.QueryEnv.fromFile full.file)
+            ~full extractedType
+        in
         match exhaustiveSwitch with
         | None -> ()
         | Some cases ->

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -255,6 +255,157 @@ module AddTypeAnnotation = struct
         | _ -> ()))
 end
 
+module ExhaustiveSwitch = struct
+  (* Expand expression to be an exhaustive switch of the underlying value *)
+  type posType = Single of Pos.t | Range of Pos.t * Pos.t
+
+  type completionType =
+    | Switch of {
+        pos: Pos.t;
+        switchExpr: Parsetree.expression;
+        completionExpr: Parsetree.expression;
+      }
+    | Selection of {expr: Parsetree.expression}
+
+  module C = struct
+    let extractTypeFromExpr expr ~debug ~path ~currentFile ~full ~pos =
+      match
+        expr.Parsetree.pexp_loc
+        |> CompletionFrontEnd.findTypeOfExpressionAtLoc ~debug ~path
+             ~currentFile
+             ~posCursor:(Pos.ofLexing expr.Parsetree.pexp_loc.loc_start)
+      with
+      | Some (completable, scope) -> (
+        let env = SharedTypes.QueryEnv.fromFile full.SharedTypes.file in
+        let completions =
+          completable
+          |> CompletionBackEnd.processCompletable ~debug ~full ~pos ~scope ~env
+               ~forHover:true
+        in
+        let rawOpens = Scope.getRawOpens scope in
+        match completions with
+        | {env} :: _ -> (
+          let opens =
+            CompletionBackEnd.getOpens ~debug ~rawOpens ~package:full.package
+              ~env
+          in
+          match
+            CompletionBackEnd.completionsGetCompletionType2 ~debug ~full
+              ~rawOpens ~opens ~pos ~scope completions
+          with
+          | Some (typ, _env) ->
+            let extractedType =
+              match typ with
+              | ExtractedType t -> Some t
+              | TypeExpr t -> TypeUtils.extractType t ~env ~package:full.package
+            in
+            extractedType
+          | None -> None)
+        | _ -> None)
+      | _ -> None
+  end
+
+  let mkIteratorSingle ~pos ~result =
+    let expr (iterator : Ast_iterator.iterator) (exp : Parsetree.expression) =
+      (match exp.pexp_desc with
+      | Pexp_ident _ when Loc.hasPosInclusiveEnd ~pos exp.pexp_loc ->
+        (* Exhaustive switch for having the cursor on an identifier. *)
+        result := Some (Selection {expr = exp})
+      | Pexp_match (completionExpr, [])
+        when Loc.hasPosInclusiveEnd ~pos exp.pexp_loc ->
+        (* No cases means there's no `|` yet in the switch, so `switch someExpr` *)
+        result := Some (Switch {pos; switchExpr = exp; completionExpr})
+      | _ -> ());
+      Ast_iterator.default_iterator.expr iterator exp
+    in
+    {Ast_iterator.default_iterator with expr}
+
+  let mkIteratorRange ~startPos ~endPos ~foundSelection =
+    let expr (iterator : Ast_iterator.iterator) (exp : Parsetree.expression) =
+      let expStartPos = Pos.ofLexing exp.pexp_loc.loc_start in
+      let expEndPos = Pos.ofLexing exp.pexp_loc.loc_end in
+
+      (if expStartPos = startPos then
+       match !foundSelection with
+       | None, endExpr -> foundSelection := (Some exp, endExpr)
+       | _ -> ());
+
+      (if expEndPos = endPos then
+       match !foundSelection with
+       | startExp, _ -> foundSelection := (startExp, Some exp));
+
+      Ast_iterator.default_iterator.expr iterator exp
+    in
+    {Ast_iterator.default_iterator with expr}
+
+  let xform ~printExpr ~path ~currentFile ~pos ~full ~structure ~codeActions
+      ~debug =
+    (* TODO: Adapt to '(' as leading/trailing character (skip one col, it's not included in the AST) *)
+    let result = ref None in
+    let foundSelection = ref (None, None) in
+    let iterator =
+      match pos with
+      | Single pos -> mkIteratorSingle ~pos ~result
+      | Range (startPos, endPos) ->
+        mkIteratorRange ~startPos ~endPos ~foundSelection
+    in
+    iterator.structure iterator structure;
+    (match !foundSelection with
+    | Some startExp, Some endExp ->
+      if debug then
+        Printf.printf "found selection: %s -> %s\n"
+          (Loc.toString startExp.pexp_loc)
+          (Loc.toString endExp.pexp_loc);
+      result := Some (Selection {expr = startExp})
+    | _ -> ());
+    match !result with
+    | None -> ()
+    | Some (Selection {expr}) -> (
+      match
+        expr
+        |> C.extractTypeFromExpr ~debug ~path ~currentFile ~full
+             ~pos:(Pos.ofLexing expr.pexp_loc.loc_start)
+      with
+      | None -> ()
+      | Some extractedType -> (
+        let open TypeUtils.Codegen in
+        let exhaustiveSwitch = extractedTypeToExhaustiveCases extractedType in
+        match exhaustiveSwitch with
+        | None -> ()
+        | Some cases ->
+          let range = rangeOfLoc expr.pexp_loc in
+          let newText =
+            printExpr ~range {expr with pexp_desc = Pexp_match (expr, cases)}
+          in
+          let codeAction =
+            CodeActions.make ~title:"Exhaustive switch" ~kind:RefactorRewrite
+              ~uri:path ~newText ~range
+          in
+          codeActions := codeAction :: !codeActions))
+    | Some (Switch {switchExpr; completionExpr; pos}) -> (
+      match
+        completionExpr
+        |> C.extractTypeFromExpr ~debug ~path ~currentFile ~full ~pos
+      with
+      | None -> ()
+      | Some extractedType -> (
+        let open TypeUtils.Codegen in
+        let exhaustiveSwitch = extractedTypeToExhaustiveCases extractedType in
+        match exhaustiveSwitch with
+        | None -> ()
+        | Some cases ->
+          let range = rangeOfLoc switchExpr.pexp_loc in
+          let newText =
+            printExpr ~range
+              {switchExpr with pexp_desc = Pexp_match (completionExpr, cases)}
+          in
+          let codeAction =
+            CodeActions.make ~title:"Exhaustive switch" ~kind:RefactorRewrite
+              ~uri:path ~newText ~range
+          in
+          codeActions := codeAction :: !codeActions))
+end
+
 module AddDocTemplate = struct
   let createTemplate () =
     let docContent = ["\n"; "\n"] in
@@ -488,7 +639,8 @@ let parseInterface ~filename =
   in
   (structure, printSignatureItem)
 
-let extractCodeActions ~path ~pos ~currentFile ~debug =
+let extractCodeActions ~path ~startPos ~endPos ~currentFile ~debug =
+  let pos = startPos in
   let codeActions = ref [] in
   match Files.classifySourceFile currentFile with
   | Res ->
@@ -504,7 +656,12 @@ let extractCodeActions ~path ~pos ~currentFile ~debug =
     let () =
       match Cmt.loadFullCmtFromPath ~path with
       | Some full ->
-        AddTypeAnnotation.xform ~path ~pos ~full ~structure ~codeActions ~debug
+        AddTypeAnnotation.xform ~path ~pos ~full ~structure ~codeActions ~debug;
+        ExhaustiveSwitch.xform ~printExpr ~path
+          ~pos:
+            (if startPos = endPos then Single startPos
+            else Range (startPos, endPos))
+          ~full ~structure ~codeActions ~debug ~currentFile
       | None -> ()
     in
 

--- a/analysis/tests/src/ExhaustiveSwitch.res
+++ b/analysis/tests/src/ExhaustiveSwitch.res
@@ -17,3 +17,22 @@ let someOpt = Some(true)
 
 // switch someOp
 //              ^com
+
+type rcrd = {someVariant: someVariant}
+
+let getV = r => r.someVariant
+
+let x: rcrd = {
+  someVariant: One,
+}
+
+let vvv = x->getV
+
+// switch x->getV
+//           ^xfm
+
+// x->getV
+// ^xfm  ^
+
+// vvv
+//  ^xfm

--- a/analysis/tests/src/ExhaustiveSwitch.res
+++ b/analysis/tests/src/ExhaustiveSwitch.res
@@ -26,7 +26,7 @@ let x: rcrd = {
   someVariant: One,
 }
 
-let vvv = x->getV
+let vvv = Some(x->getV)
 
 // switch x->getV
 //           ^xfm

--- a/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -94,3 +94,56 @@ Path someOp
     "insertTextFormat": 2
   }]
 
+Xform src/ExhaustiveSwitch.res 30:13
+posCursor:[30:13] posNoWhite:[30:12] Found expr:[30:3->30:17]
+posCursor:[30:13] posNoWhite:[30:12] Found expr:[30:10->30:17]
+Completable: Cpath Value[x]->
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[x]->
+ContextPath Value[x]
+Path x
+CPPipe env:ExhaustiveSwitch
+CPPipe type path:rcrd
+CPPipe pathFromEnv: found:true
+
+Xform src/ExhaustiveSwitch.res start: 33:3, end: 33:10
+found selection: [33:3->33:10] -> [33:6->33:10]
+XXX Not found!
+Completable: Cpath Value[getV](Nolabel)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[getV](Nolabel)
+ContextPath Value[getV]
+Path getV
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+Hit: Exhaustive switch
+{"start": {"line": 33, "character": 3}, "end": {"line": 33, "character": 10}}
+newText:
+   <--here
+   switch x->getV {
+   | One => failwith("TODO")
+   | Two => failwith("TODO")
+   | Three(_) => failwith("TODO")
+   }
+
+Xform src/ExhaustiveSwitch.res 36:4
+XXX Not found!
+Completable: Cpath Value[vvv]
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[vvv]
+Path vvv
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+Hit: Exhaustive switch
+{"start": {"line": 36, "character": 3}, "end": {"line": 36, "character": 6}}
+newText:
+   <--here
+   switch vvv {
+   | One => failwith("TODO")
+   | Two => failwith("TODO")
+   | Three(_) => failwith("TODO")
+   }
+

--- a/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -142,8 +142,10 @@ Hit: Exhaustive switch
 newText:
    <--here
    switch vvv {
-   | One => failwith("TODO")
-   | Two => failwith("TODO")
-   | Three(_) => failwith("TODO")
+   | None => failwith("TODO")
+   | Some(_) => failwith("TODO")
+   | Some(One) => failwith("TODO")
+   | Some(Two) => failwith("TODO")
+   | Some(Three(_)) => failwith("TODO")
    }
 

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -1,4 +1,12 @@
 Xform src/Xform.res 6:5
+posCursor:[6:3] posNoWhite:[6:1] Found expr:[6:0->11:1]
+Completable: Cpath Value[kind]
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[kind]
+Path kind
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
 Hit: Replace with switch
 {"start": {"line": 6, "character": 0}, "end": {"line": 11, "character": 1}}
 newText:
@@ -92,6 +100,14 @@ newText:
            : int
 
 Xform src/Xform.res 48:21
+posCursor:[48:21] posNoWhite:[48:19] Found expr:[48:15->48:25]
+Completable: Cpath Value[name]
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[name]
+Path name
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
 Hit: Add braces to function
 {"start": {"line": 48, "character": 0}, "end": {"line": 48, "character": 25}}
 newText:

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -714,6 +714,8 @@ function codeAction(msg: p.RequestMessage): p.ResponseMessage {
       filePath,
       params.range.start.line,
       params.range.start.character,
+      params.range.end.line,
+      params.range.end.character,
       tmpname,
     ],
     msg


### PR DESCRIPTION
This introduces a code action for inserting an exhaustive switch. Works for variants, polyvariants, options, and bools. It can be triggered in the following ways:

### Putting the cursor on an identifier

https://github.com/rescript-lang/rescript-vscode/assets/1457626/3f0a2ec7-3e1c-44fc-ae25-8a1912a59e0c

### Selecting an expression

https://github.com/rescript-lang/rescript-vscode/assets/1457626/a9fcee90-5a5b-4bd7-b2fb-8e8b9315cfff
