### PR TITLE
Signature help fixes

### DIFF
--- a/analysis/src/SignatureHelp.ml
+++ b/analysis/src/SignatureHelp.ml
@@ -206,26 +206,36 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
         loc |> CursorPosition.locHasCursor ~pos:posBeforeCursor
       in
       let supportsMarkdownLinks = true in
-      let foundFunctionApplicationExpr = ref None in
-      let foundConstructorExpr = ref None in
-      let setFoundConstructor r =
-        if allowForConstructorPayloads then
-          match !foundConstructorExpr with
-          | None -> foundConstructorExpr := Some r
-          | Some _ -> ()
+      let result = ref None in
+      let printThing thg =
+        match thg with
+        | `Constructor _ -> "Constructor"
+        | `FunctionCall _ -> "FunctionCall"
       in
-      let setFound r =
-        (* Because we want to handle both piped and regular function calls, and in
-           the case of piped calls the iterator will process both the pipe and the
-           regular call (even though it's piped), we need to ensure that we don't
-           re-save the same expression (but unpiped, even though it's actually piped). *)
-        match (!foundFunctionApplicationExpr, r) with
-        | Some (_, alreadyFoundExp, _), (_, newExp, _)
-          when alreadyFoundExp.Parsetree.pexp_loc <> newExp.Parsetree.pexp_loc
-          ->
-          foundFunctionApplicationExpr := Some r
-        | None, _ -> foundFunctionApplicationExpr := Some r
-        | Some _, _ -> ()
+      let setResult (loc, thing) =
+        match (thing, allowForConstructorPayloads) with
+        | `Constructor _, false -> ()
+        | _ -> (
+          match !result with
+          | None ->
+            if Debug.verbose () then
+              Printf.printf "[sig_help_result] Setting because had none\n";
+            result := Some (loc, thing)
+          | Some (currentLoc, currentThing)
+            when Pos.ofLexing loc.Location.loc_start
+                 > Pos.ofLexing currentLoc.Location.loc_start ->
+            result := Some (loc, thing);
+
+            if Debug.verbose () then
+              Printf.printf
+                "[sig_help_result] Setting because loc of %s > then existing \
+                 of %s\n"
+                (printThing thing) (printThing currentThing)
+          | Some (_, currentThing) ->
+            Printf.printf
+              "[sig_help_result] Doing nothing because loc of %s < then \
+               existing of %s\n"
+              (printThing thing) (printThing currentThing))
       in
       let searchForArgWithCursor ~isPipeExpr ~args =
         let extractedArgs = extractExpApplyArgs ~args in
@@ -315,7 +325,8 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
           let argAtCursor, extractedArgs =
             searchForArgWithCursor ~isPipeExpr:true ~args
           in
-          setFound (argAtCursor, exp, extractedArgs)
+          setResult
+            (exp.pexp_loc, `FunctionCall (argAtCursor, exp, extractedArgs))
         (* Look for applying idents, like someIdent(...) *)
         | {
          pexp_desc = Pexp_apply (({pexp_desc = Pexp_ident _} as exp), args);
@@ -325,13 +336,14 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
           let argAtCursor, extractedArgs =
             searchForArgWithCursor ~isPipeExpr:false ~args
           in
-          setFound (argAtCursor, exp, extractedArgs)
+          setResult
+            (exp.pexp_loc, `FunctionCall (argAtCursor, exp, extractedArgs))
         | {pexp_desc = Pexp_construct (lid, Some payloadExp); pexp_loc}
           when locHasCursor payloadExp.pexp_loc
                || CompletionExpressions.isExprHole payloadExp
                   && locHasCursor pexp_loc ->
           (* Constructor payloads *)
-          setFoundConstructor (lid, payloadExp)
+          setResult (lid.loc, `Constructor (lid, payloadExp))
         | _ -> ());
         Ast_iterator.default_iterator.expr iterator expr
       in
@@ -342,8 +354,8 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
       let {Res_driver.parsetree = structure} = parser ~filename:currentFile in
       iterator.structure iterator structure |> ignore;
       (* Handle function application, if found *)
-      match !foundFunctionApplicationExpr with
-      | Some (argAtCursor, exp, _extractedArgs) -> (
+      match !result with
+      | Some (_, `FunctionCall (argAtCursor, exp, _extractedArgs)) -> (
         (* Not looking for the cursor position after this, but rather the target function expression's loc. *)
         let pos = exp.pexp_loc |> Loc.end_ in
         match findFunctionType ~currentFile ~debug ~path ~pos with
@@ -423,200 +435,195 @@ let signatureHelp ~path ~pos ~currentFile ~debug ~allowForConstructorPayloads =
                 | activeParameter -> activeParameter);
             }
         | _ -> None)
-      | None -> (
-        (* Handle constructor payload if we had no function application *)
-        match !foundConstructorExpr with
-        | Some (lid, expr) -> (
+      | Some (_, `Constructor (lid, expr)) -> (
+        if Debug.verbose () then
+          Printf.printf "[signature_help] Found constructor expr!\n";
+        match Cmt.loadFullCmtFromPath ~path with
+        | None ->
           if Debug.verbose () then
-            Printf.printf "[signature_help] Found constructor expr!\n";
-          match Cmt.loadFullCmtFromPath ~path with
+            Printf.printf "[signature_help] Could not load cmt\n";
+          None
+        | Some full -> (
+          let {file} = full in
+          let env = QueryEnv.fromFile file in
+          let constructorName = Longident.last lid.txt in
+          match
+            findConstructorArgs ~full ~env ~constructorName
+              {lid.loc with loc_start = lid.loc.loc_end}
+          with
           | None ->
             if Debug.verbose () then
-              Printf.printf "[signature_help] Could not load cmt\n";
+              Printf.printf "[signature_help] Did not find constructor '%s'\n"
+                constructorName;
             None
-          | Some full -> (
-            let {file} = full in
-            let env = QueryEnv.fromFile file in
-            let constructorName = Longident.last lid.txt in
-            match
-              findConstructorArgs ~full ~env ~constructorName
-                {lid.loc with loc_start = lid.loc.loc_end}
-            with
-            | None ->
-              if Debug.verbose () then
-                Printf.printf "[signature_help] Did not find constructor '%s'\n"
-                  constructorName;
-              None
-            | Some constructor ->
-              let argParts =
-                match constructor.args with
-                | Args [] -> None
-                | InlineRecord fields ->
-                  let offset = ref 0 in
-                  Some
-                    (`InlineRecord
-                      (fields
-                      |> List.map (fun (field : field) ->
-                             let startOffset = !offset in
-                             let argText =
-                               Printf.sprintf "%s%s: %s" field.fname.txt
-                                 (if field.optional then "?" else "")
-                                 (Shared.typeToString
-                                    (if field.optional then
-                                       Utils.unwrapIfOption field.typ
-                                     else field.typ))
-                             in
-                             let endOffset =
-                               startOffset + String.length argText
-                             in
-                             offset := endOffset + String.length ", ";
-                             (argText, field, (startOffset, endOffset)))))
-                | Args [(typ, _)] ->
-                  Some
-                    (`SingleArg
-                      ( typ |> Shared.typeToString,
-                        docsForLabel ~file:full.file ~package:full.package
-                          ~supportsMarkdownLinks typ ))
-                | Args args ->
-                  let offset = ref 0 in
-                  Some
-                    (`TupleArg
-                      (args
-                      |> List.map (fun (typ, _) ->
-                             let startOffset = !offset in
-                             let argText = typ |> Shared.typeToString in
-                             let endOffset =
-                               startOffset + String.length argText
-                             in
-                             offset := endOffset + String.length ", ";
-                             ( argText,
-                               docsForLabel ~file:full.file
-                                 ~package:full.package ~supportsMarkdownLinks
-                                 typ,
-                               (startOffset, endOffset) ))))
-              in
-              let label =
-                constructor.cname.txt ^ "("
-                ^ (match argParts with
-                  | None -> ""
-                  | Some (`InlineRecord fields) ->
-                    "{"
-                    ^ (fields
-                      |> List.map (fun (argText, _, _) -> argText)
-                      |> String.concat ", ")
-                    ^ "}"
-                  | Some (`SingleArg (arg, _)) -> arg
-                  | Some (`TupleArg items) ->
-                    items
+          | Some constructor ->
+            let argParts =
+              match constructor.args with
+              | Args [] -> None
+              | InlineRecord fields ->
+                let offset = ref 0 in
+                Some
+                  (`InlineRecord
+                    (fields
+                    |> List.map (fun (field : field) ->
+                           let startOffset = !offset in
+                           let argText =
+                             Printf.sprintf "%s%s: %s" field.fname.txt
+                               (if field.optional then "?" else "")
+                               (Shared.typeToString
+                                  (if field.optional then
+                                     Utils.unwrapIfOption field.typ
+                                   else field.typ))
+                           in
+                           let endOffset =
+                             startOffset + String.length argText
+                           in
+                           offset := endOffset + String.length ", ";
+                           (argText, field, (startOffset, endOffset)))))
+              | Args [(typ, _)] ->
+                Some
+                  (`SingleArg
+                    ( typ |> Shared.typeToString,
+                      docsForLabel ~file:full.file ~package:full.package
+                        ~supportsMarkdownLinks typ ))
+              | Args args ->
+                let offset = ref 0 in
+                Some
+                  (`TupleArg
+                    (args
+                    |> List.map (fun (typ, _) ->
+                           let startOffset = !offset in
+                           let argText = typ |> Shared.typeToString in
+                           let endOffset =
+                             startOffset + String.length argText
+                           in
+                           offset := endOffset + String.length ", ";
+                           ( argText,
+                             docsForLabel ~file:full.file ~package:full.package
+                               ~supportsMarkdownLinks typ,
+                             (startOffset, endOffset) ))))
+            in
+            let label =
+              constructor.cname.txt ^ "("
+              ^ (match argParts with
+                | None -> ""
+                | Some (`InlineRecord fields) ->
+                  "{"
+                  ^ (fields
                     |> List.map (fun (argText, _, _) -> argText)
                     |> String.concat ", ")
-                ^ ")"
-              in
-              let activeParameter =
-                match expr with
-                | {pexp_desc = Pexp_tuple items} -> (
+                  ^ "}"
+                | Some (`SingleArg (arg, _)) -> arg
+                | Some (`TupleArg items) ->
+                  items
+                  |> List.map (fun (argText, _, _) -> argText)
+                  |> String.concat ", ")
+              ^ ")"
+            in
+            let activeParameter =
+              match expr with
+              | {pexp_desc = Pexp_tuple items} -> (
+                let idx = ref 0 in
+                let tupleItemWithCursor =
+                  items
+                  |> List.find_map (fun (item : Parsetree.expression) ->
+                         let currentIndex = !idx in
+                         idx := currentIndex + 1;
+                         if locHasCursor item.pexp_loc then Some currentIndex
+                         else None)
+                in
+                match tupleItemWithCursor with
+                | None -> -1
+                | Some i -> i)
+              | {pexp_desc = Pexp_record (fields, _)} -> (
+                let fieldNameWithCursor =
+                  fields
+                  |> List.find_map
+                       (fun
+                         (({loc; txt}, expr) :
+                           Longident.t Location.loc * Parsetree.expression)
+                       ->
+                         if
+                           posBeforeCursor >= Pos.ofLexing loc.loc_start
+                           && posBeforeCursor
+                              <= Pos.ofLexing expr.pexp_loc.loc_end
+                         then Some (Longident.last txt)
+                         else None)
+                in
+                match (fieldNameWithCursor, argParts) with
+                | Some fieldName, Some (`InlineRecord fields) ->
                   let idx = ref 0 in
-                  let tupleItemWithCursor =
-                    items
-                    |> List.find_map (fun (item : Parsetree.expression) ->
-                           let currentIndex = !idx in
-                           idx := currentIndex + 1;
-                           if locHasCursor item.pexp_loc then Some currentIndex
-                           else None)
-                  in
-                  match tupleItemWithCursor with
-                  | None -> -1
-                  | Some i -> i)
-                | {pexp_desc = Pexp_record (fields, _)} -> (
-                  let fieldNameWithCursor =
-                    fields
-                    |> List.find_map
-                         (fun
-                           (({loc; txt}, expr) :
-                             Longident.t Location.loc * Parsetree.expression)
-                         ->
-                           if
-                             posBeforeCursor >= Pos.ofLexing loc.loc_start
-                             && posBeforeCursor
-                                <= Pos.ofLexing expr.pexp_loc.loc_end
-                           then Some (Longident.last txt)
-                           else None)
-                  in
-                  match (fieldNameWithCursor, argParts) with
-                  | Some fieldName, Some (`InlineRecord fields) ->
-                    let idx = ref 0 in
-                    let fieldIndex = ref (-1) in
-                    fields
-                    |> List.iter (fun (_, field, _) ->
-                           idx := !idx + 1;
-                           let currentIndex = !idx in
-                           if fieldName = field.fname.txt then
-                             fieldIndex := currentIndex
-                           else ());
-                    !fieldIndex
-                  | _ -> -1)
-                | _ when locHasCursor expr.pexp_loc -> 0
-                | _ -> -1
-              in
+                  let fieldIndex = ref (-1) in
+                  fields
+                  |> List.iter (fun (_, field, _) ->
+                         idx := !idx + 1;
+                         let currentIndex = !idx in
+                         if fieldName = field.fname.txt then
+                           fieldIndex := currentIndex
+                         else ());
+                  !fieldIndex
+                | _ -> -1)
+              | _ when locHasCursor expr.pexp_loc -> 0
+              | _ -> -1
+            in
 
-              let constructorNameLength = String.length constructor.cname.txt in
-              let params =
-                match argParts with
-                | None -> []
-                | Some (`SingleArg (_, docstring)) ->
+            let constructorNameLength = String.length constructor.cname.txt in
+            let params =
+              match argParts with
+              | None -> []
+              | Some (`SingleArg (_, docstring)) ->
+                [
+                  {
+                    Protocol.label =
+                      (constructorNameLength + 1, String.length label - 1);
+                    documentation =
+                      {Protocol.kind = "markdown"; value = docstring};
+                  };
+                ]
+              | Some (`InlineRecord fields) ->
+                (* Account for leading '({' *)
+                let baseOffset = constructorNameLength + 2 in
+                {
+                  Protocol.label = (0, 0);
+                  documentation = {Protocol.kind = "markdown"; value = ""};
+                }
+                :: (fields
+                   |> List.map (fun (_, field, (start, end_)) ->
+                          {
+                            Protocol.label =
+                              (baseOffset + start, baseOffset + end_);
+                            documentation =
+                              {
+                                Protocol.kind = "markdown";
+                                value = field.docstring |> String.concat "\n";
+                              };
+                          }))
+              | Some (`TupleArg items) ->
+                (* Account for leading '(' *)
+                let baseOffset = constructorNameLength + 1 in
+                items
+                |> List.map (fun (_, docstring, (start, end_)) ->
+                       {
+                         Protocol.label = (baseOffset + start, baseOffset + end_);
+                         documentation =
+                           {Protocol.kind = "markdown"; value = docstring};
+                       })
+            in
+            Some
+              {
+                Protocol.signatures =
                   [
                     {
-                      Protocol.label =
-                        (constructorNameLength + 1, String.length label - 1);
+                      label;
+                      parameters = params;
                       documentation =
-                        {Protocol.kind = "markdown"; value = docstring};
+                        (match List.nth_opt constructor.docstring 0 with
+                        | None -> None
+                        | Some docs ->
+                          Some {Protocol.kind = "markdown"; value = docs});
                     };
-                  ]
-                | Some (`InlineRecord fields) ->
-                  (* Account for leading '({' *)
-                  let baseOffset = constructorNameLength + 2 in
-                  {
-                    Protocol.label = (0, 0);
-                    documentation = {Protocol.kind = "markdown"; value = ""};
-                  }
-                  :: (fields
-                     |> List.map (fun (_, field, (start, end_)) ->
-                            {
-                              Protocol.label =
-                                (baseOffset + start, baseOffset + end_);
-                              documentation =
-                                {
-                                  Protocol.kind = "markdown";
-                                  value = field.docstring |> String.concat "\n";
-                                };
-                            }))
-                | Some (`TupleArg items) ->
-                  (* Account for leading '(' *)
-                  let baseOffset = constructorNameLength + 1 in
-                  items
-                  |> List.map (fun (_, docstring, (start, end_)) ->
-                         {
-                           Protocol.label =
-                             (baseOffset + start, baseOffset + end_);
-                           documentation =
-                             {Protocol.kind = "markdown"; value = docstring};
-                         })
-              in
-              Some
-                {
-                  Protocol.signatures =
-                    [
-                      {
-                        label;
-                        parameters = params;
-                        documentation =
-                          (match List.nth_opt constructor.docstring 0 with
-                          | None -> None
-                          | Some docs ->
-                            Some {Protocol.kind = "markdown"; value = docs});
-                      };
-                    ];
-                  activeSignature = Some 0;
-                  activeParameter = Some activeParameter;
-                }))
-        | None -> None)))
+                  ];
+                activeSignature = Some 0;
+                activeParameter = Some activeParameter;
+              }))
+      | _ -> None))

