### PR TITLE
Improve syntax highligting for escaped characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Handle completion for DOM/element attributes and attribute values properly when using a generic JSX transform. https://github.com/rescript-lang/rescript-vscode/pull/919
 - Highlight tagged template literal functions as functions. https://github.com/rescript-lang/rescript-vscode/pull/920
 - Complete for `type t` values when encountering a `type t` in relevant scenarios. https://github.com/rescript-lang/rescript-vscode/pull/924
+- Highlight escaped sequences as a whole and not only the first character. https://github.com/rescript-lang/rescript-vscode/pull/929
+- Start highlighting escaped sequences in template literals. https://github.com/rescript-lang/rescript-vscode/pull/929
 
 ## 1.38.0
 

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -119,6 +119,10 @@
         }
       ]
     },
+    "string-character-escape": {
+      "name": "constant.character.escape",
+      "match": "\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|u{[0-9A-Fa-f]+}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
+    },
     "string": {
       "patterns": [
         {
@@ -137,8 +141,7 @@
           },
           "patterns": [
             {
-              "name": "constant.character.escape",
-              "match": "\\\\."
+              "include": "#string-character-escape"
             }
           ]
         },
@@ -161,8 +164,7 @@
           },
           "patterns": [
             {
-              "name": "constant.character.escape",
-              "match": "\\\\."
+              "include": "#string-character-escape"
             },
             {
               "name": "meta.template.expression",

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -161,6 +161,10 @@
           },
           "patterns": [
             {
+              "name": "constant.character.escape",
+              "match": "\\\\."
+            },
+            {
               "name": "meta.template.expression",
               "begin": "\\$\\{",
               "beginCaptures": {


### PR DESCRIPTION
Solves: https://github.com/rescript-lang/rescript-vscode/issues/852
Solves: https://github.com/rescript-lang/rescript-vscode/pull/928

Inspired by: https://github.com/microsoft/TypeScript-TmLanguage/blob/a771bc4e79deeae81a01d988a273e300290d0072/TypeScript.YAML-tmLanguage#L2614-L2616

Before:
<img width="259" alt="image" src="https://github.com/rescript-lang/rescript-vscode/assets/49292466/00b47cda-25a3-4dcb-9bf1-fcaf65fcef18">

After:
<img width="265" alt="image" src="https://github.com/rescript-lang/rescript-vscode/assets/49292466/a25d80b0-48f1-41f8-ae9b-8322dfed9143">
