### PR TITLE
Heuristic for JSX empty prop expr completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug Fix
 
 - Fix issue where completion inside of switch expression would not work in some cases. https://github.com/rescript-lang/rescript-vscode/pull/936
+- Fix bug that made empty prop expressions in JSX not complete if in the middle of a JSX element. https://github.com/rescript-lang/rescript-vscode/pull/935
 
 ## 1.40.0
 

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -952,6 +952,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
                   pathToComponent =
                     Utils.flattenLongIdent ~jsx:true props.compName.txt;
                   propName = prop.name;
+                  emptyJsxPropNameHint = None;
                 });
            expr iterator prop.exp;
            resetCurrentCtxPath previousCtxPath)

--- a/analysis/src/CompletionJsx.ml
+++ b/analysis/src/CompletionJsx.ml
@@ -833,7 +833,27 @@ let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor
           print_endline
             "[jsx_props_completable]--> Cursor between the prop name and expr \
              assigned";
-        None)
+        match (firstCharBeforeCursorNoWhite, prop.exp) with
+        | Some '=', {pexp_desc = Pexp_ident {txt = Lident txt}} ->
+          if Debug.verbose () then
+            Printf.printf
+              "[jsx_props_completable]--> Heuristic for empty JSX prop expr \
+               completion.\n";
+          Some
+            (Cexpression
+               {
+                 contextPath =
+                   CJsxPropValue
+                     {
+                       pathToComponent =
+                         Utils.flattenLongIdent ~jsx:true jsxProps.compName.txt;
+                       propName = prop.name;
+                       emptyJsxPropNameHint = Some txt;
+                     };
+                 nested = [];
+                 prefix = "";
+               })
+        | _ -> None)
       else if prop.exp.pexp_loc |> Loc.hasPos ~pos:posBeforeCursor then (
         if Debug.verbose () then
           print_endline "[jsx_props_completable]--> Cursor on expr assigned";
@@ -851,6 +871,7 @@ let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor
                        pathToComponent =
                          Utils.flattenLongIdent ~jsx:true jsxProps.compName.txt;
                        propName = prop.name;
+                       emptyJsxPropNameHint = None;
                      };
                  nested = List.rev nested;
                  prefix;
@@ -871,6 +892,7 @@ let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor
                        pathToComponent =
                          Utils.flattenLongIdent ~jsx:true jsxProps.compName.txt;
                        propName = prop.name;
+                       emptyJsxPropNameHint = None;
                      };
                  prefix = "";
                  nested = [];
@@ -894,6 +916,7 @@ let findJsxPropsCompletable ~jsxProps ~endPos ~posBeforeCursor
                      pathToComponent =
                        Utils.flattenLongIdent ~jsx:true jsxProps.compName.txt;
                      propName = prop.name;
+                     emptyJsxPropNameHint = None;
                    };
                prefix = "";
                nested = [];

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -622,7 +622,12 @@ module Completable = struct
         functionContextPath: contextPath;
         argumentLabel: argumentLabel;
       }
-    | CJsxPropValue of {pathToComponent: string list; propName: string}
+    | CJsxPropValue of {
+        pathToComponent: string list;
+        propName: string;
+        emptyJsxPropNameHint: string option;
+            (* This helps handle a special case in JSX prop completion. More info where this is used. *)
+      }
     | CPatternPath of {rootCtxPath: contextPath; nested: nestedPath list}
     | CTypeAtPos of Location.t
         (** A position holding something that might have a *compiled* type. *)

--- a/analysis/tests/src/CompletionJsx.res
+++ b/analysis/tests/src/CompletionJsx.res
@@ -61,3 +61,15 @@ module IntrinsicElementLowercase = {
 
 // <IntrinsicElementLowercase
 //                            ^com
+
+module MultiPropComp = {
+  type time = Now | Later
+  @react.component
+  let make = (~name, ~age, ~time: time) => {
+    ignore(time)
+    name ++ age
+  }
+}
+
+// <MultiPropComp name="Hello" time= age="35"
+//                                  ^com

--- a/analysis/tests/src/CompletionJsx.res
+++ b/analysis/tests/src/CompletionJsx.res
@@ -73,3 +73,9 @@ module MultiPropComp = {
 
 // <MultiPropComp name="Hello" time= age="35"
 //                                  ^com
+
+// <MultiPropComp name="Hello" time= age
+//                                  ^com
+
+// <MultiPropComp name time= age
+//                          ^com

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -543,3 +543,29 @@ Path IntrinsicElementLowercase.make
     "documentation": null
   }]
 