--- a/analysis/tests/src/SignatureHelp.res
+++ b/analysis/tests/src/SignatureHelp.res
@@ -110,7 +110,5 @@ let _deepestTakesPrecedence = [12]->Js.Array2.map(v =>
   }
 )
 
-// ^dv+
-// let _usesCorrectTypeInfo = [12]->Js.Array2.map(v => v)
-//                                                   she
-// ^dv-
+let _usesCorrectTypeInfo = [12]->Belt.Array.map(v => v)
+//                                                   ^she

--- a/analysis/tests/src/SignatureHelp.res
+++ b/analysis/tests/src/SignatureHelp.res
@@ -100,3 +100,17 @@ let three = Three("", [])
 
 let three2 = Three("", [])
 //                      ^she
+
+let _deepestTakesPrecedence = [12]->Js.Array2.map(v =>
+  if v > 0 {
+    One({})
+    //   ^she
+  } else {
+    Two("")
+  }
+)
+
+// ^dv+
+// let _usesCorrectTypeInfo = [12]->Js.Array2.map(v => v)
+//                                                   she
+// ^dv-

--- a/analysis/tests/src/expected/SignatureHelp.res.txt
+++ b/analysis/tests/src/expected/SignatureHelp.res.txt
@@ -247,6 +247,7 @@ extracted params:
 }
 
 Signature help src/SignatureHelp.res 53:31
