### PR TITLE
add earlybird debugger support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,25 @@
 			"outFiles": [
 				"${workspaceRoot}/client/out/test/**/*.js"
 			]
-		}
+		},
+		{
+			"name": "OCaml earlybird (experimental)",
+			"type": "ocaml.earlybird",
+			"request": "launch",
+			"program": "${workspaceFolder}/_build/default/analysis/bin/main.bc",
+			"arguments": [
+				"test",
+				"./tests/src/Pipe.res"
+			],
+			"cwd": "${workspaceFolder}/analysis",
+			"env": {
+				"LD_LIBRARY_PATH": "${workspaceFolder}/_build/default/analysis/vendor/ext"
+			},
+			"stopOnEntry": true,
+      "console": "integratedTerminal",
+			"onlyDebugGlob": "<${workspaceFolder}/**/*>",
+      "yieldSteps": 1024,
+		},
 	],
 	"compounds": [
 		{

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
 	"typescript.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single",
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	},
 	"ocaml.sandbox": {
 		"kind": "opam",

--- a/analysis.opam
+++ b/analysis.opam
@@ -8,10 +8,11 @@ bug-reports: "https://github.com/rescript-lang/rescript-vscode/issues"
 depends: [
   "ocaml" {>= "4.10"}
   "cppo" {= "1.6.9"}
-  "dune"
+  "dune" {>= "3.7"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/analysis/reanalyze/examples/deadcode/package-lock.json
+++ b/analysis/reanalyze/examples/deadcode/package-lock.json
@@ -1,125 +1,8 @@
 {
   "name": "deadcode",
   "version": "0.1.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "deadcode",
-      "version": "0.1.0",
-      "dependencies": {
-        "@glennsl/bs-json": "^5.0.4",
-        "@rescript/react": "^0.10.3"
-      },
-      "devDependencies": {
-        "react": "^16.13.1",
-        "react-dom": "^16.8.6",
-        "rescript": "^10.1.2"
-      }
-    },
-    "node_modules/@glennsl/bs-json": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@glennsl/bs-json/-/bs-json-5.0.4.tgz",
-      "integrity": "sha512-Th9DetZjRlMZrb74kgGJ44oWcoFyOTE884WlSuXft0Cd+J09vHRxiB7eVyK7Gthb4cSevsBBJDHYAbGGL25wPw=="
-    },
-    "node_modules/@rescript/react": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.10.3.tgz",
-      "integrity": "sha512-Lf9rzrR3bQPKJjOK3PBRa/B3xrJ7CqQ1HYr9VHPVxJidarIJJFZBhj0Dg1uZURX+Wg/xiP0PHFxXmdj2bK8Vxw==",
-      "peerDependencies": {
-        "react": ">=16.8.1",
-        "react-dom": ">=16.8.1"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/rescript": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.2.tgz",
-      "integrity": "sha512-PPdhOiN+lwqxQ0qvzHc1KW0TL12LDy2X+qo/JIMIP3bMfiH0vxQH2e/lXuoutWWm04fGQGTv3hWH+gKW3/UyfA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "bsc": "bsc",
-        "bsrefmt": "bsrefmt",
-        "bstracing": "lib/bstracing",
-        "rescript": "rescript"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    }
-  },
   "dependencies": {
     "@glennsl/bs-json": {
       "version": "5.0.4",
@@ -129,18 +12,19 @@
     "@rescript/react": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.10.3.tgz",
-      "integrity": "sha512-Lf9rzrR3bQPKJjOK3PBRa/B3xrJ7CqQ1HYr9VHPVxJidarIJJFZBhj0Dg1uZURX+Wg/xiP0PHFxXmdj2bK8Vxw==",
-      "requires": {}
+      "integrity": "sha512-Lf9rzrR3bQPKJjOK3PBRa/B3xrJ7CqQ1HYr9VHPVxJidarIJJFZBhj0Dg1uZURX+Wg/xiP0PHFxXmdj2bK8Vxw=="
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -148,12 +32,14 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
     },
     "prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -164,6 +50,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -174,6 +61,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -184,7 +72,8 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "rescript": {
       "version": "10.1.2",
@@ -196,6 +85,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/analysis/reanalyze/examples/termination/package-lock.json
+++ b/analysis/reanalyze/examples/termination/package-lock.json
@@ -1,30 +1,8 @@
 {
   "name": "termination",
   "version": "0.1.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "termination",
-      "version": "0.1.0",
-      "devDependencies": {
-        "rescript": "^10.1.2"
-      }
-    },
-    "node_modules/rescript": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.2.tgz",
-      "integrity": "sha512-PPdhOiN+lwqxQ0qvzHc1KW0TL12LDy2X+qo/JIMIP3bMfiH0vxQH2e/lXuoutWWm04fGQGTv3hWH+gKW3/UyfA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "bsc": "bsc",
-        "bsrefmt": "bsrefmt",
-        "bstracing": "lib/bstracing",
-        "rescript": "rescript"
-      }
-    }
-  },
   "dependencies": {
     "rescript": {
       "version": "10.1.2",

--- a/analysis/tests/package-lock.json
+++ b/analysis/tests/package-lock.json
@@ -1,158 +1,17 @@
 {
-  "name": "tests",
-  "lockfileVersion": 2,
   "requires": true,
-  "packages": {
-    "": {
-      "dependencies": {
-        "rescript": "11.0.1"
-      },
-      "devDependencies": {
-        "@rescript/react": "0.12.0"
-      }
-    },
-    "node_modules/@rescript/react": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.0.tgz",
-      "integrity": "sha512-EBLsf5rD7sJOjgfLLGwuLw/hONszc3UtYnIVgv7OdTyUNR41/m4deVm62PI0agvr3kWakXz4KchKRSd+19/bRA==",
-      "dev": true,
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/rescript": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.1.tgz",
-      "integrity": "sha512-7T4PRp/d0+CBNnY6PYKffFqo9tGZlvnZpboF/n+8SKS+JZ6VvXJO7W538VPZXf3EYx1COGAWWvkF9e/HgSAqHg==",
-      "hasInstallScript": true,
-      "bin": {
-        "bsc": "bsc",
-        "bstracing": "lib/bstracing",
-        "rescript": "rescript"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    }
-  },
+  "lockfileVersion": 1,
   "dependencies": {
     "@rescript/react": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.0.tgz",
       "integrity": "sha512-EBLsf5rD7sJOjgfLLGwuLw/hONszc3UtYnIVgv7OdTyUNR41/m4deVm62PI0agvr3kWakXz4KchKRSd+19/bRA==",
-      "dev": true,
-      "requires": {}
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "peer": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      }
+      "dev": true
     },
     "rescript": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.1.tgz",
       "integrity": "sha512-7T4PRp/d0+CBNnY6PYKffFqo9tGZlvnZpboF/n+8SKS+JZ6VvXJO7W538VPZXf3EYx1COGAWWvkF9e/HgSAqHg=="
-    },
-    "scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
     }
   }
 }

