### PR TITLE
Instantiate variant types as needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix JS syntax highlighting in single-line FFI extension points. https://github.com/rescript-lang/rescript-vscode/pull/807
 - Fix signature help in uncurried mode. https://github.com/rescript-lang/rescript-vscode/pull/809
 - Fix various issues in uncurried mode. https://github.com/rescript-lang/rescript-vscode/pull/810
+- Fixes a bug in pattern completion where for example `result` wouldn't complete, due to type variables getting lost/not being instantiated. https://github.com/rescript-lang/rescript-vscode/pull/814
 
 ## 1.18.0
 

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -320,6 +320,8 @@ and completionType =
       constructors: Constructor.t list;
       variantDecl: Types.type_declaration;
       variantName: string;
+      typeArgs: Types.type_expr list;
+      typeParams: Types.type_expr list;
     }
   | Tpolyvariant of {
       env: QueryEnv.t;

--- a/analysis/tests/src/CompletionPattern.res
+++ b/analysis/tests/src/CompletionPattern.res
@@ -211,3 +211,8 @@ let getThing = async () => One
 
 // switch await getThing() { | }
 //                            ^com
+
+let res: result<someVariant, somePolyVariant> = Ok(One)
+
+// switch res { | Ok() }
+//                   ^com

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -1105,3 +1105,39 @@ Path getThing
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionPattern.res 216:21
+posCursor:[216:21] posNoWhite:[216:20] Found pattern:[216:18->216:22]
+Ppat_construct Ok:[216:18->216:20]
+posCursor:[216:21] posNoWhite:[216:20] Found pattern:[216:20->216:22]
+Ppat_construct ():[216:20->216:22]
+Completable: Cpattern Value[res]->variantPayload::Ok($0)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[res]
+Path res
+[{
+    "label": "One",
+    "kind": 4,
+    "tags": [],
+    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
+    "documentation": null,
+    "insertText": "One",
+    "insertTextFormat": 2
+  }, {
+    "label": "Two(_)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
+    "documentation": null,
+    "insertText": "Two(${1:_})",
+    "insertTextFormat": 2
+  }, {
+    "label": "Three(_, _)",
+    "kind": 4,
+    "tags": [],
+    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
+    "documentation": null,
+    "insertText": "Three(${1:_}, ${2:_})",
+    "insertTextFormat": 2
+  }]
+


### PR DESCRIPTION
This fixes a bug where for example completion from `result` wouldn't work, because the variant's type variables wasn't instantiated (and result is linked to `Belt.Result.t`, so I guess the type variables got lost in the linkage).