+[sig_help_result] Doing nothing because loc of FunctionCall < then existing of FunctionCall
 posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:11->53:31]
 posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:20->53:31]
 Pexp_apply ...[53:20->53:29] (...[53:30->53:31])
@@ -451,4 +452,19 @@ Signature help src/SignatureHelp.res 100:24
   "activeSignature": 0,
   "activeParameter": 1
 }
+
+Signature help src/SignatureHelp.res 105:9
+[sig_help_result] Doing nothing because loc of FunctionCall < then existing of FunctionCall
+[sig_help_result] Doing nothing because loc of Constructor < then existing of FunctionCall
+{
+  "signatures": [{
+    "label": "One({miss?: bool, hit?: bool, stuff?: string})",
+    "parameters": [{"label": [0, 0], "documentation": {"kind": "markdown", "value": ""}}, {"label": [5, 16], "documentation": {"kind": "markdown", "value": ""}}, {"label": [18, 28], "documentation": {"kind": "markdown", "value": ""}}, {"label": [30, 44], "documentation": {"kind": "markdown", "value": ""}}],
+    "documentation": {"kind": "markdown", "value": " One is cool. "}
+  }],
+  "activeSignature": 0,
+  "activeParameter": -1
+}
+
+
 

--- a/analysis/tests/src/expected/SignatureHelp.res.txt
+++ b/analysis/tests/src/expected/SignatureHelp.res.txt
@@ -247,7 +247,6 @@ extracted params:
 }
 
 Signature help src/SignatureHelp.res 53:31
