### PR TITLE
[DocGen]: Rename key `item` -> `items`

### DIFF
--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -156,7 +156,7 @@ let rec stringifyDocItem ?(indentation = 0) ~originalEnv (item : docItem) =
         ("id", Some (wrapInQuotes m.id));
         ("name", Some (wrapInQuotes m.name));
         ("kind", Some (wrapInQuotes "module"));
-        ( "item",
+        ( "items",
           Some
             (stringifyDocsForModule ~originalEnv ~indentation:(indentation + 1)
                m) );

--- a/analysis/tests/src/expected/DocExtraction2.res.txt
+++ b/analysis/tests/src/expected/DocExtraction2.res.txt
@@ -24,7 +24,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
     "id": "InnerModule.DocExtraction2",
     "name": "InnerModule",
     "kind": "module",
-    "item": 
+    "items": 
     {
       "name": "InnerModule",
       "docstrings": [],

--- a/analysis/tests/src/expected/DocExtraction2.resi.txt
+++ b/analysis/tests/src/expected/DocExtraction2.resi.txt
@@ -23,7 +23,7 @@ extracting docs for src/DocExtraction2.resi
     "id": "InnerModule.DocExtraction2",
     "name": "InnerModule",
     "kind": "module",
-    "item": 
+    "items": 
     {
       "name": "InnerModule",
       "docstrings": [],

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -45,7 +45,7 @@ extracting docs for src/DocExtractionRes.res
     "id": "SomeInnerModule.DocExtractionRes",
     "name": "SomeInnerModule",
     "kind": "module",
-    "item": 
+    "items": 
     {
       "name": "SomeInnerModule",
       "docstrings": ["Another module level docstring here."],
@@ -97,7 +97,7 @@ extracting docs for src/DocExtractionRes.res
     "id": "AnotherModule.DocExtractionRes",
     "name": "AnotherModule",
     "kind": "module",
-    "item": 
+    "items": 
     {
       "name": "AnotherModule",
       "docstrings": ["Mighty fine module here too!"],
@@ -153,7 +153,7 @@ extracting docs for src/DocExtractionRes.res
     "id": "ModuleWithThingsThatShouldNotBeExported.DocExtractionRes",
     "name": "ModuleWithThingsThatShouldNotBeExported",
     "kind": "module",
-    "item": 
+    "items": 
     {
       "name": "ModuleWithThingsThatShouldNotBeExported",
       "docstrings": [],


### PR DESCRIPTION
Always emit the `items` key for modules. Top Level module emit `items`