### PR TITLE
Include fields when completing for identifiers in a braced expr that is likely a module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@
 ## master
 
 - Better error recovery when analysis fails. https://github.com/rescript-lang/rescript-vscode/pull/880
+- Expand type aliases in hovers. https://github.com/rescript-lang/rescript-vscode/pull/881
+- Include fields when completing a braced expr that's an ID, where it the path likely starts with a module. https://github.com/rescript-lang/rescript-vscode/pull/882
 
 ## 1.32.0
-
-- Expand type aliases in hovers. https://github.com/rescript-lang/rescript-vscode/pull/881
 
 #### :bug: Bug Fix
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -262,6 +262,10 @@ let findAllCompletions ~(env : QueryEnv.t) ~prefix ~exact ~namesUsed
   | Field ->
     completionForExportedFields ~env ~prefix ~exact ~namesUsed
     @ completionForExportedModules ~env ~prefix ~exact ~namesUsed
+  | ValueOrField ->
+    completionForExportedValues ~env ~prefix ~exact ~namesUsed
+    @ completionForExportedFields ~env ~prefix ~exact ~namesUsed
+    @ completionForExportedModules ~env ~prefix ~exact ~namesUsed
 
 let processLocalValue name loc contextPath scope ~prefix ~exact ~env
     ~(localTables : LocalTables.t) =
@@ -476,7 +480,7 @@ let findLocalCompletionsWithOpens ~pos ~(env : QueryEnv.t) ~prefix ~exact ~opens
    ^ Pos.toString pos);
   let localTables = LocalTables.create () in
   match completionContext with
-  | Value ->
+  | Value | ValueOrField ->
     findLocalCompletionsForValuesAndConstructors ~localTables ~env ~prefix
       ~exact ~opens ~scope
   | Type ->

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -866,7 +866,23 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
               (lidPath |> String.concat ".")
               (Loc.toString lid.loc);
           if lid.loc |> Loc.hasPos ~pos:posBeforeCursor then
-            setResult (Cpath (CPId (lidPath, Value)))
+            let isLikelyModulePath =
+              match lidPath with
+              | head :: _
+                when String.length head > 0
+                     && head.[0] == Char.uppercase_ascii head.[0] ->
+                true
+              | _ -> false
+            in
+            setResult
+              (Cpath
+                 (CPId
+                    ( lidPath,
+                      if
+                        isLikelyModulePath
+                        && expr |> Res_parsetree_viewer.isBracedExpr
+                      then ValueOrField
+                      else Value )))
         | Pexp_construct (lid, eOpt) ->
           let lidPath = flattenLidCheckDot lid in
           if debug && lid.txt <> Lident "Function$" then

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -554,7 +554,7 @@ let _ = locItemToString
 
 module Completable = struct
   (* Completion context *)
-  type completionContext = Type | Value | Module | Field
+  type completionContext = Type | Value | Module | Field | ValueOrField
 
   type argumentLabel =
     | Unlabelled of {argumentPosition: int}
@@ -651,6 +651,7 @@ module Completable = struct
     | Type -> "Type"
     | Module -> "Module"
     | Field -> "Field"
+    | ValueOrField -> "ValueOrField"
 
   let rec contextPathToString = function
     | CPString -> "string"

--- a/analysis/tests/src/Completion.res
+++ b/analysis/tests/src/Completion.res
@@ -462,3 +462,6 @@ type withUncurried = {
 
 // let f: withUncurried = {fn: }
 //                            ^com
+
+// let someRecord = { FAR. }
+//                        ^com

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1950,8 +1950,8 @@ Path red
   }]
 
 Complete src/Completion.res 405:22
-posCursor:[405:22] posNoWhite:[405:21] Found expr:[405:11->465:0]
-Pexp_apply ...__ghost__[0:-1->0:-1] (...[405:11->423:17], ...[428:0->465:0])
+posCursor:[405:22] posNoWhite:[405:21] Found expr:[405:11->467:0]
+Pexp_apply ...__ghost__[0:-1->0:-1] (...[405:11->423:17], ...[428:0->467:0])
 posCursor:[405:22] posNoWhite:[405:21] Found expr:[405:11->423:17]
 Pexp_apply ...__ghost__[0:-1->0:-1] (...[405:11->405:19], ...[405:21->423:17])
 posCursor:[405:22] posNoWhite:[405:21] Found expr:[405:21->423:17]
@@ -2204,5 +2204,34 @@ Path withUncurried
     "sortText": "A",
     "insertText": "(. ${1:v}) => {$0}",
     "insertTextFormat": 2
+  }]
+
+Complete src/Completion.res 465:26
+posCursor:[465:26] posNoWhite:[465:25] Found expr:[465:22->465:26]
+Pexp_ident FAR.:[465:22->465:26]
+Completable: Cpath ValueOrField[FAR, ""]
+Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 3 pervasives Completion.res Completion.res
+ContextPath ValueOrField[FAR, ""]
+Path FAR.
+[{
+    "label": "forAutoRecord",
+    "kind": 12,
+    "tags": [],
+    "detail": "forAutoRecord",
+    "documentation": null
+  }, {
+    "label": "forAuto",
+    "kind": 5,
+    "tags": [],
+    "detail": "forAuto: ForAuto.t\n\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}",
+    "documentation": null
+  }, {
+    "label": "something",
+    "kind": 5,
+    "tags": [],
+    "detail": "something: option<int>\n\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}",
+    "documentation": null
   }]
 


### PR DESCRIPTION
This is a QoL improvement intended to simplify the following scenario where you'd constructing a record without a type definition, but the expression is ambiguous and we don't know whether you're constructing a record yet or just typing some other expression:

```rescript
let someRecord = {
  SomeModuleWithTheRecordDefinition.<com>
}
```

Previously you'd only get values from `SomeModuleWithTheRecordDefinition`, but with this change you'll also get any fields visible in that module. 