--- a/analysis/tests/src/Pipe.res
+++ b/analysis/tests/src/Pipe.res
@@ -1,0 +1,30 @@
+type m = {name: string}
+
+module M1 = {
+  type t = m
+
+  let handle = (m: t) => {
+    assert false
+  }
+}
+
+module M2 = {
+  type t = m
+
+  let handle = (m: t) => {
+    assert false
+  }
+}
+
+let m: m = {
+  name: "zm",
+}
+
+let m1: M1.t = {
+  name: "zm",
+}
+
+let m2: M2.t = m1
+
+// m1->
+//     ^com

--- a/analysis/tests/src/expected/Pipe.res.txt
+++ b/analysis/tests/src/expected/Pipe.res.txt
@@ -1,0 +1,20 @@
+Complete src/Pipe.res 28:7
+posCursor:[28:7] posNoWhite:[28:6] Found expr:[28:3->0:-1]
+Completable: Cpath Value[m1]->
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[m1]->
+ContextPath Value[m1]
+Path m1
+CPPipe env:Pipe
+CPPipe type path:M1.t
+CPPipe pathFromEnv:M1 found:true
+Path M1.
+[{
+    "label": "M1.handle",
+    "kind": 12,
+    "tags": [],
+    "detail": "t => 'a",
+    "documentation": null
+  }]
+

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,6 @@
-(lang dune 2.3)
+(lang dune 3.7)
+
+;; from 2.3 to 3.7, for earlybird debugger
 
 (generate_opam_files true)
 
