### PR TITLE
More robust handling of namespaces in pipe completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :bug: Bug Fix
+
+- More robust handling of namespaces in pipe completions. https://github.com/rescript-lang/rescript-vscode/pull/850
+
 ## 1.24.0
 
 #### :bug: Bug Fix

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -943,10 +943,6 @@ and getCompletionsForContextPath ~debug ~full ~opens ~rawOpens ~pos ~env ~exact
           | [_], _ -> Some modulePath
           | s :: inner, first :: restPath when s = first ->
             removeRawOpen inner restPath
-          | s :: inner, first :: restPath
-            when String.contains first '-' && Utils.startsWith first s ->
-            (* This handles namespaced modules, which have their namespace appended after a '-' *)
-            removeRawOpen inner restPath
           | _ -> None
         in
         let rec removeRawOpens rawOpens modulePath =
@@ -959,7 +955,7 @@ and getCompletionsForContextPath ~debug ~full ~opens ~rawOpens ~pos ~env ~exact
           | [] -> modulePath
         in
         let completionPathMinusOpens =
-          completionPath
+          completionPath |> Utils.flattenAnyNamespaceInPath
           |> removeRawOpens package.opens
           |> removeRawOpens rawOpens |> String.concat "."
         in

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -228,3 +228,18 @@ let fileNameHasUnallowedChars s =
     ignore (Str.search_forward regexp s 0);
     true
   with Not_found -> false
+
+(* Flattens any namespace in the provided path.
+   Example:
+    Globals-RescriptBun.URL.t (which is an illegal path because of the namespace) becomes:
+    RescriptBun.Globals.URL.t
+*)
+let rec flattenAnyNamespaceInPath path =
+  match path with
+  | [] -> []
+  | head :: tail ->
+    if String.contains head '-' then
+      let parts = String.split_on_char '-' head in
+      (* Namespaces are in reverse order, so "URL-RescriptBun" where RescriptBun is the namespace. *)
+      (parts |> List.rev) @ flattenAnyNamespaceInPath tail
+    else head :: flattenAnyNamespaceInPath tail


### PR DESCRIPTION
This is a more robust implementation of https://github.com/rescript-lang/rescript-vscode/pull/843 that should cover all cases instead of just a few. Here, instead of checking for namespaces when filtering the completion items, we flatten any namespace items to their accessible paths before filtering. This allows the regular filter mechanism to just do its work like it's used to, and the filtering will work for namespaced items.