### PR TITLE
Complete creator/maker functions for type t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Include fields when completing a braced expr that's an ID, where it the path likely starts with a module. https://github.com/rescript-lang/rescript-vscode/pull/882
 - Complete domProps for lowercase JSX components from `ReactDOM.domProps` if possible. https://github.com/rescript-lang/rescript-vscode/pull/883
 - Do not emit `_` when completing in patterns. https://github.com/rescript-lang/rescript-vscode/pull/885
+- Complete for maker-style functions (functions returning type `t` of a module) when encountering a `type t` in relevant scenarios. https://github.com/rescript-lang/rescript-vscode/pull/884
 
 ## 1.32.0
 

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -331,6 +331,7 @@ and completionType =
   | Tbool of QueryEnv.t
   | Tarray of QueryEnv.t * innerType
   | Tstring of QueryEnv.t
+  | TtypeT of {env: QueryEnv.t; path: Path.t}
   | Tvariant of {
       env: QueryEnv.t;
       constructors: Constructor.t list;

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -287,3 +287,29 @@ let fnTakingPolyVariant = (a: somePolyVariant) => {
 
 // fnTakingPolyVariant(o)
 //                      ^com
+
+module SuperInt: {
+  type t
+  let increment: (t, int) => t
+  let decrement: (t, int => int) => t
+  let make: int => t
+  let toInt: t => int
+} = {
+  type t = int
+  let increment = (t, num) => t + num
+  let decrement = (t, decrementer) => decrementer(t)
+  let make = t => t
+  let toInt = t => t
+}
+
+type withIntLocal = {superInt: SuperInt.t}
+
+// let withInt: withIntLocal = {superInt: }
+//                                       ^com
+
+// CompletionSupport.makeTestHidden()
+//                                  ^com
+
+open CompletionSupport
+// CompletionSupport.makeTestHidden()
+//                                  ^com

--- a/analysis/tests/src/CompletionSupport.res
+++ b/analysis/tests/src/CompletionSupport.res
@@ -5,6 +5,16 @@ module Test = {
   let make = (name: int): t => {name: name}
 }
 
+module TestHidden: {
+  type t
+  let make: int => t
+  let self: t => t
+} = {
+  type t = {name: int}
+  let make = (name: int): t => {name: name}
+  let self = t => t
+}
+
 type testVariant = One | Two | Three(int)
 
 module TestComponent = {
@@ -26,3 +36,7 @@ module TestComponent = {
 module Nested = {
   type config = {root: ReactDOM.Client.Root.t}
 }
+
+type options = {test: TestHidden.t}
+
+let makeTestHidden = t => TestHidden.self(t)

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1168,8 +1168,8 @@ Path fnTakingPolyVariant
   }]
 
 Complete src/CompletionExpressions.res 281:24
-posCursor:[281:24] posNoWhite:[281:23] Found expr:[281:3->281:25]
-Pexp_apply ...[281:3->281:22] (...[281:23->281:25])
+posCursor:[281:24] posNoWhite:[281:23] Found expr:[281:3->290:18]
+Pexp_apply ...[281:3->281:22] (...[281:23->281:25], ...[290:0->290:16])
 Completable: Cexpression CArgument Value[fnTakingPolyVariant]($0)=#
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 1 pervasives
@@ -1237,6 +1237,62 @@ Path fnTakingPolyVariant
     "detail": "#one\n\n[#one | #three(someRecord, bool) | #two(bool)]",
     "documentation": null,
     "insertText": "#one",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 306:41
+XXX Not found!
+Completable: Cexpression Type[withIntLocal]->recordField(superInt)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Type[withIntLocal]
+Path withIntLocal
+[{
+    "label": "SuperInt.make()",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => t",
+    "documentation": null,
+    "insertText": "SuperInt.make($0)",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 309:36
+posCursor:[309:36] posNoWhite:[309:35] Found expr:[309:3->309:37]
+Pexp_apply ...[309:3->309:35] (...[309:36->309:37])
+Completable: Cexpression CArgument Value[CompletionSupport, makeTestHidden]($0)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CArgument Value[CompletionSupport, makeTestHidden]($0)
+ContextPath Value[CompletionSupport, makeTestHidden]
+Path CompletionSupport.makeTestHidden
+[{
+    "label": "CompletionSupport.TestHidden.make()",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => t",
+    "documentation": null,
+    "insertText": "CompletionSupport.TestHidden.make($0)",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionExpressions.res 313:36
+posCursor:[313:36] posNoWhite:[313:35] Found expr:[313:3->313:37]
+Pexp_apply ...[313:3->313:35] (...[313:36->313:37])
+Completable: Cexpression CArgument Value[CompletionSupport, makeTestHidden]($0)
+Raw opens: 1 CompletionSupport.place holder
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 2 pervasives CompletionSupport.res
+ContextPath CArgument Value[CompletionSupport, makeTestHidden]($0)
+ContextPath Value[CompletionSupport, makeTestHidden]
+Path CompletionSupport.makeTestHidden
+[{
+    "label": "TestHidden.make()",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => t",
+    "documentation": null,
+    "insertText": "TestHidden.make($0)",
     "insertTextFormat": 2
   }]
 


### PR DESCRIPTION
Sometime we reach a `type t` from a module when completing expressions, and cannot go any further because `type t` might be abstract, or something we cannot complete. This is pretty common when using `type t` to hide implementation.

In those scenarios, it's a convention to provide `make` or other creator functions if the type can be constructed. This PR adds completions for all maker-style functions whenever constructing an expression where the expected type is `type t` and we can't go any further in the resolution.

This is going to make APIs where the type is abstract and hidden behind `type t` _a lot_ more discoverable.

Example from a classic situation where the value we're supposed to pass is an abstract `type t` that hides the implementation of `t` and has its own `make` function (quite common scenario):
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/06f1be85-34a4-4e53-96f9-5ab8566810fc)

Another example where `type t` is abstract and hidden behind different maker functions (fairly common in bindings when binding to something very polymorphic that cannot be represented in the type system):
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/12ffdb19-d387-4d31-bec9-fa0d5964825a)

