### PR TITLE
Fix bug with pipe completion not working inside fn call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix issue with ambigious wraps in JSX prop values (`<SomeComp someProp={<com>}`) - need to figure out if we're completing for a record body or if `{}` are just wraps for the type of `someProp`. In the case of ambiguity, completions for both scenarios are provided. https://github.com/rescript-lang/rescript-vscode/pull/894
 - Many bugfixes around nested pattern and expression completion. https://github.com/rescript-lang/rescript-vscode/pull/892
+- Fix (very annoying) issue where empty pipe completion wouldn't work inside of a parenthesised function call: `Console.log(someArray->)` completing at the pipe. https://github.com/rescript-lang/rescript-vscode/pull/895
 
 #### :nail_care: Polish
 

--- a/analysis/tests/src/CompletionPipeChain.res
+++ b/analysis/tests/src/CompletionPipeChain.res
@@ -92,3 +92,9 @@ let renderer = CompletionSupport2.makeRenderer(
   },
   (),
 )
+
+// Console.log(int->)
+//                  ^com
+
+// Console.log(int->t)
+//                   ^com

--- a/analysis/tests/src/expected/CompletionPipeChain.res.txt
+++ b/analysis/tests/src/expected/CompletionPipeChain.res.txt
@@ -490,3 +490,66 @@ Path ReactDOM.Client.Root.ren
     "documentation": null
   }]
 
+Complete src/CompletionPipeChain.res 95:20
+posCursor:[95:20] posNoWhite:[95:19] Found expr:[95:3->95:21]
+Pexp_apply ...[95:3->95:14] (...[95:15->0:-1])
+posCursor:[95:20] posNoWhite:[95:19] Found expr:[95:15->0:-1]
+posCursor:[95:20] posNoWhite:[95:19] Found expr:[95:15->0:-1]
+Completable: Cpath Value[int]->
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[int]->
+ContextPath Value[int]
+Path int
+CPPipe env:CompletionPipeChain
+CPPipe type path:Integer.t
+CPPipe pathFromEnv:Integer found:true
+Path Integer.
+[{
+    "label": "Integer.toInt",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => int",
+    "documentation": null
+  }, {
+    "label": "Integer.increment",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, int) => t",
+    "documentation": null
+  }, {
+    "label": "Integer.decrement",
+    "kind": 12,
+    "tags": [],
+    "detail": "(t, int => int) => t",
+    "documentation": null
+  }, {
+    "label": "Integer.make",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => t",
+    "documentation": null
+  }]
+
+Complete src/CompletionPipeChain.res 98:21
+posCursor:[98:21] posNoWhite:[98:20] Found expr:[98:3->98:22]
+Pexp_apply ...[98:3->98:14] (...[98:15->98:21])
+posCursor:[98:21] posNoWhite:[98:20] Found expr:[98:15->98:21]
+Completable: Cpath Value[int]->t
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[int]->t
+ContextPath Value[int]
+Path int
+CPPipe env:CompletionPipeChain
+CPPipe type path:Integer.t
+CPPipe pathFromEnv:Integer found:true
+Path Integer.t
+[{
+    "label": "Integer.toInt",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => int",
+    "documentation": null
+  }]
+


### PR DESCRIPTION
This fixes a fantastically annoying bug where pipe completion doesn't work inside of function calls, e.g: `Console.log(someArr->)`, completing on the empty pipe.

This covers at least the most common case, we'll see if there are more cases to handle too after this fix is shipped. I also feel like this is a bug that shouldn't even be possible if the completion engine does the right thing, so I'll add this to my (ever growing) "refactor completion engine" list.

But this fixes one of the annoying issues for now, so it's definitely worth shipping. 