### PR TITLE
fix extracted docs of types include escaped linebreaks in signature

### DIFF
--- a/analysis/src/DocExtraction.ml
+++ b/analysis/src/DocExtraction.ml
@@ -112,13 +112,13 @@ let rec stringifyDocItem ?(indentation = 0) ~originalEnv (item : docItem) =
       [
         ("id", Some (wrapInQuotes id));
         ("kind", Some (wrapInQuotes "value"));
-        ("name", Some (name |> Json.escape |> wrapInQuotes));
+        ("name", Some (name |> wrapInQuotes));
         ( "deprecated",
           match deprecated with
           | Some d -> Some (wrapInQuotes d)
           | None -> None );
         ( "signature",
-          Some (signature |> String.trim |> Json.escape |> wrapInQuotes) );
+          Some (signature |> String.trim |> wrapInQuotes) );
         ("docstrings", Some (stringifyDocstrings docstring));
       ]
   | Type {id; docstring; signature; name; deprecated; detail} ->
@@ -126,12 +126,12 @@ let rec stringifyDocItem ?(indentation = 0) ~originalEnv (item : docItem) =
       [
         ("id", Some (wrapInQuotes id));
         ("kind", Some (wrapInQuotes "type"));
-        ("name", Some (name |> Json.escape |> wrapInQuotes));
+        ("name", Some (name |> wrapInQuotes));
         ( "deprecated",
           match deprecated with
           | Some d -> Some (wrapInQuotes d)
           | None -> None );
-        ("signature", Some (signature |> Json.escape |> wrapInQuotes));
+        ("signature", Some (signature |> wrapInQuotes));
         ("docstrings", Some (stringifyDocstrings docstring));
         ( "detail",
           match detail with

--- a/analysis/tests/src/DocExtractionRes.res
+++ b/analysis/tests/src/DocExtractionRes.res
@@ -22,6 +22,9 @@ let make = name => {
 /** Stuff goes offline.*/
 let asOffline = (t: t) => {...t, online: false}
 
+/** exotic identifier */
+let \"SomeConstant\" = 12
+
 module SomeInnerModule = {
   /*** Another module level docstring here.*/
   type status =

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -42,6 +42,13 @@ extracting docs for src/DocExtractionRes.res
     "docstrings": ["Stuff goes offline."]
   }, 
   {
+    "id": "DocExtractionRes.SomeConstant\\",
+    "kind": "value",
+    "name": "SomeConstant\\",
+    "signature": "let SomeConstant\\: int",
+    "docstrings": ["exotic identifier"]
+  }, 
+  {
     "id": "DocExtractionRes.SomeInnerModule",
     "name": "SomeInnerModule",
     "kind": "module",

--- a/analysis/tests/src/expected/DocExtractionRes.res.txt
+++ b/analysis/tests/src/expected/DocExtractionRes.res.txt
@@ -77,7 +77,7 @@ extracting docs for src/DocExtractionRes.res
       "id": "DocExtractionRes.SomeInnerModule.validInputs",
       "kind": "type",
       "name": "validInputs",
-      "signature": "type validInputs = [\\n  | #\\\"needs-escaping\\\"\\n  | #something\\n  | #status(status)\\n  | #withPayload(int)\\n]",
+      "signature": "type validInputs = [\n  | #\"needs-escaping\"\n  | #something\n  | #status(status)\n  | #withPayload(int)\n]",
       "docstrings": ["These are all the valid inputs."]
     }, 
     {
@@ -118,7 +118,7 @@ extracting docs for src/DocExtractionRes.res
       "id": "DocExtractionRes.AnotherModule.someVariantWithInlineRecords",
       "kind": "type",
       "name": "someVariantWithInlineRecords",
-      "signature": "type someVariantWithInlineRecords =\\n  | SomeStuff({offline: bool})",
+      "signature": "type someVariantWithInlineRecords =\n  | SomeStuff({offline: bool})",
       "docstrings": ["Trying how it looks with an inline record in a variant."],
       "detail": 
       {

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug Fix
 
 - Fix docstrings for module alias. Get internal docstrings of module file. https://github.com/rescript-lang/rescript-vscode/pull/878
+- Fix extracted docs of types include escaped linebreaks in signature. https://github.com/rescript-lang/rescript-vscode/pull/891
 
 ## 0.3.0
 


### PR DESCRIPTION
Closes #888

`Json.escape` was called twice:

- once explicitly
- twice in `Protocol.wrapInQuotes`

I also updated the test, to not contain e.g. `\\n`

Since this is my first PR in this repo, I hope this is fine?