### PR TITLE
feat: cli option to prevent 'start build' message

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -12,15 +12,16 @@ Options:
 
 --stdio               Use stdio
 --node-ipc            Use node-ipc
+--dont-ask            Don't ask to start build (use it as second parameter)
 -v, --version         Print version
 -h, --help            Print help`;
 
 (() => {
   switch (args[0]) {
     case '--stdio':
-      return server(true);
+      return server(true, args[1] !== "--dont-ask");
     case '--node-ipc':
-      return server(false);
+      return server(false, args[1] !== "--dont-ask");
     case '--version':
     case '-v':
       console.log(JSON.parse(fs.readFileSync('./package.json', { encoding: 'utf8' })).version);


### PR DESCRIPTION
Hey,

when I updated the language server manually for my Neovim config, I always set the askToStartBuild option in the code was to false.
Since I don't have to extract the server code from the vscode extension anymore (many thanks for the npm package) I wouldn't like to change the code manually, so an option for the cli would be usefull.

Without overcomplicating the code, I just added a second optional param to the cli.