### PR TITLE
Clean up hover of namespaced module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### :bug: Bug Fix
 
+- Clean up name of namespaced module when hovering. https://github.com/rescript-lang/rescript-vscode/pull/845
 - Fix issue `open` on submodules exposed via `-open` in bsconfig.json/rescript.json, that would cause the content of those `open` modules to not actually appear in autocomplete. https://github.com/rescript-lang/rescript-vscode/pull/842
 
 ## 1.22.0

--- a/analysis/src/Hover.ml
+++ b/analysis/src/Hover.ml
@@ -14,6 +14,7 @@ let showModuleTopLevel ~docstring ~isType ~name (topLevel : Module.item list) =
     (* TODO indent *)
     |> String.concat "\n"
   in
+  let name = Utils.cutAfterDash name in
   let full =
     Markdown.codeBlock
       ("module "

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -216,3 +216,8 @@ let rec lastElements list =
 let lowercaseFirstChar s =
   if String.length s = 0 then s
   else String.mapi (fun i c -> if i = 0 then Char.lowercase_ascii c else c) s
+
+let cutAfterDash s =
+  match String.index s '-' with
+  | n -> ( try String.sub s 0 n with Invalid_argument _ -> s)
+  | exception Not_found -> s


### PR DESCRIPTION
Fixes so that this hover of a namespaced module:

```rescript
module Test-RescriptBun: {
  ...
}
```

Instead becomes this:
```rescript
module Test: {
  ...
}
```