### PR TITLE
Extend signature help to also work on variant constructor payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :rocket: New Feature
+
+- Extend signature help to work on constructor payloads as well. Can be turned off if wanted through settings.
+
 ## 1.48.0
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :rocket: New Feature
 
-- Extend signature help to work on constructor payloads as well. Can be turned off if wanted through settings.
+- Extend signature help to work on constructor payloads as well. Can be turned off if wanted through settings. https://github.com/rescript-lang/rescript-vscode/pull/947
 
 ## 1.48.0
 

--- a/analysis/bin/main.ml
+++ b/analysis/bin/main.ml
@@ -136,10 +136,16 @@ let main () =
         (match supportsMarkdownLinks with
         | "true" -> true
         | _ -> false)
-  | [_; "signatureHelp"; path; line; col; currentFile] ->
+  | [
+   _; "signatureHelp"; path; line; col; currentFile; allowForConstructorPayloads;
+  ] ->
     Commands.signatureHelp ~path
       ~pos:(int_of_string line, int_of_string col)
       ~currentFile ~debug
+      ~allowForConstructorPayloads:
+        (match allowForConstructorPayloads with
+        | "true" -> true
+        | _ -> false)
   | [_; "inlayHint"; path; line_start; line_end; maxLength] ->
     Commands.inlayhint ~path
       ~pos:(int_of_string line_start, int_of_string line_end)

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -71,9 +71,12 @@ let hover ~path ~pos ~currentFile ~debug ~supportsMarkdownLinks =
   in
   print_endline result
 
-let signatureHelp ~path ~pos ~currentFile ~debug =
+let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
   let result =
-    match SignatureHelp.signatureHelp ~path ~pos ~currentFile ~debug with
+    match
+      SignatureHelp.signatureHelp ~path ~pos ~currentFile ~debug
+        ~allowForConstructorPayloads
+    with
     | None ->
       {Protocol.signatures = []; activeSignature = None; activeParameter = None}
     | Some res -> res
@@ -345,7 +348,8 @@ let test ~path =
               ("Signature help " ^ path ^ " " ^ string_of_int line ^ ":"
              ^ string_of_int col);
             let currentFile = createCurrentFile () in
-            signatureHelp ~path ~pos:(line, col) ~currentFile ~debug:true;
+            signatureHelp ~path ~pos:(line, col) ~currentFile ~debug:true
+              ~allowForConstructorPayloads:true;
             Sys.remove currentFile
           | "int" ->
             print_endline ("Create Interface " ^ path);

--- a/analysis/tests/src/SignatureHelp.res
+++ b/analysis/tests/src/SignatureHelp.res
@@ -74,3 +74,29 @@ let fn = (age: int, name: string, year: int) => {
 
 // let _ = fn({ iAmSoSpecial({ someFunc() }) })
 //                                      ^she
+
+/** This is my own special thing. */
+type mySpecialThing = string
+
+type t =
+  | /** One is cool. */ One({miss?: bool, hit?: bool, stuff?: string})
+  | /** Two is fun! */ Two(mySpecialThing)
+  | /** Three is... three */ Three(mySpecialThing, array<option<string>>)
+
+let _one = One({})
+//              ^she
+
+let _one = One({miss: true})
+//                ^she
+
+let _one = One({hit: true, miss: true})
+//                     ^she
+
+let two = Two("true")
+//             ^she
+
+let three = Three("", [])
+//                 ^she
+
+let three2 = Three("", [])
+//                      ^she

--- a/analysis/tests/src/expected/SignatureHelp.res.txt
+++ b/analysis/tests/src/expected/SignatureHelp.res.txt
@@ -386,3 +386,69 @@ extracted params:
   "activeParameter": 0
 }
 
