### PR TITLE
Fix issue where completion inside of switch expr would not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :bug: Bug Fix
+
+- Fix issue where completion inside of switch expression would not work in some cases. https://github.com/rescript-lang/rescript-vscode/pull/936
+
 ## 1.40.0
 
 #### :nail_care: Polish

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -348,12 +348,12 @@ module Money: {
   let plus = (m1, _) => m1
 }
 
-let tArgCompletionTestFn = (tVal: Money.t) => ()
+let tArgCompletionTestFn = (_tVal: Money.t) => ()
 
 // tArgCompletionTestFn()
 //                      ^com
 
-let labeledTArgCompletionTestFn = (~tVal: Money.t) => ()
+let labeledTArgCompletionTestFn = (~tVal as _: Money.t) => ()
 
 // labeledTArgCompletionTestFn(~tVal=)
 //                                   ^com

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -357,3 +357,8 @@ let labeledTArgCompletionTestFn = (~tVal: Money.t) => ()
 
 // labeledTArgCompletionTestFn(~tVal=)
 //                                   ^com
+
+let someTyp: someTyp = {test: true}
+
+// switch someTyp. { | _ => () }
+//                ^com

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1404,25 +1404,16 @@ Path labeledTArgCompletionTestFn
     "insertTextFormat": 2
   }]
 
-
-Complete src/CompletionExpressions.res 363:18
-[typedCompletionExpr] Has cursor
-[typedCompletionExpr] Has cases
-[typedCompletionExpr] Has cases - has ctx path
-[typedCompletionExpr] Has cases - has ctx path - hasCaseWithEmptyLoc: false, hasCaseWithCursor: false
-posCursor:[363:18] posNoWhite:[363:17] Found expr:[363:3->363:32]
-[typedCompletionExpr] Has cursor
-posCursor:[363:18] posNoWhite:[363:17] Found expr:[363:10->363:18]
-Pexp_field [363:10->363:17] _:[363:19->363:18]
-[set_result] set new result to Cpath Value[someTyp].""
+Complete src/CompletionExpressions.res 362:18
+posCursor:[362:18] posNoWhite:[362:17] Found expr:[362:3->362:32]
+posCursor:[362:18] posNoWhite:[362:17] Found expr:[362:10->362:18]
+Pexp_field [362:10->362:17] _:[362:19->362:18]
 Completable: Cpath Value[someTyp].""
 Raw opens: 1 CompletionSupport.place holder
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 2 pervasives CompletionSupport.res
 ContextPath Value[someTyp].""
-[ctx_path]--> CPField
 ContextPath Value[someTyp]
-[ctx_path]--> CPId
 Path someTyp
 [{
     "label": "test",
@@ -1431,5 +1422,4 @@ Path someTyp
     "detail": "test: bool\n\ntype someTyp = {test: bool}",
     "documentation": null
   }]
-
 

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1404,3 +1404,32 @@ Path labeledTArgCompletionTestFn
     "insertTextFormat": 2
   }]
 
+
+Complete src/CompletionExpressions.res 363:18
+[typedCompletionExpr] Has cursor
+[typedCompletionExpr] Has cases
+[typedCompletionExpr] Has cases - has ctx path
+[typedCompletionExpr] Has cases - has ctx path - hasCaseWithEmptyLoc: false, hasCaseWithCursor: false
+posCursor:[363:18] posNoWhite:[363:17] Found expr:[363:3->363:32]
+[typedCompletionExpr] Has cursor
+posCursor:[363:18] posNoWhite:[363:17] Found expr:[363:10->363:18]
+Pexp_field [363:10->363:17] _:[363:19->363:18]
+[set_result] set new result to Cpath Value[someTyp].""
+Completable: Cpath Value[someTyp].""
+Raw opens: 1 CompletionSupport.place holder
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 2 pervasives CompletionSupport.res
+ContextPath Value[someTyp].""
+[ctx_path]--> CPField
+ContextPath Value[someTyp]
+[ctx_path]--> CPId
+Path someTyp
+[{
+    "label": "test",
+    "kind": 5,
+    "tags": [],
+    "detail": "test: bool\n\ntype someTyp = {test: bool}",
+    "documentation": null
+  }]
+
+


### PR DESCRIPTION
Fixes an issue where completion inside of switch exprs wouldn't work because we iterate the cases instead when we shouldn't. 

Adds a bunch of debug logging as well.