### PR TITLE
Refactor: completion creation fns to just one

### DIFF
--- a/analysis/bin/main.ml
+++ b/analysis/bin/main.ml
@@ -110,12 +110,8 @@ let main () =
         path line col
   in
   match args with
-  | [_; "completion"; path; line; col; currentFile; supportsSnippets] ->
+  | [_; "completion"; path; line; col; currentFile] ->
     printHeaderInfo path line col;
-    (Cfg.supportsSnippets :=
-       match supportsSnippets with
-       | "true" -> true
-       | _ -> false);
     Commands.completion ~debug ~path
       ~pos:(int_of_string line, int_of_string col)
       ~currentFile
@@ -193,9 +189,7 @@ let main () =
       (Json.escape (CreateInterface.command ~path ~cmiFile))
   | [_; "format"; path] ->
     Printf.printf "\"%s\"" (Json.escape (Commands.format ~path))
-  | [_; "test"; path] ->
-    Cfg.supportsSnippets := true;
-    Commands.test ~path
+  | [_; "test"; path] -> Commands.test ~path
   | args when List.mem "-h" args || List.mem "--help" args -> prerr_endline help
   | _ ->
     prerr_endline help;

--- a/analysis/src/Cfg.ml
+++ b/analysis/src/Cfg.ml
@@ -1,5 +1,3 @@
-let supportsSnippets = ref false
-
 let debugFollowCtxPath = ref false
 
 let isDocGenFromCompiler = ref false

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -802,24 +802,8 @@ module Completion = struct
     typeArgContext: typeArgContext option;
   }
 
-  let create ~kind ~env ?typeArgContext ?(docstring = []) ?filterText ?detail
-      ?deprecated ?insertText name =
-    {
-      name;
-      env;
-      deprecated;
-      docstring;
-      kind;
-      sortText = None;
-      insertText;
-      insertTextFormat = None;
-      filterText;
-      detail;
-      typeArgContext;
-    }
-
-  let createWithSnippet ~name ?typeArgContext ?insertText ~kind ~env ?sortText
-      ?deprecated ?filterText ?detail ?(docstring = []) () =
+  let create ?typeArgContext ?(includesSnippets = false) ?insertText ~kind ~env
+      ?sortText ?deprecated ?filterText ?detail ?(docstring = []) name =
     {
       name;
       env;
@@ -828,7 +812,8 @@ module Completion = struct
       kind;
       sortText;
       insertText;
-      insertTextFormat = Some Protocol.Snippet;
+      insertTextFormat =
+        (if includesSnippets then Some Protocol.Snippet else None);
       filterText;
       detail;
       typeArgContext;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -653,7 +653,6 @@ function completion(msg: p.RequestMessage) {
       params.position.line,
       params.position.character,
       tmpname,
-      Boolean(extensionClientCapabilities.supportsSnippetSyntax),
     ],
     msg
   );


### PR DESCRIPTION
A long overdue refactor. No need for 2 functions to exist. 

Also assumes all clients support snippets, which they do.