### PR TITLE
Dont complete for illegal file module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug Fix
 
 - Clean up name of namespaced module when hovering. https://github.com/rescript-lang/rescript-vscode/pull/845
+- Don't complete illegal file module names. https://github.com/rescript-lang/rescript-vscode/pull/844
 - Fix issue `open` on submodules exposed via `-open` in bsconfig.json/rescript.json, that would cause the content of those `open` modules to not actually appear in autocomplete. https://github.com/rescript-lang/rescript-vscode/pull/842
 - Account for namespace when filtering pipe completion items. https://github.com/rescript-lang/rescript-vscode/pull/843
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -502,7 +502,7 @@ let getComplementaryCompletionsForTypedValue ~opens ~allFiles ~scope ~env prefix
              Utils.checkName name ~prefix ~exact
              && not
                   (* TODO complete the namespaced name too *)
-                  (Utils.hasUnallowedChars name)
+                  (Utils.fileNameHasUnallowedChars name)
            then
              Some
                (Completion.create name ~env ~kind:(Completion.FileModule name))
@@ -528,7 +528,7 @@ let getCompletionsForPath ~debug ~package ~opens ~full ~pos ~exact ~scope
                Utils.checkName name ~prefix ~exact
                && not
                     (* TODO complete the namespaced name too *)
-                    (Utils.hasUnallowedChars name)
+                    (Utils.fileNameHasUnallowedChars name)
              then
                Some
                  (Completion.create name ~env ~kind:(Completion.FileModule name))

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -502,7 +502,7 @@ let getComplementaryCompletionsForTypedValue ~opens ~allFiles ~scope ~env prefix
              Utils.checkName name ~prefix ~exact
              && not
                   (* TODO complete the namespaced name too *)
-                  (String.contains name '-')
+                  (Utils.hasUnallowedChars name)
            then
              Some
                (Completion.create name ~env ~kind:(Completion.FileModule name))
@@ -528,7 +528,7 @@ let getCompletionsForPath ~debug ~package ~opens ~full ~pos ~exact ~scope
                Utils.checkName name ~prefix ~exact
                && not
                     (* TODO complete the namespaced name too *)
-                    (String.contains name '-')
+                    (Utils.hasUnallowedChars name)
              then
                Some
                  (Completion.create name ~env ~kind:(Completion.FileModule name))

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -222,7 +222,7 @@ let cutAfterDash s =
   | n -> ( try String.sub s 0 n with Invalid_argument _ -> s)
   | exception Not_found -> s
 
-let hasUnallowedChars s =
+let fileNameHasUnallowedChars s =
   let regexp = Str.regexp "[^A-Za-z0-9]" in
   try
     ignore (Str.search_forward regexp s 0);

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -221,3 +221,10 @@ let cutAfterDash s =
   match String.index s '-' with
   | n -> ( try String.sub s 0 n with Invalid_argument _ -> s)
   | exception Not_found -> s
+
+let hasUnallowedChars s =
+  let regexp = Str.regexp "[^A-Za-z0-9]" in
+  try
+    ignore (Str.search_forward regexp s 0);
+    true
+  with Not_found -> false


### PR DESCRIPTION
We handled namespace file modules before, but other "exotic" file modules could still appear (example: `SomeTest.test.res`) which can't be used anyway. This filters anything with illegal characters in the name, for file modules specifically.