### PR TITLE
Docgen(fix): Remove `formatCode` function

### DIFF
--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -48,15 +48,6 @@ and docsForModule = {
   items: docItem list;
 }
 
-let formatCode content =
-  let {Res_driver.parsetree = signature; comments} =
-    Res_driver.parseInterfaceFromSource ~forPrinter:true
-      ~displayFilename:"<missing-file>" ~source:content
-  in
-  Res_printer.printInterface ~width:!Res_cli.ResClflags.width ~comments
-    signature
-  |> String.trim
-
 let stringifyDocstrings docstrings =
   let open Protocol in
   docstrings
@@ -282,8 +273,7 @@ let extractDocs ~path ~debug =
                           id = modulePath |> makeId ~identifier:item.name;
                           docstring = item.docstring |> List.map String.trim;
                           signature =
-                            "let " ^ item.name ^ ": " ^ Shared.typeToString typ
-                            |> formatCode;
+                            "let " ^ item.name ^ ": " ^ Shared.typeToString typ;
                           name = item.name;
                           deprecated = item.deprecated;
                         })
@@ -293,10 +283,7 @@ let extractDocs ~path ~debug =
                         {
                           id = modulePath |> makeId ~identifier:item.name;
                           docstring = item.docstring |> List.map String.trim;
-                          signature =
-                            typ.decl
-                            |> Shared.declToString item.name
-                            |> formatCode;
+                          signature = typ.decl |> Shared.declToString item.name;
                           name = item.name;
                           deprecated = item.deprecated;
                           detail = typeDetail typ ~full ~env;

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -118,7 +118,7 @@ extracting docs for src/DocExtractionRes.res
       "id": "DocExtractionRes.AnotherModule.someVariantWithInlineRecords",
       "kind": "type",
       "name": "someVariantWithInlineRecords",
-      "signature": "type someVariantWithInlineRecords = SomeStuff({offline: bool})",
+      "signature": "type someVariantWithInlineRecords =\\n  | SomeStuff({offline: bool})",
       "docstrings": ["Trying how it looks with an inline record in a variant."],
       "detail": 
       {


### PR DESCRIPTION
For some reason `formatCode` don`t print signature for some externals, see [Belt.Int](https://rescript-lang-fn6212fyj-rescript-association.vercel.app/docs/manual/next/api/belt/int#+)

`Shared.{type,decl}ToString` already does the formatting

Example:

```rescript
external \"-": (int, int) => int = "%subint"
``` 

Before:

```
{
  "name": "Lib",
  "docstrings": [],
  "items": [
  {
    "id": "Lib.-",
    "kind": "value",
    "name": "-",
    "signature": "let _: %rescript.typehole",
    "docstrings": []
  }]
}
``` 

After:

```
{
  "name": "Lib",
  "docstrings": [],
  "items": [
  {
    "id": "Lib.-",
    "kind": "value",
    "name": "-",
    "signature": "let -: (. int, int) => int",
    "docstrings": []
  }]
}
``` 