-[sig_help_result] Doing nothing because loc of FunctionCall < then existing of FunctionCall
 posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:11->53:31]
 posCursor:[53:29] posNoWhite:[53:28] Found expr:[53:20->53:31]
 Pexp_apply ...[53:20->53:29] (...[53:30->53:31])
@@ -454,8 +453,6 @@ Signature help src/SignatureHelp.res 100:24
 }
 
 Signature help src/SignatureHelp.res 105:9
-[sig_help_result] Doing nothing because loc of FunctionCall < then existing of FunctionCall
-[sig_help_result] Doing nothing because loc of Constructor < then existing of FunctionCall
 {
   "signatures": [{
     "label": "One({miss?: bool, hit?: bool, stuff?: string})",
@@ -466,5 +463,17 @@ Signature help src/SignatureHelp.res 105:9
   "activeParameter": -1
 }
 
-
+Signature help src/SignatureHelp.res 112:53
+argAtCursor: unlabelled<1>
+extracted params: 
+[Belt.Array.t<int>, int => int]
+{
+  "signatures": [{
+    "label": "(Belt.Array.t<int>, int => int) => array<int>",
+    "parameters": [{"label": [1, 18], "documentation": {"kind": "markdown", "value": "```rescript\nBelt.Array.t<int>\n```\n```rescript\ntype t<'a> = array<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22belt_Array.resi%22%2C27%2C0%5D)"}}, {"label": [20, 30], "documentation": {"kind": "markdown", "value": "```rescript\nBelt.Array.t<int>\n```\n```rescript\ntype t<'a> = array<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22belt_Array.resi%22%2C27%2C0%5D)"}}],
+    "documentation": {"kind": "markdown", "value": "\n```rescript\ntype t<'a> = array<'a>\n```\nGo to: [Type definition](command:rescript-vscode.go_to_location?%5B%22belt_Array.resi%22%2C27%2C0%5D)"}
+  }],
+  "activeSignature": 0,
+  "activeParameter": 1
+}
 


### PR DESCRIPTION
* Ensures that locations are taken into account, so that the deepest signature help item with the cursor is the one that triggers.
* Refactors the function call lookup so that we try using typed information first before resorting to using the completion enginge for unsaved content. This will yield better results with incremental type checking because type params etc will be instantiated.