### PR TITLE
Account for namespace when filtering pipe completion items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug Fix
 
 - Fix issue `open` on submodules exposed via `-open` in bsconfig.json/rescript.json, that would cause the content of those `open` modules to not actually appear in autocomplete. https://github.com/rescript-lang/rescript-vscode/pull/842
+- Account for namespace when filtering pipe completion items. https://github.com/rescript-lang/rescript-vscode/pull/843
 
 ## 1.22.0
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -943,6 +943,10 @@ and getCompletionsForContextPath ~debug ~full ~opens ~rawOpens ~pos ~env ~exact
           | [_], _ -> Some modulePath
           | s :: inner, first :: restPath when s = first ->
             removeRawOpen inner restPath
+          | s :: inner, first :: restPath
+            when String.contains first '-' && Utils.startsWith first s ->
+            (* This handles namespaced modules, which have their namespace appended after a '-' *)
+            removeRawOpen inner restPath
           | _ -> None
         in
         let rec removeRawOpens rawOpens modulePath =


### PR DESCRIPTION
This handles filtering out namespaced modules when producing the relative completion path in pipe completion. 

Before (the issue is the namespace, that should be covered by `open Test` above):
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/f93853aa-1cc7-4c1e-8a46-fcc9ea9927c4)

After (namespace is now accounted for, which leads to `Test` disappearing correctly from the completion path):
<img width="1325" alt="Pasted Graphic 3" src="https://github.com/rescript-lang/rescript-vscode/assets/1457626/171237df-5634-47e6-9ce2-259119a3ed39">
