### PR TITLE
Add completion for type t values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Latest parser for newest syntax features. https://github.com/rescript-lang/rescript-vscode/pull/917
 - Handle completion for DOM/element attributes and attribute values properly when using a generic JSX transform. https://github.com/rescript-lang/rescript-vscode/pull/919
 - Highlight tagged template literal functions as functions. https://github.com/rescript-lang/rescript-vscode/pull/920
+- Complete for `type t` values when encountering a `type t` in relevant scenarios. https://github.com/rescript-lang/rescript-vscode/pull/924
 
 ## 1.38.0
 

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1283,7 +1283,7 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
         | _ -> false)
       | _ -> false
     in
-    let getComplitionName exportedValueName =
+    let getCompletionName exportedValueName =
       let fnNname =
         TypeUtils.getPathRelativeToEnv ~debug:false
           ~env:(QueryEnv.fromFile full.file)
@@ -1298,16 +1298,16 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
         in
         Some ((base |> String.concat ".") ^ "." ^ exportedValueName)
     in
-    let getExportedValueComplition name (declared : Types.type_expr Declared.t)
+    let getExportedValueCompletion name (declared : Types.type_expr Declared.t)
         =
       let typeExpr = declared.item in
       if valueWithTypeT typeExpr then
-        getComplitionName name
+        getCompletionName name
         |> Option.map (fun name ->
                createWithSnippet ~name ~insertText:name ~kind:(Value typeExpr)
                  ~env ())
       else if fnReturnsTypeT typeExpr then
-        getComplitionName name
+        getCompletionName name
         |> Option.map (fun name ->
                createWithSnippet
                  ~name:(Printf.sprintf "%s()" name)
@@ -1320,7 +1320,7 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
           match Stamps.findValue env.file.stamps stamp with
           | None -> all
           | Some declaredTypeExpr -> (
-            match getExportedValueComplition name declaredTypeExpr with
+            match getExportedValueCompletion name declaredTypeExpr with
             | None -> all
             | Some completion -> completion :: all))
         env.exported.values_ []

--- a/analysis/src/CompletionBackEnd.ml
+++ b/analysis/src/CompletionBackEnd.ml
@@ -1257,6 +1257,12 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
   match t with
   | TtypeT {env; path} ->
     if Debug.verbose () then print_endline "[complete_typed_value]--> TtypeT";
+    (* Find all values in the module with type t *)
+    let valueWithTypeT t =
+      match t.Types.desc with
+      | Tconstr (Pident {name = "t"}, [], _) -> true
+      | _ -> false
+    in
     (* Find all functions in the module that returns type t *)
     let rec fnReturnsTypeT t =
       match t.Types.desc with
@@ -1277,41 +1283,49 @@ let rec completeTypedValue ?(typeArgContext : typeArgContext option) ~rawOpens
         | _ -> false)
       | _ -> false
     in
-    let functionsReturningTypeT =
-      Hashtbl.create (Hashtbl.length env.exported.values_)
+    let getComplitionName exportedValueName =
+      let fnNname =
+        TypeUtils.getPathRelativeToEnv ~debug:false
+          ~env:(QueryEnv.fromFile full.file)
+          ~envFromItem:env (Utils.expandPath path)
+      in
+      match fnNname with
+      | None -> None
+      | Some base ->
+        let base =
+          TypeUtils.removeOpensFromCompletionPath ~rawOpens
+            ~package:full.package base
+        in
+        Some ((base |> String.concat ".") ^ "." ^ exportedValueName)
     in
-    env.exported.values_
-    |> Hashtbl.iter (fun name stamp ->
-           match Stamps.findValue env.file.stamps stamp with
-           | None -> ()
-           | Some {item} -> (
-             if fnReturnsTypeT item then
-               let fnNname =
-                 TypeUtils.getPathRelativeToEnv ~debug:false
-                   ~env:(QueryEnv.fromFile full.file)
-                   ~envFromItem:env (Utils.expandPath path)
-               in
-
-               match fnNname with
-               | None -> ()
-               | Some base ->
-                 let base =
-                   TypeUtils.removeOpensFromCompletionPath ~rawOpens
-                     ~package:full.package base
-                 in
-                 Hashtbl.add functionsReturningTypeT
-                   ((base |> String.concat ".") ^ "." ^ name)
-                   item));
-
+    let getExportedValueComplition name (declared : Types.type_expr Declared.t)
+        =
+      let typeExpr = declared.item in
+      if valueWithTypeT typeExpr then
+        getComplitionName name
+        |> Option.map (fun name ->
+               createWithSnippet ~name ~insertText:name ~kind:(Value typeExpr)
+                 ~env ())
+      else if fnReturnsTypeT typeExpr then
+        getComplitionName name
+        |> Option.map (fun name ->
+               createWithSnippet
+                 ~name:(Printf.sprintf "%s()" name)
+                 ~insertText:(name ^ "($0)") ~kind:(Value typeExpr) ~env ())
+      else None
+    in
     let completionItems =
       Hashtbl.fold
-        (fun fnName typeExpr all ->
-          createWithSnippet
-            ~name:(Printf.sprintf "%s()" fnName)
-            ~insertText:(fnName ^ "($0)") ~kind:(Value typeExpr) ~env ()
-          :: all)
-        functionsReturningTypeT []
+        (fun name stamp all ->
+          match Stamps.findValue env.file.stamps stamp with
+          | None -> all
+          | Some declaredTypeExpr -> (
+            match getExportedValueComplition name declaredTypeExpr with
+            | None -> all
+            | Some completion -> completion :: all))
+        env.exported.values_ []
     in
