### PR TITLE
Fix code action for inserting missing record fields for v11 of ReScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add code action for wrapping patterns where option is expected with `Some`. https://github.com/rescript-lang/rescript-vscode/pull/806
 - Better completion from identifiers with inferred types. https://github.com/rescript-lang/rescript-vscode/pull/808
 - Make suggested template functions async when the target function returns a promise. https://github.com/rescript-lang/rescript-vscode/pull/816
+- Fix code action for inserting undefined record fields in ReScript v11. https://github.com/rescript-lang/rescript-vscode/pull/817
 
 #### :nail_care: Polish
 


### PR DESCRIPTION
Was broken in v11 due to text it relied on having changed. Now works in both v10 and v11.