### PR TITLE
Do not emit _ when completing expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Expand type aliases in hovers. https://github.com/rescript-lang/rescript-vscode/pull/881
 - Include fields when completing a braced expr that's an ID, where it the path likely starts with a module. https://github.com/rescript-lang/rescript-vscode/pull/882
 - Complete domProps for lowercase JSX components from `ReactDOM.domProps` if possible. https://github.com/rescript-lang/rescript-vscode/pull/883
+- Do not emit `_` when completing in patterns. https://github.com/rescript-lang/rescript-vscode/pull/885
 
 ## 1.32.0
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1204,6 +1204,11 @@ type completionMode = Pattern of Completable.patternMode | Expression
 
 let rec completeTypedValue ~full ~prefix ~completionContext ~mode
     (t : SharedTypes.completionType) =
+  let emptyCase num =
+    match mode with
+    | Expression -> "$" ^ string_of_int (num - 1)
+    | Pattern _ -> "${" ^ string_of_int num ^ ":_}"
+  in
   match t with
   | Tbool env ->
     [
@@ -1278,7 +1283,9 @@ let rec completeTypedValue ~full ~prefix ~completionContext ~mode
     let noneCase = Completion.create "None" ~kind:(kindFromInnerType t) ~env in
     let someAnyCase =
       Completion.createWithSnippet ~name:"Some(_)" ~kind:(kindFromInnerType t)
-        ~env ~insertText:"Some(${1:_})" ()
+        ~env
+        ~insertText:(Printf.sprintf "Some(%s)" (emptyCase 1))
+        ()
     in
     let completions =
       match completionContext with
@@ -1338,11 +1345,13 @@ let rec completeTypedValue ~full ~prefix ~completionContext ~mode
     in
     let okAnyCase =
       Completion.createWithSnippet ~name:"Ok(_)" ~kind:(Value okType) ~env
-        ~insertText:"Ok(${1:_})" ()
+        ~insertText:(Printf.sprintf "Ok(%s)" (emptyCase 1))
+        ()
     in
     let errorAnyCase =
       Completion.createWithSnippet ~name:"Error(_)" ~kind:(Value errorType) ~env
-        ~insertText:"Error(${1:_})" ()
+        ~insertText:(Printf.sprintf "Error(%s)" (emptyCase 1))
+        ()
     in
     let completions =
       match completionContext with

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -204,7 +204,7 @@ Path fnTakingRecord
     "tags": [],
     "detail": "otherRecord",
     "documentation": null,
-    "insertText": "Some(${1:_})",
+    "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "None",
@@ -411,7 +411,7 @@ Path fnTakingArray
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "insertText": "Some(${1:_})",
+    "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "Some(true)",
@@ -488,7 +488,7 @@ Path fnTakingArray
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "insertText": "Some(${1:_})",
+    "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "Some(true)",
@@ -525,7 +525,7 @@ Path fnTakingArray
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "insertText": "Some(${1:_})",
+    "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "Some(true)",
@@ -624,7 +624,7 @@ Path fnTakingRecordWithOptVariant
     "tags": [],
     "detail": "someVariant",
     "documentation": null,
-    "insertText": "Some(${1:_})",
+    "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "None",

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -201,7 +201,7 @@ Path someFnTakingVariant
     "detail": "someVariant",
     "documentation": null,
     "sortText": "A Some(_)",
-    "insertText": "Some(${1:_})",
+    "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "Sort",

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -188,7 +188,7 @@ Path someTuple
     "tags": [],
     "detail": "bool",
     "documentation": null,
-    "insertText": "Some(${1:_})",
+    "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "Some(true)",
@@ -224,7 +224,7 @@ Path someVariant
     "tags": [],
     "detail": "type someVariant = One | Two(bool)",
     "documentation": null,
-    "insertText": "Some(${1:_})",
+    "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "Some(One)",


### PR DESCRIPTION
A small touch up that makes sure we don't emit `_` unless we need to when completing in expressions. We emit `_` in patterns and that makes sense, but it doesn't make sense in expressions in all cases.