### PR TITLE
Grammar: Support escape in tagged templates

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -161,6 +161,10 @@
           },
           "patterns": [
             {
+              "name": "constant.character.escape",
+              "match": "\\\\."
+            },
+            {
               "name": "meta.template.expression",
               "begin": "\\$\\{",
               "beginCaptures": {


### PR DESCRIPTION
Before:
<img width="217" alt="Pasted Graphic 1" src="https://github.com/rescript-lang/rescript-vscode/assets/49292466/f1a1957c-58b6-4107-8cf1-89f8ec7ac6d9">

After:
<img width="221" alt="image" src="https://github.com/rescript-lang/rescript-vscode/assets/49292466/a7d5633f-cf1e-417e-8d02-3ccc3973ae25">