@@ -9,6 +11,10 @@
 (homepage "https://github.com/rescript-lang/rescript-vscode")
 
 (bug_reports "https://github.com/rescript-lang/rescript-vscode/issues")
+
+;; for earlybird debugger
+
+(map_workspace_root false)
 
 (package
  (name analysis)

--- a/tools.opam
+++ b/tools.opam
@@ -9,10 +9,11 @@ depends: [
   "ocaml" {>= "4.10"}
   "cppo" {= "1.6.9"}
   "analysis"
-  "dune"
+  "dune" {>= "3.7"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/tools/tests/package-lock.json
+++ b/tools/tests/package-lock.json
@@ -1,92 +1,18 @@
 {
   "name": "docstrings-test",
   "version": "0.0.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "docstrings-test",
-      "version": "0.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@rescript/react": "^0.12.0-alpha.3",
-        "rescript": "^11.0.0"
-      }
+  "dependencies": {
+    "@rescript/react": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmmirror.com/@rescript/react/-/react-0.12.0.tgz",
+      "integrity": "sha512-EBLsf5rD7sJOjgfLLGwuLw/hONszc3UtYnIVgv7OdTyUNR41/m4deVm62PI0agvr3kWakXz4KchKRSd+19/bRA=="
     },
-    "node_modules/@rescript/react": {
-      "version": "0.12.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.0-alpha.3.tgz",
-      "integrity": "sha512-/S1uj77RPDzuLg3Ofb8KKU3Vppqy97/vF6bBdBZ+saIO9bpHVlsmmJyJG8QXjGZKE+aMynrrR3Tj4+9+5OzLdw==",
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "peer": true
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/rescript": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.0.tgz",
-      "integrity": "sha512-uIUwDZZmDUb7ymGkBiiGioxMg8hXh1mze/2k/qhYQcZGgi7PrLHQIW9AksM7gb9WnpjCAvFsA8U2VgC0nA468w==",
-      "hasInstallScript": true,
-      "bin": {
-        "bsc": "bsc",
-        "bstracing": "lib/bstracing",
-        "rescript": "rescript"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+    "rescript": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmmirror.com/rescript/-/rescript-11.0.1.tgz",
+      "integrity": "sha512-7T4PRp/d0+CBNnY6PYKffFqo9tGZlvnZpboF/n+8SKS+JZ6VvXJO7W538VPZXf3EYx1COGAWWvkF9e/HgSAqHg=="
     }
   }
 }


### PR DESCRIPTION
Hi, i add earlybird debugger support in my fork of rescript-vscode. I think the visual debugger support can let more people easily to understand the OCaml analysis code logic and participate into our rescript-vscode development.
Here are the steps to initialize.
1. opam install earlybird
2. select OCaml earlybird(experimantal) item in RUN AND DEBUG in vscode.
3. add some breakpoints in the code, then everything is fine.
The earlybird is much useful then i ever thought, currently some breakpoints may not be worked, may be some bugs exist in earlybird, just try again.
![image](https://github.com/rescript-lang/rescript-vscode/assets/21278900/5fca7672-879e-4c42-a46a-16b75a10013c)

