### PR TITLE
Heuristic for JSX completion happening at the very end of a component with children

### DIFF
--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -249,14 +249,14 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
       Some text.[offsetNoWhite]
     else None
   in
+  let charAtCursor =
+    if offset < String.length text then text.[offset] else '\n'
+  in
   let posBeforeCursor = Pos.posBeforeCursor posCursor in
   let charBeforeCursor, blankAfterCursor =
     match Pos.positionToOffset text posCursor with
     | Some offset when offset > 0 -> (
       let charBeforeCursor = text.[offset - 1] in
-      let charAtCursor =
-        if offset < String.length text then text.[offset] else '\n'
-      in
       match charAtCursor with
       | ' ' | '\t' | '\r' | '\n' ->
         (Some charBeforeCursor, Some charBeforeCursor)
@@ -918,7 +918,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
             CompletionJsx.findJsxPropsCompletable ~jsxProps
               ~endPos:(Loc.end_ expr.pexp_loc) ~posBeforeCursor
               ~posAfterCompName:(Loc.end_ compName.loc)
-              ~firstCharBeforeCursorNoWhite
+              ~firstCharBeforeCursorNoWhite ~charAtCursor
           in
           if jsxCompletable <> None then setResultOpt jsxCompletable
           else if compName.loc |> Loc.hasPos ~pos:posBeforeCursor then

--- a/analysis/src/CompletionJsx.ml
+++ b/analysis/src/CompletionJsx.ml
@@ -869,8 +869,6 @@ let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor
         (* This is a special case for: <SomeComponent someProp=> (completing directly after the '=').
            The completion comes at the end of the component, after the equals sign, but before any
            children starts, and '>' marks that it's at the end of the component JSX.
-
-           The parser parses this differently to when there's a space after the '=' sign.
            This little heuristic makes sure we pick up this special case. *)
         Some
           (Cexpression

--- a/analysis/src/CompletionJsx.ml
+++ b/analysis/src/CompletionJsx.ml
@@ -802,11 +802,16 @@ type jsxProps = {
 }
 
 let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor
-    ~firstCharBeforeCursorNoWhite ~posAfterCompName =
+    ~firstCharBeforeCursorNoWhite ~charAtCursor ~posAfterCompName =
   let allLabels =
     List.fold_right
       (fun prop allLabels -> prop.name :: allLabels)
       jsxProps.props []
+  in
+  let beforeChildrenStart =
+    match jsxProps.childrenStart with
+    | Some childrenPos -> posBeforeCursor < childrenPos
+    | None -> posBeforeCursor <= endPos
   in
   let rec loop props =
     match props with
@@ -860,13 +865,28 @@ let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor
                  nested = [];
                })
         else None
+      else if rest = [] && beforeChildrenStart && charAtCursor = '>' then
+        (* This is a special case for: <SomeComponent someProp=> (completing directly after the '=').
+           The completion comes at the end of the component, after the equals sign, but before any
+           children starts, and '>' marks that it's at the end of the component JSX.
+
+           The parser parses this differently to when there's a space after the '=' sign.
+           This little heuristic makes sure we pick up this special case. *)
+        Some
+          (Cexpression
+             {
+               contextPath =
+                 CJsxPropValue
+                   {
+                     pathToComponent =
+                       Utils.flattenLongIdent ~jsx:true jsxProps.compName.txt;
+                     propName = prop.name;
+                   };
+               prefix = "";
+               nested = [];
+             })
       else loop rest
     | [] ->
-      let beforeChildrenStart =
-        match jsxProps.childrenStart with
-        | Some childrenPos -> posBeforeCursor < childrenPos
-        | None -> posBeforeCursor <= endPos
-      in
       let afterCompName = posBeforeCursor >= posAfterCompName in
       if afterCompName && beforeChildrenStart then
         Some

--- a/analysis/tests/src/CompletionJsx.res
+++ b/analysis/tests/src/CompletionJsx.res
@@ -45,3 +45,6 @@ module CompWithoutJsxPpx = {
 
 // <CompWithoutJsxPpx n
 //                     ^com
+
+// <SomeComponent someProp=>
+//                         ^com

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -473,3 +473,22 @@ Path CompWithoutJsxPpx.make
     "documentation": null
   }]
 
+Complete src/CompletionJsx.res 48:27
+posCursor:[48:27] posNoWhite:[48:26] Found expr:[48:4->48:28]
+JSX <SomeComponent:[48:4->48:17] someProp[48:18->48:26]=...[48:18->48:26]> _children:None
+Completable: Cexpression CJsxPropValue [SomeComponent] someProp
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CJsxPropValue [SomeComponent] someProp
+Path SomeComponent.make
+[{
+    "label": "\"\"",
+    "kind": 12,
+    "tags": [],
+    "detail": "string",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "{\"$0\"}",
+    "insertTextFormat": 2
+  }]
+


### PR DESCRIPTION
Comment in the code says it all. Fixes an edge case where completing `<SomeComponent someProp=>` after `=` wouldn't work because the parser doesn't parse this the same as `<SomeComponent someProp= >` (which does work because we get an expr hole in `someProp=`).