### PR TITLE
Tools: enable doc extraction from compiler

### DIFF
--- a/analysis/src/BuildSystem.ml
+++ b/analysis/src/BuildSystem.ml
@@ -6,15 +6,18 @@ let namespacedName namespace name =
 let ( /+ ) = Filename.concat
 
 let getBsPlatformDir rootPath =
-  let result =
-    ModuleResolution.resolveNodeModulePath ~startPath:rootPath "rescript"
-  in
-  match result with
-  | Some path -> Some path
-  | None ->
-    let message = "rescript could not be found" in
-    Log.log message;
-    None
+  match !Cfg.isDocGenFromCompiler with
+  | false -> (
+    let result =
+      ModuleResolution.resolveNodeModulePath ~startPath:rootPath "rescript"
+    in
+    match result with
+    | Some path -> Some path
+    | None ->
+      let message = "rescript could not be found" in
+      Log.log message;
+      None)
+  | true -> Some rootPath
 
 let getLibBs root = Files.ifExists (root /+ "lib" /+ "bs")
 

--- a/analysis/src/Cfg.ml
+++ b/analysis/src/Cfg.ml
@@ -1,3 +1,5 @@
 let supportsSnippets = ref false
 
 let debugFollowCtxPath = ref false
+
+let isDocGenFromCompiler = ref false

--- a/analysis/src/Cli.ml
+++ b/analysis/src/Cli.ml
@@ -143,7 +143,13 @@ let main () =
       ~pos:(int_of_string line_start, int_of_string line_end)
       ~maxLength ~debug
   | [_; "codeLens"; path] -> Commands.codeLens ~path ~debug
-  | [_; "extractDocs"; path] -> DocExtraction.extractDocs ~path ~debug
+  | [_; "extractDocs"; path] ->
+
+    let () = match Sys.getenv_opt "FROM_COMPILER" with
+    | Some("true") -> Cfg.isDocGenFromCompiler := true
+    | _ -> () in
+
+    DocExtraction.extractDocs ~path ~debug
   | [_; "codeAction"; path; startLine; startCol; endLine; endCol; currentFile]
     ->
     Commands.codeAction ~path

--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -32,7 +32,10 @@ let newBsPackage ~rootPath =
   let bsconfigJson = Filename.concat rootPath "bsconfig.json" in
 
   let parseRaw raw =
-    let libBs = BuildSystem.getLibBs rootPath in
+    let libBs = match !Cfg.isDocGenFromCompiler with
+    | true -> BuildSystem.getStdlib rootPath
+    | false -> BuildSystem.getLibBs rootPath
+    in
     match Json.parse raw with
     | Some config -> (
       match FindFiles.findDependencyFiles rootPath config with

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 - Expose more `decode` functions. https://github.com/rescript-lang/rescript-vscode/pull/866
 
+#### :house: [Internal]
+
+- Add env var `FROM_COMPILER` to extract docstrings from compiler repo. https://github.com/rescript-lang/rescript-vscode/pull/868
+
 #### :bug: Bug Fix
 
 - Fix tagged variant for `Module` and add attr to interface files. https://github.com/rescript-lang/rescript-vscode/pull/866
+- Fix output truncate when run `rescript-tools doc path/to/file.res` in a separate process. https://github.com/rescript-lang/rescript-vscode/pull/868


### PR DESCRIPTION
This PR has one workaround to extract docs from the compiler repo and a fix

1. Introduce an env var `FROM_COMPILER` to analysis find the correct path to `cmt` files. In standalone packages, the `cmt` files are located in `lib/bs/`, but in the compiler repo they are in `lib/ocaml`
2. Add `stdio: "inherit"`. Node was truncating output when I run a separate process in `rescript-tools doc path/to/rescript-compiler/lib/ocaml/js.ml` https://github.com/nodejs/node/issues/2360