### PR TITLE
Account for pipes in completion of single unlabelled argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix signature help in uncurried mode. https://github.com/rescript-lang/rescript-vscode/pull/809
 - Fix various issues in uncurried mode. https://github.com/rescript-lang/rescript-vscode/pull/810
 - Fixes a bug in pattern completion where for example `result` wouldn't complete, due to type variables getting lost/not being instantiated. https://github.com/rescript-lang/rescript-vscode/pull/814
+- Fix bug where pipes would not be considered in certain cases when completing for single unlabelled function arguments. https://github.com/rescript-lang/rescript-vscode/pull/818
 
 ## 1.18.0
 

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -129,7 +129,9 @@ let findArgCompletables ~(args : arg list) ~endPos ~posBeforeCursor
              CArgument
                {
                  functionContextPath = contextPath;
-                 argumentLabel = Unlabelled {argumentPosition = 0};
+                 argumentLabel =
+                   Unlabelled
+                     {argumentPosition = (if isPipedExpr then 1 else 0)};
                };
            prefix = "";
            nested = [];

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -257,3 +257,8 @@ let fnTakingAsyncCallback = (cb: unit => promise<unit>) => {
 
 // fnTakingAsyncCallback()
 //                       ^com
+
+let arr = ["hello"]
+
+// arr->Belt.Array.map()
+//                     ^com

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1094,3 +1094,22 @@ Path fnTakingAsyncCallback
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionExpressions.res 262:23
+posCursor:[262:23] posNoWhite:[262:22] Found expr:[262:3->262:24]
+Completable: Cexpression CArgument Value[Belt, Array, map]($1)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CArgument Value[Belt, Array, map]($1)
+ContextPath Value[Belt, Array, map]
+Path Belt.Array.map
+[{
+    "label": "v => {}",
+    "kind": 12,
+    "tags": [],
+    "detail": "'a => 'b",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "${1:v} => {$0}",
+    "insertTextFormat": 2
+  }]
+


### PR DESCRIPTION
Another quality-of-life thing. Previously, this: `someArray->Array.map(<com>` would ignore the pipe and complete as the first argument to `Array.map`, which would be the array itself, rendering a `[]` suggestion. With this change we instead get a function template suggested, like `v => {}`.

Next level on this would be to track the path/name of `Array.map` and change the suggested variable name in the function template to something nicer than the generic `v`, like `item`.