### PR TITLE
Fix Language Server and Tools `--version` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :bug: Bug Fix
 
-- Fix `rescript-language-server --version` command. https://github.com/rescript-lang/rescript-vscode/pull/853
+- Fix `rescript-language-server --version` and `rescript-tools --version` command. https://github.com/rescript-lang/rescript-vscode/pull/853
 
 ## 1.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Proper default for `"uncurried"` in V11 projects. https://github.com/rescript-lang/rescript-vscode/pull/867
 - Treat `result` type as a proper built in type. https://github.com/rescript-lang/rescript-vscode/pull/860
-- Fix `rescript-language-server --version` and `rescript-tools --version` command. https://github.com/rescript-lang/rescript-vscode/pull/853
+- Fix `rescript-language-server --version` command. https://github.com/rescript-lang/rescript-vscode/pull/853
 
 #### :nail_care: Polish
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :bug: Bug Fix
+
+- Fix `rescript-language-server --version` command. https://github.com/rescript-lang/rescript-vscode/pull/853
+
 ## 1.26.0
 
 #### :bug: Bug Fix

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import fs from "fs";
 import server from "./server";
 
 const args = process.argv.slice(2)
@@ -23,7 +22,7 @@ Options:
       return server(false);
     case '--version':
     case '-v':
-      console.log(JSON.parse(fs.readFileSync('./package.json', { encoding: 'utf8' })).version);
+      console.log(require('../package.json').version);
       process.exit(0);
     case '--help':
     case '-h':

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-import server from "./server";
-
+const server = require("./server")
 const args = process.argv.slice(2)
 
 const help = `ReScript Language Server

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -19,3 +19,4 @@
 #### :bug: Bug Fix
 
 - Fix tagged variant for `Module` and add attr to interface files. https://github.com/rescript-lang/rescript-vscode/pull/866
+- Fix `rescript-tools --version` command. https://github.com/rescript-lang/rescript-vscode/pull/853

--- a/tools/src/Cli.res
+++ b/tools/src/Cli.res
@@ -1,6 +1,6 @@
 @@directive("#!/usr/bin/env node")
 
-@module("fs") external readFileSync: string => string = "readFileSync"
+@val external require: string => Js.Dict.t<string> = "require"
 @variadic @module("path") external join: array<string> => string = "join"
 @module("path") external dirname: string => string = "dirname"
 @val external __dirname: string = "__dirname"
@@ -94,9 +94,9 @@ switch args->Belt.List.fromArray {
   }
 | list{"-h" | "--help"} => logAndExit(~log=help, ~code=0)
 | list{"-v" | "--version"} =>
-  switch readFileSync("./package.json")->Js.Json.parseExn->Js.Json.decodeObject {
+  switch require("../package.json")->Js.Dict.get("version") {
   | None => logAndExit(~log="error: failed to find version in package.json", ~code=1)
-  | Some(dict) => logAndExit(~log=dict->Js.Dict.unsafeGet("version"), ~code=0)
+  | Some(version) => logAndExit(~log=version, ~code=0)
   }
 | _ => logAndExit(~log=help, ~code=1)
 }


### PR DESCRIPTION
```
➜ npm i -g @rescript/language-server

added 22 packages in 2s

2 packages are looking for funding
  run `npm fund` for details

~ took 2s
➜ rescript-language-server -v
node:internal/fs/utils:350
    throw err;
    ^

Error: ENOENT: no such file or directory, open './package.json'
    at Object.openSync (node:fs:603:3)
    at Object.readFileSync (node:fs:471:35)
    at /home/pedro/.local/share/fnm/node-versions/v18.18.2/installation/lib/node_modules/@rescript/language-server/out/cli.js:28:49
    at Object.<anonymous> (/home/pedro/.local/share/fnm/node-versions/v18.18.2/installation/lib/node_modules/@rescript/language-server/out/cli.js:38:3)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:86:12)
    at node:internal/main/run_main_module:23:47 {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: './package.json'
}

Node.js v18.18.2
```


Now:

```
rescript-language-server -v
1.26.0
``` 