### PR TITLE
Put cursor after pattern on field completion

### DIFF
--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1275,7 +1275,7 @@ let rec completeTypedValue ~full ~prefix ~completionContext ~mode
           Completion.createWithSnippet
             ~name:("Some(" ^ fieldName ^ ")")
             ~kind:(kindFromInnerType t) ~env
-            ~insertText:("Some(${1:" ^ fieldName ^ "})")
+            ~insertText:("Some(" ^ fieldName ^ ")$0")
             ();
           someAnyCase;
           noneCase;

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -196,7 +196,7 @@ Path fnTakingRecord
     "tags": [],
     "detail": "otherRecord",
     "documentation": null,
-    "insertText": "Some(${1:nested})",
+    "insertText": "Some(nested)$0",
     "insertTextFormat": 2
   }, {
     "label": "Some(_)",
@@ -616,7 +616,7 @@ Path fnTakingRecordWithOptVariant
     "tags": [],
     "detail": "someVariant",
     "documentation": null,
-    "insertText": "Some(${1:someVariant})",
+    "insertText": "Some(someVariant)$0",
     "insertTextFormat": 2
   }, {
     "label": "Some(_)",


### PR DESCRIPTION
Small QoL improvement - in patterns you get completions for optional record fields, and one of the completions is "Some(theFieldName)". This is to make this type of pattern easy to insert via autocomplete: `switch x { | {id: Some(id)} => id` where `Some(id)` would be a completion item when completing at `id: <com>`.

Before this PR, the cursor would mark the contents of the the `Some` after insertion: `Some(<cursor>id</cursor>)`. But, this is almost never what you want to do in this case, you almost always want to continue matching on other things. So, this, PR changes the position of the cursor after insertion to instead be after the full `Some`: `Some(id)<cursor />`.