### PR TITLE
[DocGen]: add module name field

### DIFF
--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -127,6 +127,7 @@ let rec stringifyDocItem ?(indentation = 0) ~originalEnv (item : docItem) =
     stringifyObject ~startOnNewline:true ~indentation
       [
         ("id", Some (wrapInQuotes m.id));
+        ("name", Some (wrapInQuotes m.name));
         ("kind", Some (wrapInQuotes "module"));
         ( "item",
           Some
@@ -138,6 +139,7 @@ let rec stringifyDocItem ?(indentation = 0) ~originalEnv (item : docItem) =
       [
         ("id", Some (wrapInQuotes m.id));
         ("kind", Some (wrapInQuotes "moduleAlias"));
+        ("name", Some (wrapInQuotes m.name));
         ("docstrings", Some (stringifyDocstrings m.docstring));
         ("signature", Some (m.signature |> Json.escape |> wrapInQuotes));
       ]

--- a/analysis/tests/src/expected/DocExtraction2.res.txt
+++ b/analysis/tests/src/expected/DocExtraction2.res.txt
@@ -22,6 +22,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
   }, 
   {
     "id": "InnerModule.DocExtraction2",
+    "name": "InnerModule",
     "kind": "module",
     "item": 
     {

--- a/analysis/tests/src/expected/DocExtraction2.resi.txt
+++ b/analysis/tests/src/expected/DocExtraction2.resi.txt
@@ -21,6 +21,7 @@ extracting docs for src/DocExtraction2.resi
   }, 
   {
     "id": "InnerModule.DocExtraction2",
+    "name": "InnerModule",
     "kind": "module",
     "item": 
     {

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -41,6 +41,7 @@ extracting docs for src/DocExtractionRes.res
   }, 
   {
     "id": "SomeInnerModule.DocExtractionRes",
+    "name": "SomeInnerModule",
     "kind": "module",
     "item": 
     {
@@ -92,6 +93,7 @@ extracting docs for src/DocExtractionRes.res
   }, 
   {
     "id": "AnotherModule.DocExtractionRes",
+    "name": "AnotherModule",
     "kind": "module",
     "item": 
     {
@@ -101,6 +103,7 @@ extracting docs for src/DocExtractionRes.res
       {
         "id": "DocExtractionRes.AnotherModule.SomeInnerModule",
         "kind": "moduleAlias",
+        "name": "LinkedModule",
         "docstrings": ["This links another module. Neat."],
         "signature": "module LinkedModule = SomeInnerModule"
       }, 
@@ -146,6 +149,7 @@ extracting docs for src/DocExtractionRes.res
   }, 
   {
     "id": "ModuleWithThingsThatShouldNotBeExported.DocExtractionRes",
+    "name": "ModuleWithThingsThatShouldNotBeExported",
     "kind": "module",
     "item": 
     {


### PR DESCRIPTION
This is useful for generating submodule titles.