### PR TITLE
Account for "public" setting in bsconfig

### DIFF
--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -39,8 +39,9 @@ let newBsPackage ~rootPath =
                  config
              in
              let projectFilesAndPaths =
-               FindFiles.findProjectFiles ~namespace ~path:rootPath
-                 ~sourceDirectories ~libBs
+               FindFiles.findProjectFiles
+                 ~public:(FindFiles.getPublic config)
+                 ~namespace ~path:rootPath ~sourceDirectories ~libBs
              in
              projectFilesAndPaths
              |> List.iter (fun (_name, paths) -> Log.log (showPaths paths));


### PR DESCRIPTION
This accounts for the "public" setting in `bsconfig`. Seems like a fairly hidden property, but we should still support it imo given that trying to use something not listed in public (when public is set) is an error, even though items appear in autocomplete.

Example from the forum: https://forum.rescript-lang.org/t/how-to-only-expose-one-module-from-a-lib/4744/2