### PR TITLE
Complete lowercase JSX labels from the domProps type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Better error recovery when analysis fails. https://github.com/rescript-lang/rescript-vscode/pull/880
 - Expand type aliases in hovers. https://github.com/rescript-lang/rescript-vscode/pull/881
 - Include fields when completing a braced expr that's an ID, where it the path likely starts with a module. https://github.com/rescript-lang/rescript-vscode/pull/882
+- Complete domProps for lowercase JSX components from `ReactDOM.domProps` if possible. https://github.com/rescript-lang/rescript-vscode/pull/883
 
 ## 1.32.0
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1585,6 +1585,8 @@ let rec processCompletable ~debug ~full ~scope ~env ~pos ~forHover completable =
     match fromDomProps with
     | Some domProps -> domProps
     | None ->
+      if debug then
+        Printf.printf "Could not find ReactDOM.domProps to complete from.\n";
       (CompletionJsx.domLabels
       |> List.filter (fun (name, _t) ->
              Utils.startsWith name prefix

--- a/analysis/tests/src/CompletionJsx.res
+++ b/analysis/tests/src/CompletionJsx.res
@@ -48,3 +48,6 @@ module CompWithoutJsxPpx = {
 
 // <SomeComponent someProp=>
 //                         ^com
+
+// <h1 hidd
+//         ^com

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -1684,6 +1684,8 @@ Completable: Cjsx([div], name, [name])
 Raw opens: 2 Shadow.B.place holder ... Shadow.A.place holder
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 3 pervasives Completion.res Completion.res
+Path ReactDOM.domProps
+Path Pervasives.JsxDOM.domProps
 {"contents": {"kind": "markdown", "value": "```rescript\nstring\n```"}}
 
 Hover src/Completion.res 349:17

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -492,3 +492,19 @@ Path SomeComponent.make
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionJsx.res 51:11
+posCursor:[51:11] posNoWhite:[51:10] Found expr:[51:4->51:11]
+JSX <h1:[51:4->51:6] hidd[51:7->51:11]=...[51:7->51:11]> _children:None
+Completable: Cjsx([h1], hidd, [hidd])
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+Path ReactDOM.domProps
+Path Pervasives.JsxDOM.domProps
+[{
+    "label": "hidden",
+    "kind": 4,
+    "tags": [],
+    "detail": "bool",
+    "documentation": null
+  }]
+

--- a/analysis/tests/src/expected/Div.res.txt
+++ b/analysis/tests/src/expected/Div.res.txt
@@ -8,6 +8,8 @@ JSX <div:[3:4->3:7] dangerous[3:8->3:17]=...[3:8->3:17]> _children:None
 Completable: Cjsx([div], dangerous, [dangerous])
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 1 pervasives
+Path ReactDOM.domProps
+Path Pervasives.JsxDOM.domProps
 [{
     "label": "dangerouslySetInnerHTML",
     "kind": 4,


### PR DESCRIPTION
Change completion of DOM props of lowercase elements to try to look up `ReactDOM.domProps` first, before falling back to the current method of completing from a pre-defined list of DOM props (that was there because of JSXv3).

This is an adaption to JSXv4, and also a preparation for our upcoming generic JSX transform where we'll want to be able to swap out `domProps` to something custom for the generic transform.