### PR TITLE
tools: docstring for nested submodules

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ## master
 
+#### :bug: Bug Fix
+
+- Print docstrings for nested submodules. https://github.com/rescript-lang/rescript-vscode/pull/897
+- Print `deprecated` field for module. https://github.com/rescript-lang/rescript-vscode/pull/897
+
 ## 0.4.0
 
 #### :bug: Bug Fix

--- a/tools/tests/src/ModC.res
+++ b/tools/tests/src/ModC.res
@@ -1,0 +1,6 @@
+/**
+User Module
+*/
+module User = {
+  let name = "ReScript"
+}

--- a/tools/tests/src/ModC.resi
+++ b/tools/tests/src/ModC.resi
@@ -1,0 +1,6 @@
+/**
+User Module from interface file
+*/
+module User: {
+  let name: string
+}

--- a/tools/tests/src/expected/ModC.res.json
+++ b/tools/tests/src/expected/ModC.res.json
@@ -1,0 +1,20 @@
+
+{
+  "name": "ModC",
+  "docstrings": [],
+  "items": [
+  {
+    "id": "ModC.User",
+    "name": "User",
+    "kind": "module",
+    "docstrings": ["User Module from interface file"],
+    "items": [
+    {
+      "id": "ModC.User.name",
+      "kind": "value",
+      "name": "name",
+      "signature": "let name: string",
+      "docstrings": []
+    }]
+  }]
+}

--- a/tools/tests/src/expected/ModC.resi.json
+++ b/tools/tests/src/expected/ModC.resi.json
@@ -1,0 +1,20 @@
+
+{
+  "name": "ModC",
+  "docstrings": [],
+  "items": [
+  {
+    "id": "ModC.User",
+    "name": "User",
+    "kind": "module",
+    "docstrings": ["User Module from interface file"],
+    "items": [
+    {
+      "id": "ModC.User.name",
+      "kind": "value",
+      "name": "name",
+      "signature": "let name: string",
+      "docstrings": []
+    }]
+  }]
+}


### PR DESCRIPTION
The output doesn't print docstrings for nested submodules in interface files.

Example: API Docs for [Core.Math.Constants](https://rescript-lang.org/docs/manual/latest/api/core/math/constants)

- [Core__Math.resi](https://github.com/rescript-association/rescript-core/blob/532af3a588a1144a5d867abc8e73a64e2d2b7c63/src/Core__Math.resi#L30-L33)


Now

```sh
dune exec -- rescript-tools doc ~/Desktop/projects/rescript-core/src/Core__Math.res | head
```

```
{
  "name": "Core__Math",
  "docstrings": ["Functions for interacting with JavaScript Math.\nSee: [`Math`](https://developer.mozil
la.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math)."],
  "items": [
  {
    "id": "Core__Math.Constants",
    "name": "Constants",
    "kind": "module",
    "docstrings": ["Mathematical Constants"],
```

### Other Change

- Print `deprecated` field for module