### PR TITLE
Complete payload of @module attribute

### DIFF
--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -736,7 +736,21 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
           Printf.printf "Attribute id:%s:%s label:%s\n" id.txt
             (Loc.toString id.loc) label;
         setResult (Completable.Cdecorator label)
-      | _ -> ());
+      | _ -> ()
+    else if id.txt = "module" then
+      (match payload with
+      | PStr
+          [
+            {
+              pstr_desc =
+                Pstr_eval
+                  ( {pexp_loc; pexp_desc = Pexp_constant (Pconst_string (s, _))},
+                    _ );
+            };
+          ]
+        when locHasCursor pexp_loc ->
+        setResult (Completable.CdecoratorPayload (Module s))
+      | _ -> ()));
     Ast_iterator.default_iterator.attribute iterator (id, payload)
   in
   let rec iterateFnArguments ~args ~iterator ~isPipe

--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -47,6 +47,11 @@ let newBsPackage ~rootPath =
           Some
             (let namespace = FindFiles.getNamespace config in
              let rescriptVersion = getReScriptVersion () in
+             let suffix =
+              match config |> Json.get "suffix" with
+              | Some (String suffix) -> suffix
+              | _ -> ".js"
+            in
              let uncurried =
                let ns = config |> Json.get "uncurried" in
                match (rescriptVersion, ns) with
@@ -115,6 +120,7 @@ let newBsPackage ~rootPath =
                ("Opens from ReScript config file: "
                ^ (opens |> List.map pathToString |> String.concat " "));
              {
+               suffix;
                rescriptVersion;
                rootPath;
                projectFiles =

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -489,6 +489,7 @@ type builtInCompletionModules = {
 }
 
 type package = {
+  suffix: string;
   rootPath: filePath;
   projectFiles: FileSet.t;
   dependenciesFiles: FileSet.t;
@@ -619,8 +620,11 @@ module Completable = struct
 
   type patternMode = Default | Destructuring
 
+  type decoratorPayload = Module of string
+
   type t =
     | Cdecorator of string  (** e.g. @module *)
+    | CdecoratorPayload of decoratorPayload
     | CnamedArg of contextPath * string * string list
         (** e.g. (..., "label", ["l1", "l2"]) for ...(...~l1...~l2...~label...) *)
     | Cnone  (** e.g. don't complete inside strings *)
@@ -701,6 +705,7 @@ module Completable = struct
   let toString = function
     | Cpath cp -> "Cpath " ^ contextPathToString cp
     | Cdecorator s -> "Cdecorator(" ^ str s ^ ")"
+    | CdecoratorPayload (Module s) -> "CdecoratorPayload(module=" ^ s ^ ")"
     | CnamedArg (cp, s, sl2) ->
       "CnamedArg("
       ^ (cp |> contextPathToString)

--- a/analysis/src/Utils.ml
+++ b/analysis/src/Utils.ml
@@ -260,3 +260,16 @@ let printMaybeExoticIdent ?(allowUident = false) txt =
       | _ -> "\"" ^ txt ^ "\""
   in
   if Res_token.isKeywordTxt txt then "\"" ^ txt ^ "\"" else loop 0
+
+let findPackageJson root =
+  let path = Uri.toPath root in
+
+  let rec loop path =
+    if path = "/" then None
+    else if Files.exists (Filename.concat path "package.json") then
+      Some (Filename.concat path "package.json")
+    else
+      let parent = Filename.dirname path in
+      if parent = path then (* reached root *) None else loop parent
+  in
+  loop path

--- a/analysis/tests/src/CompletionAttributes.res
+++ b/analysis/tests/src/CompletionAttributes.res
@@ -1,0 +1,3 @@
+// @module("") external doStuff: t = "test"
+//          ^com
+

--- a/analysis/tests/src/expected/CompletionAttributes.res.txt
+++ b/analysis/tests/src/expected/CompletionAttributes.res.txt
@@ -1,0 +1,19 @@
+Complete src/CompletionAttributes.res 0:12
+XXX Not found!
+Completable: CdecoratorPayload(module=)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+[{
+    "label": "@rescript/react",
+    "kind": 4,
+    "tags": [],
+    "detail": "Package",
+    "documentation": null
+  }, {
+    "label": "./tst.js",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }]
+


### PR DESCRIPTION
Adds basic completion for the string payload of the `@module()` attribute. A (pretty weird) example:
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/5396150d-8bb4-42a1-9cd3-b0462977e878)

This is a basic version that will complete for:
- Package names in `dependencies` + `devDependencies` of `package.json`, if it can find it
- Local `.js` and `.mjs` files next to the source ReScript file

Ideas building on this:
- Resolve relative paths (completing `../` gives that folder contents, etc)
- Resolve `.d.ts` files relative to packages. Completing `next/` could give `next/link`, etc

One could maybe even go further and resolve `@scope` in combination with `@module`, and the external assignment, like:
```rescript
@module("next/link") external make: ... = "<com>"
```
And via that look up what exports there actually are in the `next/link` package. 

One can dream at least. This is a first small step.