### PR TITLE
Enhance module attribute completion some more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Enhance decorator completion. https://github.com/rescript-lang/rescript-vscode/pull/908
 - Completion for import attributes in `@module`. https://github.com/rescript-lang/rescript-vscode/pull/913
+- Relax filter for what local files that come up in from and regular string completion in `@module`. https://github.com/rescript-lang/rescript-vscode/pull/918
+- Make from completion trigger for expr hole so we get a nice experience when completing {from: <com>} in `@module`. https://github.com/rescript-lang/rescript-vscode/pull/918
 
 ## 1.38.0
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1884,6 +1884,7 @@ let rec processCompletable ~debug ~full ~scope ~env ~pos ~forHover completable =
                  match Filename.extension fileName with
                  | ".res" | ".resi" | "" -> None
                  | _ -> Some ("./" ^ fileName))
+        |> List.sort String.compare
       with _ ->
         if debug then print_endline "Could not read relative directory";
         []

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1882,8 +1882,8 @@ let rec processCompletable ~debug ~full ~scope ~env ~pos ~forHover completable =
                then None
                else
                  match Filename.extension fileName with
-                 | ".js" | ".mjs" -> Some ("./" ^ fileName)
-                 | _ -> None)
+                 | ".res" | ".resi" | "" -> None
+                 | _ -> Some ("./" ^ fileName))
       with _ ->
         if debug then print_endline "Could not read relative directory";
         []

--- a/analysis/tests/src/CompletionAttributes.res
+++ b/analysis/tests/src/CompletionAttributes.res
@@ -31,3 +31,6 @@
 // @module({from: "" }) external doStuff: t = "default"
 //                 ^com
 
+// @module({from: }) external doStuff: t = "default"
+//               ^com
+

--- a/analysis/tests/src/expected/CompletionAttributes.res.txt
+++ b/analysis/tests/src/expected/CompletionAttributes.res.txt
@@ -25,7 +25,7 @@ Resolved opens 1 pervasives
     "detail": "Package",
     "documentation": null
   }, {
-    "label": "./test.json",
+    "label": "./TableclothMap.ml",
     "kind": 4,
     "tags": [],
     "detail": "Local file",
@@ -37,7 +37,7 @@ Resolved opens 1 pervasives
     "detail": "Local file",
     "documentation": null
   }, {
-    "label": "./TableclothMap.ml",
+    "label": "./test.json",
     "kind": 4,
     "tags": [],
     "detail": "Local file",
@@ -204,7 +204,7 @@ Resolved opens 1 pervasives
     "detail": "Package",
     "documentation": null
   }, {
-    "label": "./test.json",
+    "label": "./TableclothMap.ml",
     "kind": 4,
     "tags": [],
     "detail": "Local file",
@@ -216,7 +216,7 @@ Resolved opens 1 pervasives
     "detail": "Local file",
     "documentation": null
   }, {
-    "label": "./TableclothMap.ml",
+    "label": "./test.json",
     "kind": 4,
     "tags": [],
     "detail": "Local file",
@@ -241,7 +241,7 @@ Resolved opens 1 pervasives
     "detail": "Package",
     "documentation": null
   }, {
-    "label": "./test.json",
+    "label": "./TableclothMap.ml",
     "kind": 4,
     "tags": [],
     "detail": "Local file",
@@ -253,7 +253,7 @@ Resolved opens 1 pervasives
     "detail": "Local file",
     "documentation": null
   }, {
-    "label": "./TableclothMap.ml",
+    "label": "./test.json",
     "kind": 4,
     "tags": [],
     "detail": "Local file",

--- a/analysis/tests/src/expected/CompletionAttributes.res.txt
+++ b/analysis/tests/src/expected/CompletionAttributes.res.txt
@@ -25,6 +25,24 @@ Resolved opens 1 pervasives
     "detail": "Package",
     "documentation": null
   }, {
+    "label": "./test.json",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }, {
+    "label": "./TableclothMap.mli",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }, {
+    "label": "./TableclothMap.ml",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }, {
     "label": "./tst.js",
     "kind": 4,
     "tags": [],
@@ -184,6 +202,61 @@ Resolved opens 1 pervasives
     "kind": 4,
     "tags": [],
     "detail": "Package",
+    "documentation": null
+  }, {
+    "label": "./test.json",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }, {
+    "label": "./TableclothMap.mli",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }, {
+    "label": "./TableclothMap.ml",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }, {
+    "label": "./tst.js",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }]
+
+Complete src/CompletionAttributes.res 33:17
+XXX Not found!
+Completable: CdecoratorPayload(module=)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+[{
+    "label": "@rescript/react",
+    "kind": 4,
+    "tags": [],
+    "detail": "Package",
+    "documentation": null
+  }, {
+    "label": "./test.json",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }, {
+    "label": "./TableclothMap.mli",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
+    "documentation": null
+  }, {
+    "label": "./TableclothMap.ml",
+    "kind": 4,
+    "tags": [],
+    "detail": "Local file",
     "documentation": null
   }, {
     "label": "./tst.js",


### PR DESCRIPTION
- Relax filter for what local files that come up in `from` and regular string completion in `@module`
- Make `from` completion trigger for expr hole so we get a nice experience when completing `{from: <com>}`.