### PR TITLE
distinguish regular modules from module types

### DIFF
--- a/analysis/src/ProcessCmt.ml
+++ b/analysis/src/ProcessCmt.ml
@@ -1,5 +1,10 @@
 open SharedTypes
 
+let isModuleType (declared : Module.t Declared.t) =
+  match declared.modulePath with
+  | ExportedModule {isType} -> isType
+  | _ -> false
+
 let addDeclared ~(name : string Location.loc) ~extent ~stamp ~(env : Env.t)
     ~item attributes addExported addStamp =
   let isExported = addExported name.txt stamp in
@@ -150,7 +155,8 @@ let rec forTypeSignatureItem ~(env : SharedTypes.Env.t) ~(exported : Exported.t)
     in
     [
       {
-        Module.kind = Module declared.item;
+        Module.kind =
+          Module {type_ = declared.item; isModuleType = isModuleType declared};
         name = declared.name.txt;
         docstring = declared.docstring;
         deprecated = declared.deprecated;
@@ -367,7 +373,8 @@ let rec forSignatureItem ~env ~(exported : Exported.t)
     in
     [
       {
-        Module.kind = Module declared.item;
+        Module.kind =
+          Module {type_ = declared.item; isModuleType = isModuleType declared};
         name = declared.name.txt;
         docstring = declared.docstring;
         deprecated = declared.deprecated;
@@ -481,7 +488,8 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
     in
     [
       {
-        Module.kind = Module declared.item;
+        Module.kind =
+          Module {type_ = declared.item; isModuleType = isModuleType declared};
         name = declared.name.txt;
         docstring = declared.docstring;
         deprecated = declared.deprecated;
@@ -513,7 +521,8 @@ let rec forStructureItem ~env ~(exported : Exported.t) item =
     in
     [
       {
-        Module.kind = Module modTypeItem;
+        Module.kind =
+          Module {type_ = declared.item; isModuleType = isModuleType declared};
         name = declared.name.txt;
         docstring = declared.docstring;
         deprecated = declared.deprecated;

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -120,7 +120,7 @@ module Module = struct
   type kind =
     | Value of Types.type_expr
     | Type of Type.t * Types.rec_status
-    | Module of t
+    | Module of {type_: t; isModuleType: bool}
 
   and item = {
     kind: kind;

--- a/tools/npm/Tools_Docgen.res
+++ b/tools/npm/Tools_Docgen.res
@@ -59,6 +59,15 @@ type rec item =
       source: source,
       items: array<item>,
     })
+  | @as("moduleType")
+  ModuleType({
+      id: string,
+      docstrings: array<string>,
+      deprecated?: string,
+      name: string,
+      source: source,
+      items: array<item>,
+    })
   | @as("moduleAlias")
   ModuleAlias({
       id: string,

--- a/tools/npm/Tools_Docgen.resi
+++ b/tools/npm/Tools_Docgen.resi
@@ -58,6 +58,15 @@ type rec item =
       source: source,
       items: array<item>,
     })
+  | @as("moduleType")
+  ModuleType({
+      id: string,
+      docstrings: array<string>,
+      deprecated?: string,
+      name: string,
+      source: source,
+      items: array<item>,
+    })
   | @as("moduleAlias")
   ModuleAlias({
       id: string,

--- a/tools/tests/src/DocExtractionRes.res
+++ b/tools/tests/src/DocExtractionRes.res
@@ -23,7 +23,7 @@ let make = name => {
 let asOffline = (t: t) => {...t, online: false}
 
 /** exotic identifier */
-let \"SomeConstant\" = 12
+let \"SomeConstant" = 12
 
 module SomeInnerModule = {
   /*** Another module level docstring here.*/
@@ -94,6 +94,38 @@ module ModuleWithThingsThatShouldNotBeExported: {
       "2"
     }
   }
+}
+
+module type Example = {
+  /***
+  this is an example module type 
+  */
+
+  /**
+  main type of this module 
+  */
+  type t
+
+  /**
+  function from t to t
+  */
+  let f: t => t
+}
+
+module M: Example = {
+  /***
+  implementation of Example module type
+  */
+
+  /**
+  main type 
+  */
+  type t = int
+
+  /**
+  identity function
+  */
+  let f = (x: int) => x
 }
 
 // ^dex

--- a/tools/tests/src/expected/DocExtractionRes.res.json
+++ b/tools/tests/src/expected/DocExtractionRes.res.json
@@ -60,10 +60,10 @@
     }
   }, 
   {
-    "id": "DocExtractionRes.SomeConstant\\",
+    "id": "DocExtractionRes.SomeConstant",
     "kind": "value",
-    "name": "SomeConstant\\",
-    "signature": "let SomeConstant\\: int",
+    "name": "SomeConstant",
+    "signature": "let SomeConstant: int",
     "docstrings": ["exotic identifier"],
     "source": {
       "filepath": "src/DocExtractionRes.res",
@@ -267,6 +267,42 @@
       "source": {
         "filepath": "src/DocExtractionRes.res",
         "line": 71,
+        "col": 3
+      }
+    }]
+  }, 
+  {
+    "id": "DocExtractionRes.Example",
+    "name": "Example",
+    "kind": "moduleType",
+    "docstrings": [],
+    "source": {
+      "filepath": "src/DocExtractionRes.res",
+      "line": 99,
+      "col": 13
+    },
+    "items": [
+    {
+      "id": "DocExtractionRes.Example.t",
+      "kind": "type",
+      "name": "t",
+      "signature": "type t",
+      "docstrings": ["main type of this module"],
+      "source": {
+        "filepath": "src/DocExtractionRes.res",
+        "line": 107,
+        "col": 3
+      }
+    }, 
+    {
+      "id": "DocExtractionRes.Example.f",
+      "kind": "value",
+      "name": "f",
+      "signature": "let f: t => t",
+      "docstrings": ["function from t to t"],
+      "source": {
+        "filepath": "src/DocExtractionRes.res",
+        "line": 109,
         "col": 3
       }
     }]


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/902

@woeps please look through this and say what you think. A few things I can think of right away:
- We don't indicate when a module is implementing a module type. Not sure if this would be relevant for docgen.
- We can have id clashes now I guess, because I think a regular module and a module type with the same name can co-exist in the same module scope. So we need to account for that in the id generation.