+Complete src/CompletionJsx.res 73:36
+posCursor:[73:36] posNoWhite:[73:35] Found expr:[73:4->73:41]
+JSX <MultiPropComp:[73:4->73:17] name[73:18->73:22]=...[73:23->73:30] time[73:31->73:35]=...[73:37->73:40]> _children:None
+Completable: Cexpression CJsxPropValue [MultiPropComp] time
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CJsxPropValue [MultiPropComp] time
+Path MultiPropComp.make
+[{
+    "label": "Now",
+    "kind": 4,
+    "tags": [],
+    "detail": "Now\n\ntype time = Now | Later",
+    "documentation": null,
+    "insertText": "{Now}",
+    "insertTextFormat": 2
+  }, {
+    "label": "Later",
+    "kind": 4,
+    "tags": [],
+    "detail": "Later\n\ntype time = Now | Later",
+    "documentation": null,
+    "insertText": "{Later}",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -569,3 +569,55 @@ Path MultiPropComp.make
     "insertTextFormat": 2
   }]
 
+Complete src/CompletionJsx.res 76:36
+posCursor:[76:36] posNoWhite:[76:35] Found expr:[76:4->76:40]
+JSX <MultiPropComp:[76:4->76:17] name[76:18->76:22]=...[76:23->76:30] time[76:31->76:35]=...[76:37->76:40]> _children:None
+Completable: Cexpression CJsxPropValue [MultiPropComp] time
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CJsxPropValue [MultiPropComp] time
+Path MultiPropComp.make
+[{
+    "label": "Now",
+    "kind": 4,
+    "tags": [],
+    "detail": "Now\n\ntype time = Now | Later",
+    "documentation": null,
+    "insertText": "{Now}",
+    "insertTextFormat": 2
+  }, {
+    "label": "Later",
+    "kind": 4,
+    "tags": [],
+    "detail": "Later\n\ntype time = Now | Later",
+    "documentation": null,
+    "insertText": "{Later}",
+    "insertTextFormat": 2
+  }]
+
+Complete src/CompletionJsx.res 79:28
+posCursor:[79:28] posNoWhite:[79:27] Found expr:[79:4->79:32]
+JSX <MultiPropComp:[79:4->79:17] name[79:18->79:22]=...[79:18->79:22] time[79:23->79:27]=...[79:29->79:32]> _children:None
+Completable: Cexpression CJsxPropValue [MultiPropComp] time
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CJsxPropValue [MultiPropComp] time
+Path MultiPropComp.make
+[{
+    "label": "Now",
+    "kind": 4,
+    "tags": [],
+    "detail": "Now\n\ntype time = Now | Later",
+    "documentation": null,
+    "insertText": "{Now}",
+    "insertTextFormat": 2
+  }, {
+    "label": "Later",
+    "kind": 4,
+    "tags": [],
+    "detail": "Later\n\ntype time = Now | Later",
+    "documentation": null,
+    "insertText": "{Later}",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/Jsx2.res.txt
+++ b/analysis/tests/src/expected/Jsx2.res.txt
@@ -481,7 +481,22 @@ Path Outer.Inner.
 Complete src/Jsx2.res 136:7
 posCursor:[136:7] posNoWhite:[136:6] Found expr:[135:3->138:9]
 JSX <div:[135:3->135:6] x[136:5->136:6]=...[138:4->138:8]> _children:None
-[]
+Completable: Cexpression CJsxPropValue [div] x
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CJsxPropValue [div] x
+Path ReactDOM.domProps
+Path PervasivesU.JsxDOM.domProps
+[{
+    "label": "\"\"",
+    "kind": 12,
+    "tags": [],
+    "detail": "string",
+    "documentation": null,
+    "sortText": "A",
+    "insertText": "{\"$0\"}",
+    "insertTextFormat": 2
+  }]
 
 Complete src/Jsx2.res 150:21
 posCursor:[150:21] posNoWhite:[150:20] Found expr:[150:12->150:32]


### PR DESCRIPTION
This fixes a bug that made empty prop expressions in JSX not complete if in the middle of a JSX element, because of the parser not being able to provide an expr hole for the empty prop expr (which in turn is because of valid reasons).