### PR TITLE
fix(tools): get docstrings from module file

### DIFF
--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -294,7 +294,7 @@ let extractDocs ~path ~debug =
                    let id =
                      (modulePath |> List.rev |> List.hd) ^ "." ^ item.name
                    in
-                   let items, docstring =
+                   let items, internalDocstrings =
                      match
                        ProcessCmt.fileForModule ~package:full.package
                          aliasToModule
@@ -312,7 +312,7 @@ let extractDocs ~path ~debug =
                           id;
                           name = item.name;
                           items;
-                          docstring = docstring |> List.map String.trim;
+                          docstring = item.docstring @ internalDocstrings |> List.map String.trim;
                         })
                  | Module (Structure m) ->
                    (* module Whatever = {} in res or module Whatever: {} in resi. *)

--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -294,17 +294,17 @@ let extractDocs ~path ~debug =
                    let id =
                      (modulePath |> List.rev |> List.hd) ^ "." ^ item.name
                    in
-                   let items =
+                   let items, docstring =
                      match
                        ProcessCmt.fileForModule ~package:full.package
                          aliasToModule
                      with
-                     | None -> []
+                     | None -> ([], [])
                      | Some file ->
                        let docs =
                          extractDocsForModule ~modulePath:[id] file.structure
                        in
-                       docs.items
+                       (docs.items, docs.docstring)
                    in
                    Some
                      (ModuleAlias
@@ -312,7 +312,7 @@ let extractDocs ~path ~debug =
                           id;
                           name = item.name;
                           items;
-                          docstring = item.docstring |> List.map String.trim;
+                          docstring = docstring |> List.map String.trim;
                         })
                  | Module (Structure m) ->
                    (* module Whatever = {} in res or module Whatever: {} in resi. *)

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -97,7 +97,7 @@ extracting docs for src/DocExtractionRes.res
       "id": "DocExtractionRes.LinkedModule",
       "kind": "moduleAlias",
       "name": "LinkedModule",
-      "docstrings": ["This links another module. Neat."],
+      "docstrings": [],
       "items": []
     }, 
     {

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -97,7 +97,7 @@ extracting docs for src/DocExtractionRes.res
       "id": "DocExtractionRes.LinkedModule",
       "kind": "moduleAlias",
       "name": "LinkedModule",
-      "docstrings": [],
+      "docstrings": ["This links another module. Neat."],
       "items": []
     }, 
     {

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :bug: Bug Fix
+
+- Fix docstrings for module alias. Get internal docstrings of module file. https://github.com/rescript-lang/rescript-vscode/pull/878
+
 ## 0.3.0
 
 #### :rocket: New Feature


### PR DESCRIPTION
```bash
FROM_COMPILER=true ./analysis/rescript-editor-analysis.exe extractDocs ~/Desktop/projects/rescript-compiler/jscomp/others/belt.res | jq '{items}[] | map(select(.id == "Belt.Array")) | .[0] | .docstrings'
```

Before:


```
[
  "[`Belt.Array`]()\n\n  **mutable array**: Utilities functions"
]
```

After:

```
[
  "Utililites for `Array` functions.\n\n### Note about index syntax\n\nCode like `arr[0]` does *not* compile to JavaScript `arr[0]`. Reason transforms\nthe `[]` index synta
x into a function: `Array.get(arr, 0)`. By default, this\nuses the default standard library's `Array.get` function, which may raise an\nexception if the index isn't found. 
If you `open Belt`, it will use the\n`Belt.Array.get` function which returns options instead of raising exceptions. \n[See this for more information](../belt.mdx#array-acce
ss-runtime-safety)."
]
```