### PR TITLE
Extend quoting functionality to include polyvariant keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug Fix
 
 - Fix so that you don't need a leading `#` to complete for polyvariant constructors. https://github.com/rescript-lang/rescript-vscode/pull/874
+- Print keyword polyvariant constructors with quotes when doing completions. https://github.com/rescript-lang/rescript-vscode/pull/877
 
 ## 1.30.0
 

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -259,4 +259,4 @@ let printMaybeExoticIdent ?(allowUident = false) txt =
       | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '\'' | '_' -> loop (i + 1)
       | _ -> "\"" ^ txt ^ "\""
   in
-  loop 0
+  if Res_token.isKeywordTxt txt then "\"" ^ txt ^ "\"" else loop 0

--- a/analysis/tests/src/ExhaustiveSwitch.res
+++ b/analysis/tests/src/ExhaustiveSwitch.res
@@ -1,5 +1,5 @@
 type someVariant = One | Two | Three(option<bool>)
-type somePolyVariant = [#one | #two | #three(option<bool>) | #"exotic ident"]
+type somePolyVariant = [#one | #two | #three(option<bool>) | #"exotic ident" | #"switch"]
 
 let withSomeVariant = One
 let withSomePoly: somePolyVariant = #one

--- a/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -42,7 +42,7 @@ Path withSomePol
     "detail": "insert exhaustive switch for value",
     "documentation": null,
     "filterText": "withSomePoly",
-    "insertText": "withSomePoly {\n   | #one => ${1:failwith(\"todo\")}\n   | #three(_) => ${2:failwith(\"todo\")}\n   | #two => ${3:failwith(\"todo\")}\n   | #\"exotic ident\" => ${4:failwith(\"todo\")}\n   }",
+    "insertText": "withSomePoly {\n   | #\"switch\" => ${1:failwith(\"todo\")}\n   | #one => ${2:failwith(\"todo\")}\n   | #three(_) => ${3:failwith(\"todo\")}\n   | #two => ${4:failwith(\"todo\")}\n   | #\"exotic ident\" => ${5:failwith(\"todo\")}\n   }",
     "insertTextFormat": 2
   }]
 


### PR DESCRIPTION
Hey,
Following up #870, we have now extended the functionality to also wrap polyvariant keywords with quotes.