+Signature help src/SignatureHelp.res 85:16
+{
+  "signatures": [{
+    "label": "One({miss?: bool, hit?: bool, stuff?: string})",
+    "parameters": [{"label": [0, 0], "documentation": {"kind": "markdown", "value": ""}}, {"label": [5, 16], "documentation": {"kind": "markdown", "value": ""}}, {"label": [18, 28], "documentation": {"kind": "markdown", "value": ""}}, {"label": [30, 44], "documentation": {"kind": "markdown", "value": ""}}],
+    "documentation": {"kind": "markdown", "value": " One is cool. "}
+  }],
+  "activeSignature": 0,
+  "activeParameter": -1
+}
+
+Signature help src/SignatureHelp.res 88:18
+{
+  "signatures": [{
+    "label": "One({miss?: bool, hit?: bool, stuff?: string})",
+    "parameters": [{"label": [0, 0], "documentation": {"kind": "markdown", "value": ""}}, {"label": [5, 16], "documentation": {"kind": "markdown", "value": ""}}, {"label": [18, 28], "documentation": {"kind": "markdown", "value": ""}}, {"label": [30, 44], "documentation": {"kind": "markdown", "value": ""}}],
+    "documentation": {"kind": "markdown", "value": " One is cool. "}
+  }],
+  "activeSignature": 0,
+  "activeParameter": 1
+}
+
+Signature help src/SignatureHelp.res 91:23
+{
+  "signatures": [{
+    "label": "One({miss?: bool, hit?: bool, stuff?: string})",
+    "parameters": [{"label": [0, 0], "documentation": {"kind": "markdown", "value": ""}}, {"label": [5, 16], "documentation": {"kind": "markdown", "value": ""}}, {"label": [18, 28], "documentation": {"kind": "markdown", "value": ""}}, {"label": [30, 44], "documentation": {"kind": "markdown", "value": ""}}],
+    "documentation": {"kind": "markdown", "value": " One is cool. "}
+  }],
+  "activeSignature": 0,
+  "activeParameter": 2
+}
+
+Signature help src/SignatureHelp.res 94:15
+{
+  "signatures": [{
+    "label": "Two(mySpecialThing)",
+    "parameters": [{"label": [4, 18], "documentation": {"kind": "markdown", "value": "```rescript\nmySpecialThing\n```\n```rescript\ntype mySpecialThing = string\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22SignatureHelp.res%22%2C78%2C0%5D)"}}],
+    "documentation": {"kind": "markdown", "value": " Two is fun! "}
+  }],
+  "activeSignature": 0,
+  "activeParameter": 0
+}
+
+Signature help src/SignatureHelp.res 97:19
+{
+  "signatures": [{
+    "label": "Three(mySpecialThing, array<option<string>>)",
+    "parameters": [{"label": [6, 20], "documentation": {"kind": "markdown", "value": "```rescript\nmySpecialThing\n```\n```rescript\ntype mySpecialThing = string\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22SignatureHelp.res%22%2C78%2C0%5D)"}}, {"label": [22, 43], "documentation": {"kind": "markdown", "value": "```rescript\narray<option<string>>\n```"}}],
+    "documentation": {"kind": "markdown", "value": " Three is... three "}
+  }],
+  "activeSignature": 0,
+  "activeParameter": 0
+}
+
+Signature help src/SignatureHelp.res 100:24
+{
+  "signatures": [{
+    "label": "Three(mySpecialThing, array<option<string>>)",
+    "parameters": [{"label": [6, 20], "documentation": {"kind": "markdown", "value": "```rescript\nmySpecialThing\n```\n```rescript\ntype mySpecialThing = string\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22SignatureHelp.res%22%2C78%2C0%5D)"}}, {"label": [22, 43], "documentation": {"kind": "markdown", "value": "```rescript\narray<option<string>>\n```"}}],
+    "documentation": {"kind": "markdown", "value": " Three is... three "}
+  }],
+  "activeSignature": 0,
+  "activeParameter": 1
+}
+

--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
 					"default": true,
 					"description": "Enable signature help for function calls."
 				},
+				"rescript.settings.signatureHelp.forConstructorPayloads": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable signature help for variant constructor payloads."
+				},
 				"rescript.settings.incrementalTypechecking.enabled": {
 					"type": "boolean",
 					"default": false,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -3,22 +3,23 @@ import { Message } from "vscode-languageserver-protocol";
 export type send = (msg: Message) => void;
 
 export interface extensionConfiguration {
-  allowBuiltInFormatter: boolean;
-  askToStartBuild: boolean;
+  allowBuiltInFormatter?: boolean;
+  askToStartBuild?: boolean;
   inlayHints?: {
-    enable: boolean;
-    maxLength: number | null;
+    enable?: boolean;
+    maxLength?: number | null;
   };
-  codeLens: boolean;
-  binaryPath: string | null;
-  platformPath: string | null;
+  codeLens?: boolean;
+  binaryPath?: string | null;
+  platformPath?: string | null;
   signatureHelp?: {
-    enabled: boolean;
+    enabled?: boolean;
+    forConstructorPayloads?: boolean;
   };
   incrementalTypechecking?: {
-    enabled: boolean;
-    acrossFiles: boolean;
-    debugLogging: boolean;
+    enabled?: boolean;
+    acrossFiles?: boolean;
+    debugLogging?: boolean;
   };
 }
 
@@ -37,6 +38,7 @@ let config: { extensionConfiguration: extensionConfiguration } = {
     platformPath: null,
     signatureHelp: {
       enabled: true,
+      forConstructorPayloads: true,
     },
     incrementalTypechecking: {
       enabled: false,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -469,6 +469,9 @@ function signatureHelp(msg: p.RequestMessage) {
       params.position.line,
       params.position.character,
       tmpname,
+      config.extensionConfiguration.signatureHelp?.forConstructorPayloads
+        ? "true"
+        : "false",
     ],
     msg
   );
@@ -745,7 +748,7 @@ function format(msg: p.RequestMessage): Array<p.Message> {
       bscExeBinaryPath,
       filePath,
       code,
-      config.extensionConfiguration.allowBuiltInFormatter
+      Boolean(config.extensionConfiguration.allowBuiltInFormatter)
     );
     if (formattedResult.kind === "success") {
       let max = code.length;


### PR DESCRIPTION
Made it possible to turn off if wanted. This can be quite useful - figure out what arguments a constructor takes (and where you're at with the arguments) via signature help. 

Examples:
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/330d65a9-1dc3-43c1-bfc5-5c473675eab0)
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/2dbf95e4-305c-43e3-b1b0-11f9f92843dc)
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/801a4f9c-6a23-49bb-9e5d-91e8ef569413)

