### PR TITLE
Add (failing) test for hover on aliased record

### DIFF
--- a/analysis/tests/src/Hover.res
+++ b/analysis/tests/src/Hover.res
@@ -263,3 +263,6 @@ let coolVariant = CoolVariant
 
 module Arr = Belt.Array
 //      ^hov
+
+type t2 = RecordCompletion.t2
+//    ^hov

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -264,3 +264,6 @@ Path x
 Hover src/Hover.res 263:8
 {"contents": {"kind": "markdown", "value": "\n [`Belt.Array`]()\n\n  **mutable array**: Utilities functions\n\n```rescript\nmodule Array: {\n  module Id\n  module Array\n  module SortArray\n  module MutableQueue\n  module MutableStack\n  module List\n  module Range\n  module Set\n  module Map\n  module MutableSet\n  module MutableMap\n  module HashSet\n  module HashMap\n  module Option\n  module Result\n  module Int\n  module Float\n}\n```"}}
 
+Hover src/Hover.res 266:6
+{"contents": {"kind": "markdown", "value": "```rescript\ntype t2 = RecordCompletion.t2 = {n2: RecordCompletion.t}\n```"}}
+


### PR DESCRIPTION
At work we are using aliases a lot (see screenshot). I think we should not lose hover info when they are aliased. So I added a failing test as a first step towards that.

<img width="463" alt="image" src="https://github.com/rescript-lang/rescript-vscode/assets/18074327/848d0cdf-3dbf-47be-933f-e9be7d7c8543">

