### PR TITLE
Do not crash entire extension when analysis fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ## master
 
+- Better error recovery when analysis fails. https://github.com/rescript-lang/rescript-vscode/pull/880
+
 ## 1.32.0
 
 - Expand type aliases in hovers. https://github.com/rescript-lang/rescript-vscode/pull/881

--- a/server/src/errorReporter.ts
+++ b/server/src/errorReporter.ts
@@ -1,0 +1,22 @@
+type cb = (msg: string) => void;
+
+let subscribers: Array<cb> = [];
+const errorLastNotified: Record<string, number> = {};
+
+export const onErrorReported = (cb: (msg: string) => void) => {
+  subscribers.push(cb);
+  return () => {
+    subscribers = subscribers.filter((s) => s !== cb);
+  };
+};
+
+export const reportError = (identifier: string, msg: string) => {
+  // Warn once per 15 min per error
+  if (
+    errorLastNotified[identifier] == null ||
+    errorLastNotified[identifier] < Date.now() - 15 * 1000 * 60
+  ) {
+    errorLastNotified[identifier] = Date.now();
+    subscribers.forEach((cb) => cb(msg));
+  }
+};

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from "url";
 import { ChildProcess } from "child_process";
 import { WorkspaceEdit } from "vscode-languageserver";
 import { filesDiagnostics } from "./utils";
+import { onErrorReported } from "./errorReporter";
 
 interface extensionConfiguration {
   allowBuiltInFormatter: boolean;
@@ -1306,3 +1307,21 @@ function onMessage(msg: p.Message) {
     }
   }
 }
+
+// Gate behind a debug setting potentially?
+onErrorReported((msg) => {
+  let params: p.ShowMessageParams = {
+    type: p.MessageType.Warning,
+    message: `ReScript tooling: Internal error. Something broke. Here's the error message that you can report if you want:
+    
+${msg}
+
+(this message will only be reported once every 15 minutes)`,
+  };
+  let message: p.NotificationMessage = {
+    jsonrpc: c.jsonrpcVersion,
+    method: "window/showMessage",
+    params: params,
+  };
+  send(message);
+});

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -12,6 +12,7 @@ import * as os from "os";
 import * as codeActions from "./codeActions";
 import * as c from "./constants";
 import * as lookup from "./lookup";
+import { reportError } from "./errorReporter";
 
 let tempFilePrefix = "rescript_format_file_" + process.pid + "_";
 let tempFileId = 0;
@@ -186,9 +187,15 @@ export let runAnalysisAfterSanityCheck = (
       RESCRIPT_VERSION: rescriptVersion,
     },
   };
-  let stdout = childProcess.execFileSync(binaryPath, args, options);
-
-  return JSON.parse(stdout.toString());
+  try {
+    let stdout = childProcess.execFileSync(binaryPath, args, options);
+    return JSON.parse(stdout.toString());
+  } catch (e) {
+    console.error(e);
+    // Element 0 is the action we're performing
+    reportError(String(args[0]), String(e));
+    return null;
+  }
 };
 
 export let runAnalysisCommand = (


### PR DESCRIPTION
Instead report the error as a message, but only every 15 minutes.

We want people to report when things crash, but having the entire extension crash because of some potentially minor thing (code actions failing to resolve for example) is a bad experience. This makes sure that the extension does not crash when the analysis fails, but rather reports a message with the error (and not too often).

This is a good balance imo between getting people to report and preserving the UX of the extension.