### PR TITLE
Make function template async when fn returns a promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add completion to top level decorators. https://github.com/rescript-lang/rescript-vscode/pull/799
 - Add code action for wrapping patterns where option is expected with `Some`. https://github.com/rescript-lang/rescript-vscode/pull/806
 - Better completion from identifiers with inferred types. https://github.com/rescript-lang/rescript-vscode/pull/808
+- Make suggested template functions async when the target function returns a promise. https://github.com/rescript-lang/rescript-vscode/pull/816
 
 #### :nail_care: Polish
 

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -343,6 +343,7 @@ and completionType =
       args: typedFnArg list;
       typ: Types.type_expr;
       uncurried: bool;
+      returnType: Types.type_expr;
     }
 
 module Env = struct

--- a/analysis/src/TypeUtils.ml
+++ b/analysis/src/TypeUtils.ml
@@ -125,8 +125,8 @@ let rec extractType ~env ~package (t : Types.type_expr) =
   | Tconstr (Pident {name = "function$"}, [t; _], _) -> (
     (* Uncurried functions. *)
     match extractFunctionType t ~env ~package with
-    | args, _tRet when args <> [] ->
-      Some (Tfunction {env; args; typ = t; uncurried = true})
+    | args, tRet when args <> [] ->
+      Some (Tfunction {env; args; typ = t; uncurried = true; returnType = tRet})
     | _args, _tRet -> None)
   | Tconstr (path, typeArgs, _) -> (
     match References.digConstructor ~env ~package path with
@@ -168,8 +168,9 @@ let rec extractType ~env ~package (t : Types.type_expr) =
     Some (Tpolyvariant {env; constructors; typeExpr = t})
   | Tarrow _ -> (
     match extractFunctionType t ~env ~package with
-    | args, _tRet when args <> [] ->
-      Some (Tfunction {env; args; typ = t; uncurried = false})
+    | args, tRet when args <> [] ->
+      Some
+        (Tfunction {env; args; typ = t; uncurried = false; returnType = tRet})
     | _args, _tRet -> None)
   | _ -> None
 

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -250,3 +250,10 @@ external commitLocalUpdate: (~updater: RecordSourceSelectorProxy.t => unit) => u
 
 // commitLocalUpdate(~updater=)
 //                            ^com
+
+let fnTakingAsyncCallback = (cb: unit => promise<unit>) => {
+  let _ = cb
+}
+
+// fnTakingAsyncCallback()
+//                       ^com

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1074,3 +1074,23 @@ Path commitLocalUpdate
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionExpressions.res 257:25
+posCursor:[257:25] posNoWhite:[257:24] Found expr:[257:3->257:26]
+Pexp_apply ...[257:3->257:24] (...[257:25->257:26])
+Completable: Cexpression CArgument Value[fnTakingAsyncCallback]($0)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CArgument Value[fnTakingAsyncCallback]($0)
+ContextPath Value[fnTakingAsyncCallback]
+Path fnTakingAsyncCallback
+[{
+    "label": "async () => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "unit => promise<unit>",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "async () => {$0}",
+    "insertTextFormat": 2
+  }]
+


### PR DESCRIPTION
Small quality of life improvement - when a function returns a promise, make the suggested function template async.