### PR TITLE
Support inline record fields in doc extraction

### DIFF
--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -3,7 +3,18 @@ open SharedTypes
 let showConstructor {Constructor.cname = {txt}; args; res} =
   txt
   ^ (match args with
-    | Args [] | InlineRecord _ -> ""
+    | Args [] -> ""
+    | InlineRecord fields ->
+      "({"
+      ^ (fields
+        |> List.map (fun (field : field) ->
+               Printf.sprintf "%s%s: %s" field.fname.txt
+                 (if field.optional then "?" else "")
+                 (Shared.typeToString
+                    (if field.optional then Utils.unwrapIfOption field.typ
+                     else field.typ)))
+        |> String.concat ", ")
+      ^ "})"
     | Args args ->
       "("
       ^ (args

--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -156,6 +156,7 @@ let rec stringifyDocItem ?(indentation = 0) ~originalEnv (item : docItem) =
         ("id", Some (wrapInQuotes m.id));
         ("name", Some (wrapInQuotes m.name));
         ("kind", Some (wrapInQuotes "module"));
+        ("docstrings", Some (stringifyDocstrings m.docstring));
         ( "items",
           Some
             (m.items

--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -118,7 +118,7 @@ let stringifyDetail ?(indentation = 0) (detail : docItemDetail) =
                          Some (stringifyDocstrings constructorDoc.docstrings) );
                        ( "signature",
                          Some (wrapInQuotes constructorDoc.signature) );
-                       ( "items",
+                       ( "payload",
                          match constructorDoc.items with
                          | None -> None
                          | Some constructorPayload ->

--- a/analysis/tests/src/DocExtractionRes.res
+++ b/analysis/tests/src/DocExtractionRes.res
@@ -49,7 +49,12 @@ module AnotherModule = {
   let isGoodStatus = (status: SomeInnerModule.status) => status == Stopped
 
   /** Trying how it looks with an inline record in a variant. */
-  type someVariantWithInlineRecords = | /** This has inline records...*/ SomeStuff({offline: bool})
+  type someVariantWithInlineRecords =
+    | /** This has inline records...*/
+    SomeStuff({
+        offline: bool,
+        /** Is the user online? */ online?: bool,
+      })
 
   open ReactDOM
 

--- a/analysis/tests/src/expected/DocExtraction2.res.txt
+++ b/analysis/tests/src/expected/DocExtraction2.res.txt
@@ -24,6 +24,7 @@ preferring found resi file for impl: src/DocExtraction2.resi
     "id": "DocExtraction2.InnerModule",
     "name": "InnerModule",
     "kind": "module",
+    "docstrings": [],
     "items": [
     {
       "id": "DocExtraction2.InnerModule.t",

--- a/analysis/tests/src/expected/DocExtraction2.resi.txt
+++ b/analysis/tests/src/expected/DocExtraction2.resi.txt
@@ -23,6 +23,7 @@ extracting docs for src/DocExtraction2.resi
     "id": "DocExtraction2.InnerModule",
     "name": "InnerModule",
     "kind": "module",
+    "docstrings": [],
     "items": [
     {
       "id": "DocExtraction2.InnerModule.t",

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -52,6 +52,7 @@ extracting docs for src/DocExtractionRes.res
     "id": "DocExtractionRes.SomeInnerModule",
     "name": "SomeInnerModule",
     "kind": "module",
+    "docstrings": ["Another module level docstring here."],
     "items": [
     {
       "id": "DocExtractionRes.SomeInnerModule.status",
@@ -99,6 +100,7 @@ extracting docs for src/DocExtractionRes.res
     "id": "DocExtractionRes.AnotherModule",
     "name": "AnotherModule",
     "kind": "module",
+    "docstrings": ["Mighty fine module here too!"],
     "items": [
     {
       "id": "DocExtractionRes.LinkedModule",
@@ -161,6 +163,7 @@ extracting docs for src/DocExtractionRes.res
     "id": "DocExtractionRes.ModuleWithThingsThatShouldNotBeExported",
     "name": "ModuleWithThingsThatShouldNotBeExported",
     "kind": "module",
+    "docstrings": [],
     "items": [
     {
       "id": "DocExtractionRes.ModuleWithThingsThatShouldNotBeExported.t",

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -125,7 +125,7 @@ extracting docs for src/DocExtractionRes.res
       "id": "DocExtractionRes.AnotherModule.someVariantWithInlineRecords",
       "kind": "type",
       "name": "someVariantWithInlineRecords",
-      "signature": "type someVariantWithInlineRecords =\n  | SomeStuff({offline: bool})",
+      "signature": "type someVariantWithInlineRecords =\n  | SomeStuff({offline: bool, online?: bool})",
       "docstrings": ["Trying how it looks with an inline record in a variant."],
       "detail": 
       {
@@ -134,7 +134,18 @@ extracting docs for src/DocExtractionRes.res
         {
           "name": "SomeStuff",
           "docstrings": ["This has inline records..."],
-          "signature": "SomeStuff"
+          "signature": "SomeStuff({offline: bool, online?: bool})",
+          "inlineRecordFields": [{
+            "name": "offline",
+            "optional": false,
+            "docstrings": [],
+            "signature": "bool"
+          }, {
+            "name": "online",
+            "optional": true,
+            "docstrings": ["Is the user online?"],
+            "signature": "option<bool>"
+          }]
         }]
       }
     }, 

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -137,7 +137,7 @@ extracting docs for src/DocExtractionRes.res
           "name": "SomeStuff",
           "docstrings": ["This has inline records..."],
           "signature": "SomeStuff({offline: bool, online?: bool})",
-          "items": {
+          "payload": {
             "kind": "inlineRecord",
             "fields": [{
               "name": "offline",

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -137,17 +137,20 @@ extracting docs for src/DocExtractionRes.res
           "name": "SomeStuff",
           "docstrings": ["This has inline records..."],
           "signature": "SomeStuff({offline: bool, online?: bool})",
-          "inlineRecordFields": [{
-            "name": "offline",
-            "optional": false,
-            "docstrings": [],
-            "signature": "bool"
-          }, {
-            "name": "online",
-            "optional": true,
-            "docstrings": ["Is the user online?"],
-            "signature": "option<bool>"
-          }]
+          "items": {
+            "kind": "inlineRecord",
+            "fields": [{
+              "name": "offline",
+              "optional": false,
+              "docstrings": [],
+              "signature": "bool"
+            }, {
+              "name": "online",
+              "optional": true,
+              "docstrings": ["Is the user online?"],
+              "signature": "option<bool>"
+            }]
+          }
         }]
       }
     }, 

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :bug: Bug Fix
 
-- Support inline record fields in constructors.
+- Support inline record fields in constructors. https://github.com/rescript-lang/rescript-vscode/pull/889
 - Fix docstrings for module alias. Get internal docstrings of module file. https://github.com/rescript-lang/rescript-vscode/pull/878
 - Fix extracted docs of types include escaped linebreaks in signature. https://github.com/rescript-lang/rescript-vscode/pull/891
 

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### :bug: Bug Fix
 
+- Support inline record fields in constructors.
 - Fix docstrings for module alias. Get internal docstrings of module file. https://github.com/rescript-lang/rescript-vscode/pull/878
 - Fix extracted docs of types include escaped linebreaks in signature. https://github.com/rescript-lang/rescript-vscode/pull/891
 

--- a/tools/src/Tools_Docgen.res
+++ b/tools/src/Tools_Docgen.res
@@ -11,6 +11,7 @@ type constructor = {
   docstrings: array<string>,
   signature: string,
   deprecated?: string,
+  inlineRecordFields?: array<field>,
 }
 
 @tag("kind")
@@ -54,159 +55,6 @@ type rec item =
       items: array<item>,
     })
 
-let decodeDocstrings = item => {
-  open Js.Json
-  switch item->Js.Dict.get("docstrings") {
-  | Some(Array(arr)) =>
-    arr->Js.Array2.map(s =>
-      switch s {
-      | String(s) => s
-      | _ => assert(false)
-      }
-    )
-  | _ => []
-  }
-}
-
-let decodeStringByField = (item, field) => {
-  open Js.Json
-  switch item->Js.Dict.get(field) {
-  | Some(String(s)) => s
-  | _ => assert(false)
-  }
-}
-
-let decodeDepreacted = item => {
-  open Js.Json
-  switch item->Js.Dict.get("deprecated") {
-  | Some(String(s)) => Some(s)
-  | _ => None
-  }
-}
-
-let decodeRecordFields = fields => {
-  open Js.Json
-  let items = fields->Js.Array2.map(field => {
-    switch field {
-    | Object(doc) => {
-        let name = doc->decodeStringByField("name")
-        let docstrings = doc->decodeDocstrings
-        let signature = doc->decodeStringByField("signature")
-        let deprecated = doc->decodeDepreacted
-        let optional = switch Js.Dict.get(doc, "optional") {
-        | Some(Boolean(bool)) => bool
-        | _ => assert(false)
-        }
-
-        {name, docstrings, signature, optional, ?deprecated}
-      }
-
-    | _ => assert(false)
-    }
-  })
-  Record({items: items})
-}
-
-let decodeConstructorFields = fields => {
-  open Js.Json
-  let items = fields->Js.Array2.map(field => {
-    switch field {
-    | Object(doc) => {
-        let name = doc->decodeStringByField("name")
-        let docstrings = doc->decodeDocstrings
-        let signature = doc->decodeStringByField("signature")
-        let deprecated = doc->decodeDepreacted
-
-        {name, docstrings, signature, ?deprecated}
-      }
-
-    | _ => assert(false)
-    }
-  })
-  Variant({items: items})
-}
-
-let decodeDetail = detail => {
-  open Js.Json
-
-  switch detail {
-  | Object(detail) =>
-    switch (detail->Js.Dict.get("kind"), detail->Js.Dict.get("items")) {
-    | (Some(String(kind)), Some(Array(items))) =>
-      switch kind {
-      | "record" => decodeRecordFields(items)
-      | "variant" => decodeConstructorFields(items)
-      | _ => assert(false)
-      }
-    | _ => assert(false)
-    }
-
-  | _ => assert(false)
-  }
-}
-
-let rec decodeValue = item => {
-  let id = item->decodeStringByField("id")
-  let signature = item->decodeStringByField("signature")
-  let name = item->decodeStringByField("name")
-  let deprecated = item->decodeDepreacted
-  let docstrings = item->decodeDocstrings
-  Value({id, docstrings, signature, name, ?deprecated})
-}
-and decodeType = item => {
-  let id = item->decodeStringByField("id")
-  let signature = item->decodeStringByField("signature")
-  let name = item->decodeStringByField("name")
-  let deprecated = item->decodeDepreacted
-  let docstrings = item->decodeDocstrings
-  let detail = switch item->Js_dict.get("detail") {
-  | Some(field) => decodeDetail(field)->Some
-  | None => None
-  }
-  Type({id, docstrings, signature, name, ?deprecated, ?detail})
-}
-and decodeModuleAlias = item => {
-  open Js.Json
-  let id = item->decodeStringByField("id")
-  let name = item->decodeStringByField("name")
-  let docstrings = item->decodeDocstrings
-  let items = switch Js.Dict.get(item, "items") {
-  | Some(Array(items)) => items->Js.Array2.map(item => decodeItem(item))
-  | _ => assert(false)
-  }
-  ModuleAlias({id, items, name, docstrings})
-}
-and decodeModule = item => {
-  open Js.Json
-  let id = item->decodeStringByField("id")
-  let name = item->decodeStringByField("name")
-  let deprecated = item->decodeDepreacted
-  let docstrings = item->decodeDocstrings
-  let items = switch Js.Dict.get(item, "items") {
-  | Some(Array(items)) => items->Js.Array2.map(item => decodeItem(item))
-  | _ => assert(false)
-  }
-  Module({id, name, docstrings, ?deprecated, items})
-}
-and decodeItem = item => {
-  open Js.Json
-  switch item {
-  | Object(value) =>
-    switch Js.Dict.get(value, "kind") {
-    | Some(String(kind)) =>
-      switch kind {
-      | "type" => decodeType(value)
-      | "value" => decodeValue(value)
-      | "module" => decodeModule(value)
-      | "moduleAlias" => decodeModuleAlias(value)
-      | _ => assert(false)
-      }
-    | _ => assert(false)
-    }
-  | _ => assert(false)
-  }
-}
-
 type doc = {
   name: string,
   deprecated: option<string>,
@@ -217,22 +65,4 @@ type doc = {
 /**
 `decodeFromJson(json)` parse JSON generated from `restool doc` command
 */
-let decodeFromJson = json => {
-  open Js.Json
-
-  switch json {
-  | Object(mod) => {
-      let name = mod->decodeStringByField("name")
-      let deprecated = mod->decodeDepreacted
-      let docstrings = mod->decodeDocstrings
-      let items = switch Js.Dict.get(mod, "items") {
-      | Some(Array(items)) => items->Js.Array2.map(item => decodeItem(item))
-      | _ => assert(false)
-      }
-
-      {name, deprecated, docstrings, items}
-    }
-
-  | _ => assert(false)
-  }
-}
+external decodeFromJson: Js.Json.t => doc = "%identity"

--- a/tools/src/Tools_Docgen.res
+++ b/tools/src/Tools_Docgen.res
@@ -6,12 +6,15 @@ type field = {
   deprecated?: string,
 }
 
+@tag("kind")
+type constructorPayload = | @as("inlineRecord") InlineRecord({fields: array<field>})
+
 type constructor = {
   name: string,
   docstrings: array<string>,
   signature: string,
   deprecated?: string,
-  inlineRecordFields?: array<field>,
+  constructorPayload?: constructorPayload,
 }
 
 @tag("kind")

--- a/tools/src/Tools_Docgen.res
+++ b/tools/src/Tools_Docgen.res
@@ -14,7 +14,7 @@ type constructor = {
   docstrings: array<string>,
   signature: string,
   deprecated?: string,
-  constructorPayload?: constructorPayload,
+  payload?: constructorPayload,
 }
 
 @tag("kind")

--- a/tools/src/Tools_Docgen.resi
+++ b/tools/src/Tools_Docgen.resi
@@ -10,6 +10,7 @@ type constructor = {
   docstrings: array<string>,
   signature: string,
   deprecated?: string,
+  inlineRecordFields?: array<field>,
 }
 @tag("kind")
 type detail =
@@ -54,9 +55,4 @@ type rec item =
 
 type doc = {name: string, deprecated: option<string>, docstrings: array<string>, items: array<item>}
 
-let decodeValue: Js.Dict.t<Js.Json.t> => item
-let decodeType: Js.Dict.t<Js.Json.t> => item
-let decodeModule: Js.Dict.t<Js.Json.t> => item
-let decodeModuleAlias: Js.Dict.t<Js.Json.t> => item
-let decodeItem: Js.Json.t => item
 let decodeFromJson: Js.Json.t => doc

--- a/tools/src/Tools_Docgen.resi
+++ b/tools/src/Tools_Docgen.resi
@@ -14,7 +14,7 @@ type constructor = {
   docstrings: array<string>,
   signature: string,
   deprecated?: string,
-  constructorPayload?: constructorPayload,
+  payload?: constructorPayload,
 }
 @tag("kind")
 type detail =

--- a/tools/src/Tools_Docgen.resi
+++ b/tools/src/Tools_Docgen.resi
@@ -5,12 +5,16 @@ type field = {
   optional: bool,
   deprecated?: string,
 }
+
+@tag("kind")
+type constructorPayload = | @as("inlineRecord") InlineRecord({fields: array<field>})
+
 type constructor = {
   name: string,
   docstrings: array<string>,
   signature: string,
   deprecated?: string,
-  inlineRecordFields?: array<field>,
+  constructorPayload?: constructorPayload,
 }
 @tag("kind")
 type detail =


### PR DESCRIPTION
Closes https://github.com/rescript-lang/rescript-vscode/issues/887

I've also removed all of the JSON decoding code, because with untagged variants we can just map to the result zero cost, which is a lot easier to maintain.

cc @aspeddro 