### PR TITLE
Add pre-release to `@rescript/language-server`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,15 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} ${{ steps.tag_name.outputs.tag }} --no-git-tag-version
 
+    - name: Publish LSP as pre-release to NPM
+      if: github.ref == 'refs/heads/master'
+      working-directory: server
+      run: |
+        npm version preminor --preid next
+        npm publish --access public --tag next
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     - name: Publish LSP to NPM
       if: startsWith(github.ref, 'refs/tags/')
       working-directory: server


### PR DESCRIPTION
`npm version preminor --preid next` increase minor version.

Example:
```diff
- "version": "1.22.0",
+ "version": "1.23.0-next.0"
```

install using `next` tag: `npm i -g @rescript/language-server@next`