+
     (* Special casing for things where we want extra things in the completions *)
     let completionItems =
       match path with

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -321,3 +321,34 @@ let mkStuff = (r: Js.Re.t) => {
 
 // mkStuff()
 //         ^com
+
+module Money: {
+  type t
+
+  let zero: t
+
+  let nonTType: string
+
+  let make: unit => t
+
+  let fromInt: int => t
+
+  let plus: (t, t) => t
+} = {
+  type t = string
+
+  let zero: t = "0"
+
+  let nonTType = "0"
+
+  let make = (): t => zero
+
+  let fromInt = (int): t => int->Js.Int.toString
+
+  let plus = (m1, _) => m1
+}
+
+let tArgCompletionTestFn = (tVal: Money.t) => ()
+
+// tArgCompletionTestFn()
+//                      ^com

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -352,3 +352,8 @@ let tArgCompletionTestFn = (tVal: Money.t) => ()
 
 // tArgCompletionTestFn()
 //                      ^com
+
+let labeledTArgCompletionTestFn = (~tVal: Money.t) => ()
+
+// labeledTArgCompletionTestFn(~tVal=)
+//                                   ^com

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1368,3 +1368,39 @@ Path tArgCompletionTestFn
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionExpressions.res 357:37
+posCursor:[357:37] posNoWhite:[357:36] Found expr:[357:3->357:38]
+Pexp_apply ...[357:3->357:30] (~tVal357:32->357:36=...__ghost__[0:-1->0:-1])
+Completable: Cexpression CArgument Value[labeledTArgCompletionTestFn](~tVal)
+Raw opens: 1 CompletionSupport.place holder
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 2 pervasives CompletionSupport.res
+ContextPath CArgument Value[labeledTArgCompletionTestFn](~tVal)
+ContextPath Value[labeledTArgCompletionTestFn]
+Path labeledTArgCompletionTestFn
+[{
+    "label": "Money.fromInt()",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => t",
+    "documentation": null,
+    "insertText": "Money.fromInt($0)",
+    "insertTextFormat": 2
+  }, {
+    "label": "Money.make()",
+    "kind": 12,
+    "tags": [],
+    "detail": "unit => t",
+    "documentation": null,
+    "insertText": "Money.make($0)",
+    "insertTextFormat": 2
+  }, {
+    "label": "Money.zero",
+    "kind": 12,
+    "tags": [],
+    "detail": "t",
+    "documentation": null,
+    "insertText": "Money.zero",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1315,20 +1315,20 @@ Path mkStuff
     "insertText": "%re(\"/$0/g\")",
     "insertTextFormat": 2
   }, {
-    "label": "Js.Re.fromStringWithFlags()",
-    "kind": 12,
-    "tags": [],
-    "detail": "(string, ~flags: string) => t",
-    "documentation": null,
-    "insertText": "Js.Re.fromStringWithFlags($0)",
-    "insertTextFormat": 2
-  }, {
     "label": "Js.Re.fromString()",
     "kind": 12,
     "tags": [],
     "detail": "string => t",
     "documentation": null,
     "insertText": "Js.Re.fromString($0)",
+    "insertTextFormat": 2
+  }, {
+    "label": "Js.Re.fromStringWithFlags()",
+    "kind": 12,
+    "tags": [],
+    "detail": "(string, ~flags: string) => t",
+    "documentation": null,
+    "insertText": "Js.Re.fromStringWithFlags($0)",
     "insertTextFormat": 2
   }]
 

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1332,3 +1332,39 @@ Path mkStuff
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionExpressions.res 352:24
+posCursor:[352:24] posNoWhite:[352:23] Found expr:[352:3->352:25]
+Pexp_apply ...[352:3->352:23] (...[352:24->352:25])
+Completable: Cexpression CArgument Value[tArgCompletionTestFn]($0)
+Raw opens: 1 CompletionSupport.place holder
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 2 pervasives CompletionSupport.res
+ContextPath CArgument Value[tArgCompletionTestFn]($0)
+ContextPath Value[tArgCompletionTestFn]
+Path tArgCompletionTestFn
+[{
+    "label": "Money.fromInt()",
+    "kind": 12,
+    "tags": [],
+    "detail": "int => t",
+    "documentation": null,
+    "insertText": "Money.fromInt($0)",
+    "insertTextFormat": 2
+  }, {
+    "label": "Money.make()",
+    "kind": 12,
+    "tags": [],
+    "detail": "unit => t",
+    "documentation": null,
+    "insertText": "Money.make($0)",
+    "insertTextFormat": 2
+  }, {
+    "label": "Money.zero",
+    "kind": 12,
+    "tags": [],
+    "detail": "t",
+    "documentation": null,
+    "insertText": "Money.zero",
+    "insertTextFormat": 2
+  }]
+


### PR DESCRIPTION
An example from our project. We have a `Money.zero` value and now it's also included in the autocomplete:

<img width="767" alt="image" src="https://github.com/rescript-lang/rescript-vscode/assets/49292466/1a85607b-489d-4342-8de3-a240949e282c">

```
// Money.res
type t = string

let zero: t = "sdf"

let make = (): t => zero

let fromInt = (int): t => int->Js.Int.toString
```
```
// Money.resi
type t

let zero: t

let make: unit => t

let fromInt: int => t
```