### PR TITLE
Fix renaming of labelled arguments

### DIFF
--- a/analysis/src/ProcessExtra.ml
+++ b/analysis/src/ProcessExtra.ml
@@ -358,8 +358,16 @@ let typ ~env ~extra (iter : Tast_iterator.iterator) (item : Typedtree.core_type)
 
 let pat ~(file : File.t) ~env ~extra (iter : Tast_iterator.iterator)
     (pattern : Typedtree.pattern) =
-  let addForPattern stamp name =
+  let addForPattern stamp (name : string Location.loc) =
     if Stamps.findValue file.stamps stamp = None then (
+      let name =
+        match
+          pattern.pat_attributes
+          |> List.find_opt (fun ({Asttypes.txt}, _) -> txt = "res.namedArgLoc")
+        with
+        | None -> name
+        | Some ({loc}, _) -> {name with loc}
+      in
       let declared =
         ProcessAttributes.newDeclared ~name ~stamp ~modulePath:NotVisible
           ~extent:pattern.pat_loc ~item:pattern.pat_type false

--- a/analysis/tests/src/Rename.res
+++ b/analysis/tests/src/Rename.res
@@ -9,3 +9,6 @@ let c = x
 
 let foo = (~xx) => xx + 1
 //                 ^ren yy
+
+let foo2 = (~xx) => xx + 1
+//            ^ren yy

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -22,9 +22,11 @@ Hover src/Hover.res 33:4
 {"contents": {"kind": "markdown", "value": "```rescript\nunit => int\n```\n\nDoc comment for functionWithTypeAnnotation"}}
 
 Hover src/Hover.res 37:13
-getLocItem #5: heuristic for JSX and compiler combined:
-~x becomes Props#x
-heuristic for: [Props, x], give loc of `x`
+getLocItem #7: heuristic for JSX on type-annotated labeled (~arg:t):
+(~arg:t) becomes Props#arg
+Props has the location range of arg:t
+arg has the location range of arg
+heuristic for: [Props, arg], give loc of `arg`
 n1:Props n2:name
 {"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
 
@@ -74,7 +76,9 @@ Hover src/Hover.res 103:25
 {"contents": {"kind": "markdown", "value": "```rescript\nfloat\n```"}}
 
 Hover src/Hover.res 106:21
-{"contents": {"kind": "markdown", "value": "```rescript\nint\n```"}}
+Nothing at that position. Now trying to use completion.
+posCursor:[106:21] posNoWhite:[106:19] Found expr:[106:13->106:36]
+null
 
 Hover src/Hover.res 116:16
 {"contents": {"kind": "markdown", "value": "```rescript\nAA.cond<[< #str(string)]> => AA.cond<[< #str(string)]>\n```\n\n---\n\n```\n \n```\n```rescript\ntype AA.cond<'a> = 'a\n  constraint 'a = [< #str(string)]\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22Hover.res%22%2C110%2C2%5D)\n"}}

--- a/analysis/tests/src/expected/References.res.txt
+++ b/analysis/tests/src/expected/References.res.txt
@@ -10,7 +10,7 @@ References src/References.res 0:4
 
 References src/References.res 9:19
 [
-{"uri": "References.res", "range": {"start": {"line": 9, "character": 11}, "end": {"line": 9, "character": 14}}},
+{"uri": "References.res", "range": {"start": {"line": 9, "character": 12}, "end": {"line": 9, "character": 14}}},
 {"uri": "References.res", "range": {"start": {"line": 9, "character": 19}, "end": {"line": 9, "character": 21}}}
 ]
 

--- a/analysis/tests/src/expected/Rename.res.txt
+++ b/analysis/tests/src/expected/Rename.res.txt
@@ -26,10 +26,27 @@ Rename src/Rename.res 9:19 yy
   "uri": "Rename.res"
   },
   "edits": [{
-  "range": {"start": {"line": 9, "character": 11}, "end": {"line": 9, "character": 14}},
+  "range": {"start": {"line": 9, "character": 12}, "end": {"line": 9, "character": 14}},
   "newText": "yy"
   }, {
   "range": {"start": {"line": 9, "character": 19}, "end": {"line": 9, "character": 21}},
+  "newText": "yy"
+  }]
+  }
+]
+
+Rename src/Rename.res 12:14 yy
+[
+{
+  "textDocument": {
+  "version": null,
+  "uri": "Rename.res"
+  },
+  "edits": [{
+  "range": {"start": {"line": 12, "character": 13}, "end": {"line": 12, "character": 15}},
+  "newText": "yy"
+  }, {
+  "range": {"start": {"line": 12, "character": 20}, "end": {"line": 12, "character": 22}},
   "newText": "yy"
   }]
   }

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -75,11 +75,6 @@ let foo = x => {
 }
 
 Xform src/Xform.res 34:21
-Hit: Add type annotation
-{"start": {"line": 34, "character": 24}, "end": {"line": 34, "character": 24}}
-newText:
-                        <--here
-                        : int
 
 Xform src/Xform.res 38:5
 Hit: Add Documentation template
@@ -93,11 +88,6 @@ newText:
 let make = (~name) => React.string(name)
 
 Xform src/Xform.res 41:9
-Hit: Add type annotation
-{"start": {"line": 41, "character": 11}, "end": {"line": 41, "character": 11}}
-newText:
-           <--here
-           : int
 
 Xform src/Xform.res 48:21
 posCursor:[48:21] posNoWhite:[48:19] Found expr:[48:15->48:25]


### PR DESCRIPTION
This is an attempt to fix renaming of labelled arguments breaking because it doesn't account for `~` (so `~` is either removed from the argument definition, or added to local bindings that are renamed).

This seems to have broken a few other things though that I'm a bit unsure of how to fix. Maybe this isn't the optimal approach to this problem anyway.