### PR TITLE
Cleanup completion details docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :rocket: New Feature
 
 - Extend signature help to work on constructor payloads as well. Can be turned off if wanted through settings. https://github.com/rescript-lang/rescript-vscode/pull/947
+- Show module docs for file modules. https://github.com/rescript-lang/rescript-vscode/pull/952
 
 #### :nail_care: Polish
 
@@ -22,6 +23,7 @@
 - Clean occasional dots from "insert missing fields" code action. https://github.com/rescript-lang/rescript-vscode/pull/948
 - Pick up code actions in incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/948
 - Various improvements to the signature help functionality. https://github.com/rescript-lang/rescript-vscode/pull/950
+- Clean up completion item "details" and "documentation". https://github.com/rescript-lang/rescript-vscode/pull/952
 
 ## 1.48.0
 

--- a/analysis/bin/main.ml
+++ b/analysis/bin/main.ml
@@ -115,6 +115,8 @@ let main () =
     Commands.completion ~debug ~path
       ~pos:(int_of_string line, int_of_string col)
       ~currentFile
+  | [_; "completionResolve"; path; modulePath] ->
+    Commands.completionResolve ~path ~modulePath
   | [_; "definition"; path; line; col] ->
     Commands.definition ~path
       ~pos:(int_of_string line, int_of_string col)

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -4,13 +4,12 @@ let completion ~debug ~path ~pos ~currentFile =
       Completions.getCompletions ~debug ~path ~pos ~currentFile ~forHover:false
     with
     | None -> []
-    | Some (completions, _, _) -> completions
+    | Some (completions, full, _) ->
+      completions
+      |> List.map (CompletionBackEnd.completionToItem ~full)
+      |> List.map Protocol.stringifyCompletionItem
   in
-  print_endline
-    (completions
-    |> List.map CompletionBackEnd.completionToItem
-    |> List.map Protocol.stringifyCompletionItem
-    |> Protocol.array)
+  completions |> Protocol.array |> print_endline
 
 let inlayhint ~path ~pos ~maxLength ~debug =
   let result =

--- a/analysis/src/Protocol.ml
+++ b/analysis/src/Protocol.ml
@@ -50,6 +50,7 @@ type completionItem = {
   insertTextFormat: insertTextFormat option;
   insertText: string option;
   documentation: markupContent option;
+  data: (string * string) list option;
 }
 
 type location = {uri: string; range: range}
@@ -139,6 +140,14 @@ let stringifyCompletionItem c =
         | None -> None
         | Some insertTextFormat ->
           Some (Printf.sprintf "%i" (insertTextFormatToInt insertTextFormat)) );
+      ( "data",
+        match c.data with
+        | None -> None
+        | Some fields ->
+          Some
+            (fields
+            |> List.map (fun (key, value) -> (key, Some (wrapInQuotes value)))
+            |> stringifyObject ~indentation:2) );
     ]
 
 let stringifyHover value =

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -775,7 +775,7 @@ end
 
 module Completion = struct
   type kind =
-    | Module of Module.t
+    | Module of {docstring: string list; module_: Module.t}
     | Value of Types.type_expr
     | ObjLabel of Types.type_expr
     | Label of string

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -800,10 +800,11 @@ module Completion = struct
     kind: kind;
     detail: string option;
     typeArgContext: typeArgContext option;
+    data: (string * string) list option;
   }
 
-  let create ?typeArgContext ?(includesSnippets = false) ?insertText ~kind ~env
-      ?sortText ?deprecated ?filterText ?detail ?(docstring = []) name =
+  let create ?data ?typeArgContext ?(includesSnippets = false) ?insertText ~kind
+      ~env ?sortText ?deprecated ?filterText ?detail ?(docstring = []) name =
     {
       name;
       env;
@@ -817,6 +818,7 @@ module Completion = struct
       filterText;
       detail;
       typeArgContext;
+      data;
     }
 
   (* https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion *)

--- a/analysis/tests-incremental-typechecking/src/expected/ConstructorCompletion__Json.res.txt
+++ b/analysis/tests-incremental-typechecking/src/expected/ConstructorCompletion__Json.res.txt
@@ -12,7 +12,7 @@ ContextPath CTypeAtPos()
     "kind": 12,
     "tags": [],
     "detail": "t",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": " The JSON data structure \n\n```rescript\ntype t =\n  | Boolean(bool)\n  | Null\n  | String(string)\n  | Number(float)\n  | Object(Js.Dict.t<t>)\n  | Array(array<t>)\n```"},
     "sortText": "A",
     "insertText": "[$0]",
     "insertTextFormat": 2

--- a/analysis/tests/src/CompletionResolve.res
+++ b/analysis/tests/src/CompletionResolve.res
@@ -1,0 +1,4 @@
+// ^cre Belt_Array
+
+// ^cre ModuleStuff
+

--- a/analysis/tests/src/ModuleStuff.res
+++ b/analysis/tests/src/ModuleStuff.res
@@ -1,0 +1,5 @@
+/*** This is a top level module doc. */
+
+module Nested = {
+  /*** Module doc for nested. */
+}

--- a/analysis/tests/src/expected/CompletePrioritize2.res.txt
+++ b/analysis/tests/src/expected/CompletePrioritize2.res.txt
@@ -31,6 +31,6 @@ Path ax
     "kind": 12,
     "tags": [],
     "detail": "Test.t",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype t = {name: int}\n```"}
   }]
 

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -878,13 +878,21 @@ Path Lis
     "kind": 9,
     "tags": [],
     "detail": "module List",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "List",
+      "filePath": "src/Completion.res"
+    }
   }, {
     "label": "ListLabels",
     "kind": 9,
     "tags": [],
     "detail": "module ListLabels",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "ListLabels",
+      "filePath": "src/Completion.res"
+    }
   }]
 
 Complete src/Completion.res 169:16
@@ -1648,13 +1656,21 @@ Path Res
     "kind": 9,
     "tags": [],
     "detail": "module RescriptReactErrorBoundary",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "RescriptReactErrorBoundary",
+      "filePath": "src/Completion.res"
+    }
   }, {
     "label": "RescriptReactRouter",
     "kind": 9,
     "tags": [],
     "detail": "module RescriptReactRouter",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "RescriptReactRouter",
+      "filePath": "src/Completion.res"
+    }
   }]
 
 Complete src/Completion.res 343:57
@@ -1765,19 +1781,31 @@ Path T
     "kind": 9,
     "tags": [],
     "detail": "module TableclothMap",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "TableclothMap",
+      "filePath": "src/Completion.res"
+    }
   }, {
     "label": "TypeAtPosCompletion",
     "kind": 9,
     "tags": [],
     "detail": "module TypeAtPosCompletion",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "TypeAtPosCompletion",
+      "filePath": "src/Completion.res"
+    }
   }, {
     "label": "TypeDefinition",
     "kind": 9,
     "tags": [],
     "detail": "module TypeDefinition",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "TypeDefinition",
+      "filePath": "src/Completion.res"
+    }
   }]
 
 Complete src/Completion.res 373:21

--- a/analysis/tests/src/expected/Completion.res.txt
+++ b/analysis/tests/src/expected/Completion.res.txt
@@ -296,7 +296,7 @@ Path Array.
     "label": "Floatarray",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module Floatarray",
     "documentation": null
   }]
 
@@ -732,14 +732,14 @@ Path r
     "label": "x",
     "kind": 5,
     "tags": [],
-    "detail": "x: int\n\ntype r = {x: int, y: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nx: int\n```\n\n```rescript\ntype r = {x: int, y: string}\n```"}
   }, {
     "label": "y",
     "kind": 5,
     "tags": [],
-    "detail": "y: string\n\ntype r = {x: int, y: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\ny: string\n```\n\n```rescript\ntype r = {x: int, y: string}\n```"}
   }]
 
 Complete src/Completion.res 113:25
@@ -755,14 +755,14 @@ Path Objects.Rec.recordVal
     "label": "xx",
     "kind": 5,
     "tags": [],
-    "detail": "xx: int\n\ntype recordt = {xx: int, ss: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nxx: int\n```\n\n```rescript\ntype recordt = {xx: int, ss: string}\n```"}
   }, {
     "label": "ss",
     "kind": 5,
     "tags": [],
-    "detail": "ss: string\n\ntype recordt = {xx: int, ss: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nss: string\n```\n\n```rescript\ntype recordt = {xx: int, ss: string}\n```"}
   }]
 
 Complete src/Completion.res 120:7
@@ -819,7 +819,7 @@ Path O.
     "label": "Comp",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module Comp",
     "documentation": null
   }]
 
@@ -837,14 +837,14 @@ Path q
     "label": "x",
     "kind": 5,
     "tags": [],
-    "detail": "x: int\n\ntype aa = {x: int, name: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nx: int\n```\n\n```rescript\ntype aa = {x: int, name: string}\n```"}
   }, {
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype aa = {x: int, name: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype aa = {x: int, name: string}\n```"}
   }]
 
 Complete src/Completion.res 159:9
@@ -861,8 +861,8 @@ Path q
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype aa = {x: int, name: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype aa = {x: int, name: string}\n```"}
   }]
 
 Complete src/Completion.res 162:6
@@ -877,13 +877,13 @@ Path Lis
     "label": "List",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module List",
     "documentation": null
   }, {
     "label": "ListLabels",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module ListLabels",
     "documentation": null
   }]
 
@@ -899,7 +899,7 @@ Path WithChildren
     "label": "WithChildren",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module WithChildren",
     "documentation": null
   }]
 
@@ -915,20 +915,20 @@ Path Js.n
     "label": "null_undefined",
     "kind": 22,
     "tags": [],
-    "detail": "type null_undefined<'a> = nullable<'a>",
-    "documentation": null
+    "detail": "type null_undefined",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype null_undefined<'a> = nullable<'a>\n```"}
   }, {
     "label": "nullable",
     "kind": 22,
     "tags": [],
-    "detail": "type nullable<'a> = Value('a) | Null | Undefined",
-    "documentation": null
+    "detail": "type nullable",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype nullable<'a> = Value('a) | Null | Undefined\n```"}
   }, {
     "label": "null",
     "kind": 22,
     "tags": [],
-    "detail": "type null<'a> = Value('a) | Null",
-    "documentation": {"kind": "markdown", "value": "\n  Nullable value of this type can be either null or 'a. This type is equivalent to Js.Null.t.\n"}
+    "detail": "type null",
+    "documentation": {"kind": "markdown", "value": "\n  Nullable value of this type can be either null or 'a. This type is equivalent to Js.Null.t.\n\n\n```rescript\ntype null<'a> = Value('a) | Null\n```"}
   }]
 
 Complete src/Completion.res 174:20
@@ -943,8 +943,8 @@ Path ForAuto.
     "label": "t",
     "kind": 22,
     "tags": [],
-    "detail": "type t = int",
-    "documentation": null
+    "detail": "type t",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype t = int\n```"}
   }]
 
 Complete src/Completion.res 179:13
@@ -959,8 +959,8 @@ Path As
     "label": "Asterix",
     "kind": 4,
     "tags": [],
-    "detail": "Asterix\n\ntype z = Allo | Asterix | Baba",
-    "documentation": null
+    "detail": "Asterix",
+    "documentation": {"kind": "markdown", "value": "```rescript\nAsterix\n```\n\n```rescript\ntype z = Allo | Asterix | Baba\n```"}
   }]
 
 Complete src/Completion.res 182:17
@@ -974,7 +974,7 @@ Path For
     "label": "ForAuto",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module ForAuto",
     "documentation": null
   }]
 
@@ -1077,14 +1077,14 @@ Path FAO.forAutoObject
     "label": "forAuto",
     "kind": 5,
     "tags": [],
-    "detail": "forAuto: ForAuto.t\n\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}",
-    "documentation": null
+    "detail": "ForAuto.t",
+    "documentation": {"kind": "markdown", "value": "```rescript\nforAuto: ForAuto.t\n```\n\n```rescript\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}\n```"}
   }, {
     "label": "something",
     "kind": 5,
     "tags": [],
-    "detail": "something: option<int>\n\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}",
-    "documentation": null
+    "detail": "option<int>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomething: option<int>\n```\n\n```rescript\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}\n```"}
   }]
 
 Complete src/Completion.res 227:46
@@ -1185,14 +1185,14 @@ Path _z
     "label": "x",
     "kind": 5,
     "tags": [],
-    "detail": "x: int\n\ntype r = {x: int, y: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nx: int\n```\n\n```rescript\ntype r = {x: int, y: string}\n```"}
   }, {
     "label": "y",
     "kind": 5,
     "tags": [],
-    "detail": "y: string\n\ntype r = {x: int, y: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\ny: string\n```\n\n```rescript\ntype r = {x: int, y: string}\n```"}
   }]
 
 Complete src/Completion.res 254:17
@@ -1208,7 +1208,7 @@ Path SomeLo
     "label": "SomeLocalModule",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module SomeLocalModule",
     "documentation": null
   }]
 
@@ -1225,8 +1225,8 @@ Path SomeLocalModule.
     "label": "zz",
     "kind": 22,
     "tags": [],
-    "detail": "type zz = int",
-    "documentation": null
+    "detail": "type zz",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype zz = int\n```"}
   }]
 
 Complete src/Completion.res 261:33
@@ -1242,8 +1242,8 @@ Path SomeLocalModule.
     "label": "zz",
     "kind": 22,
     "tags": [],
-    "detail": "type zz = int",
-    "documentation": null
+    "detail": "type zz",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype zz = int\n```"}
   }]
 
 Complete src/Completion.res 268:21
@@ -1258,13 +1258,13 @@ Path SomeLocal
     "label": "SomeLocalVariantItem",
     "kind": 4,
     "tags": [],
-    "detail": "SomeLocalVariantItem\n\ntype someLocalVariant = SomeLocalVariantItem",
-    "documentation": null
+    "detail": "SomeLocalVariantItem",
+    "documentation": {"kind": "markdown", "value": "```rescript\nSomeLocalVariantItem\n```\n\n```rescript\ntype someLocalVariant = SomeLocalVariantItem\n```"}
   }, {
     "label": "SomeLocalModule",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module SomeLocalModule",
     "documentation": null
   }]
 
@@ -1282,7 +1282,7 @@ Path SomeLocal
     "label": "SomeLocalModule",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module SomeLocalModule",
     "documentation": null
   }]
 
@@ -1319,14 +1319,14 @@ Path s
     "label": "someType",
     "kind": 22,
     "tags": [],
-    "detail": "type someType = {hello: string}",
-    "documentation": null
+    "detail": "type someType",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someType = {hello: string}\n```"}
   }, {
     "label": "someLocalVariant",
     "kind": 22,
     "tags": [],
-    "detail": "type someLocalVariant = SomeLocalVariantItem",
-    "documentation": null
+    "detail": "type someLocalVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someLocalVariant = SomeLocalVariantItem\n```"}
   }]
 
 Complete src/Completion.res 291:30
@@ -1363,14 +1363,14 @@ Path retAA
     "label": "x",
     "kind": 5,
     "tags": [],
-    "detail": "x: int\n\ntype aa = {x: int, name: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nx: int\n```\n\n```rescript\ntype aa = {x: int, name: string}\n```"}
   }, {
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype aa = {x: int, name: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype aa = {x: int, name: string}\n```"}
   }]
 
 Complete src/Completion.res 301:13
@@ -1647,13 +1647,13 @@ Path Res
     "label": "RescriptReactErrorBoundary",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module RescriptReactErrorBoundary",
     "documentation": null
   }, {
     "label": "RescriptReactRouter",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module RescriptReactRouter",
     "documentation": null
   }]
 
@@ -1752,31 +1752,31 @@ Path T
     "label": "That",
     "kind": 4,
     "tags": [],
-    "detail": "That\n\ntype v = This | That",
-    "documentation": null
+    "detail": "That",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThat\n```\n\n```rescript\ntype v = This | That\n```"}
   }, {
     "label": "This",
     "kind": 4,
     "tags": [],
-    "detail": "This\n\ntype v = This | That",
-    "documentation": null
+    "detail": "This",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThis\n```\n\n```rescript\ntype v = This | That\n```"}
   }, {
     "label": "TableclothMap",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module TableclothMap",
     "documentation": null
   }, {
     "label": "TypeAtPosCompletion",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module TypeAtPosCompletion",
     "documentation": null
   }, {
     "label": "TypeDefinition",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module TypeDefinition",
     "documentation": null
   }]
 
@@ -1796,8 +1796,8 @@ Path AndThatOther.T
     "label": "ThatOther",
     "kind": 4,
     "tags": [],
-    "detail": "ThatOther\n\ntype v = And | ThatOther",
-    "documentation": null
+    "detail": "ThatOther",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThatOther\n```\n\n```rescript\ntype v = And | ThatOther\n```"}
   }]
 
 Complete src/Completion.res 378:24
@@ -1873,14 +1873,14 @@ Path funRecord
     "label": "someFun",
     "kind": 5,
     "tags": [],
-    "detail": "someFun: (~name: string) => unit\n\ntype funRecord = {\n  someFun: (~name: string) => unit,\n  stuff: string,\n}",
-    "documentation": null
+    "detail": "(~name: string) => unit",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeFun: (~name: string) => unit\n```\n\n```rescript\ntype funRecord = {\n  someFun: (~name: string) => unit,\n  stuff: string,\n}\n```"}
   }, {
     "label": "stuff",
     "kind": 5,
     "tags": [],
-    "detail": "stuff: string\n\ntype funRecord = {\n  someFun: (~name: string) => unit,\n  stuff: string,\n}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nstuff: string\n```\n\n```rescript\ntype funRecord = {\n  someFun: (~name: string) => unit,\n  stuff: string,\n}\n```"}
   }]
 
 Complete src/Completion.res 389:12
@@ -1984,7 +1984,7 @@ Path r
     "kind": 12,
     "tags": [],
     "detail": "rAlias",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype r = {x: int, y: string}\n```"}
   }]
 
 Complete src/Completion.res 409:21
@@ -2129,14 +2129,14 @@ Path rWithDepr
     "label": "someInt",
     "kind": 5,
     "tags": [1],
-    "detail": "someInt: int\n\ntype someRecordWithDeprecatedField = {\n  name: string,\n  someInt: int,\n  someFloat: float,\n}",
-    "documentation": {"kind": "markdown", "value": "Deprecated: \n\n"}
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "Deprecated: \n\n```rescript\nsomeInt: int\n```\n\n```rescript\ntype someRecordWithDeprecatedField = {\n  name: string,\n  someInt: int,\n  someFloat: float,\n}\n```"}
   }, {
     "label": "someFloat",
     "kind": 5,
     "tags": [1],
-    "detail": "someFloat: float\n\ntype someRecordWithDeprecatedField = {\n  name: string,\n  someInt: int,\n  someFloat: float,\n}",
-    "documentation": {"kind": "markdown", "value": "Deprecated: Use 'someInt'.\n\n"}
+    "detail": "float",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use 'someInt'.\n\n```rescript\nsomeFloat: float\n```\n\n```rescript\ntype someRecordWithDeprecatedField = {\n  name: string,\n  someInt: int,\n  someFloat: float,\n}\n```"}
   }]
 
 Complete src/Completion.res 450:37
@@ -2151,24 +2151,24 @@ Path someVariantWithDeprecated
     "label": "DoNotUseMe",
     "kind": 4,
     "tags": [1],
-    "detail": "DoNotUseMe\n\ntype someVariantWithDeprecated =\n  | DoNotUseMe\n  | UseMeInstead\n  | AndNotMe",
-    "documentation": {"kind": "markdown", "value": "Deprecated: \n\n"},
+    "detail": "DoNotUseMe",
+    "documentation": {"kind": "markdown", "value": "Deprecated: \n\n```rescript\nDoNotUseMe\n```\n\n```rescript\ntype someVariantWithDeprecated =\n  | DoNotUseMe\n  | UseMeInstead\n  | AndNotMe\n```"},
     "insertText": "DoNotUseMe",
     "insertTextFormat": 2
   }, {
     "label": "UseMeInstead",
     "kind": 4,
     "tags": [],
-    "detail": "UseMeInstead\n\ntype someVariantWithDeprecated =\n  | DoNotUseMe\n  | UseMeInstead\n  | AndNotMe",
-    "documentation": null,
+    "detail": "UseMeInstead",
+    "documentation": {"kind": "markdown", "value": "```rescript\nUseMeInstead\n```\n\n```rescript\ntype someVariantWithDeprecated =\n  | DoNotUseMe\n  | UseMeInstead\n  | AndNotMe\n```"},
     "insertText": "UseMeInstead",
     "insertTextFormat": 2
   }, {
     "label": "AndNotMe",
     "kind": 4,
     "tags": [1],
-    "detail": "AndNotMe\n\ntype someVariantWithDeprecated =\n  | DoNotUseMe\n  | UseMeInstead\n  | AndNotMe",
-    "documentation": {"kind": "markdown", "value": "Deprecated: Use 'UseMeInstead'\n\n"},
+    "detail": "AndNotMe",
+    "documentation": {"kind": "markdown", "value": "Deprecated: Use 'UseMeInstead'\n\n```rescript\nAndNotMe\n```\n\n```rescript\ntype someVariantWithDeprecated =\n  | DoNotUseMe\n  | UseMeInstead\n  | AndNotMe\n```"},
     "insertText": "AndNotMe",
     "insertTextFormat": 2
   }]
@@ -2226,18 +2226,18 @@ Path FAR.
     "kind": 12,
     "tags": [],
     "detail": "forAutoRecord",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}\n```"}
   }, {
     "label": "forAuto",
     "kind": 5,
     "tags": [],
-    "detail": "forAuto: ForAuto.t\n\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}",
-    "documentation": null
+    "detail": "ForAuto.t",
+    "documentation": {"kind": "markdown", "value": "```rescript\nforAuto: ForAuto.t\n```\n\n```rescript\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}\n```"}
   }, {
     "label": "something",
     "kind": 5,
     "tags": [],
-    "detail": "something: option<int>\n\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}",
-    "documentation": null
+    "detail": "option<int>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomething: option<int>\n```\n\n```rescript\ntype forAutoRecord = {\n  forAuto: ForAuto.t,\n  something: option<int>,\n}\n```"}
   }]
 

--- a/analysis/tests/src/expected/CompletionAttributes.res.txt
+++ b/analysis/tests/src/expected/CompletionAttributes.res.txt
@@ -74,20 +74,20 @@ Resolved opens 1 pervasives
     "label": "version",
     "kind": 5,
     "tags": [],
-    "detail": "version?: int\n\ntype jsxConfig = {version: int, module_: string, mode: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nversion?: int\n```\n\n```rescript\ntype jsxConfig = {version: int, module_: string, mode: string}\n```"}
   }, {
     "label": "module_",
     "kind": 5,
     "tags": [],
-    "detail": "module_?: string\n\ntype jsxConfig = {version: int, module_: string, mode: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nmodule_?: string\n```\n\n```rescript\ntype jsxConfig = {version: int, module_: string, mode: string}\n```"}
   }, {
     "label": "mode",
     "kind": 5,
     "tags": [],
-    "detail": "mode?: string\n\ntype jsxConfig = {version: int, module_: string, mode: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nmode?: string\n```\n\n```rescript\ntype jsxConfig = {version: int, module_: string, mode: string}\n```"}
   }]
 
 Complete src/CompletionAttributes.res 12:17
@@ -99,14 +99,14 @@ Resolved opens 1 pervasives
     "label": "module_",
     "kind": 5,
     "tags": [],
-    "detail": "module_?: string\n\ntype jsxConfig = {version: int, module_: string, mode: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nmodule_?: string\n```\n\n```rescript\ntype jsxConfig = {version: int, module_: string, mode: string}\n```"}
   }, {
     "label": "mode",
     "kind": 5,
     "tags": [],
-    "detail": "mode?: string\n\ntype jsxConfig = {version: int, module_: string, mode: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nmode?: string\n```\n\n```rescript\ntype jsxConfig = {version: int, module_: string, mode: string}\n```"}
   }]
 
 Complete src/CompletionAttributes.res 15:25
@@ -134,14 +134,14 @@ Resolved opens 1 pervasives
     "label": "version",
     "kind": 5,
     "tags": [],
-    "detail": "version?: int\n\ntype jsxConfig = {version: int, module_: string, mode: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nversion?: int\n```\n\n```rescript\ntype jsxConfig = {version: int, module_: string, mode: string}\n```"}
   }, {
     "label": "mode",
     "kind": 5,
     "tags": [],
-    "detail": "mode?: string\n\ntype jsxConfig = {version: int, module_: string, mode: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nmode?: string\n```\n\n```rescript\ntype jsxConfig = {version: int, module_: string, mode: string}\n```"}
   }]
 
 Complete src/CompletionAttributes.res 21:12
@@ -153,14 +153,14 @@ Resolved opens 1 pervasives
     "label": "from",
     "kind": 5,
     "tags": [],
-    "detail": "from?: string\n\ntype moduleConfig = {from: string, with: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfrom?: string\n```\n\n```rescript\ntype moduleConfig = {from: string, with: string}\n```"}
   }, {
     "label": "with",
     "kind": 5,
     "tags": [],
-    "detail": "with?: string\n\ntype moduleConfig = {from: string, with: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nwith?: string\n```\n\n```rescript\ntype moduleConfig = {from: string, with: string}\n```"}
   }]
 
 Complete src/CompletionAttributes.res 24:17
@@ -172,8 +172,8 @@ Resolved opens 1 pervasives
     "label": "{}",
     "kind": 12,
     "tags": [],
-    "detail": "type importAttributesConfig = {type_: string}",
-    "documentation": null,
+    "detail": "importAttributesConfig",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype importAttributesConfig = {type_: string}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -188,8 +188,8 @@ Resolved opens 1 pervasives
     "label": "type_",
     "kind": 5,
     "tags": [],
-    "detail": "type_?: string\n\ntype importAttributesConfig = {type_: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype_?: string\n```\n\n```rescript\ntype importAttributesConfig = {type_: string}\n```"}
   }]
 
 Complete src/CompletionAttributes.res 30:19

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -31,38 +31,38 @@ Path fnTakingRecord
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nsomeRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "offline",
     "kind": 5,
     "tags": [],
-    "detail": "offline: bool\n\nsomeRecord",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\noffline: bool\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "online",
     "kind": 5,
     "tags": [],
-    "detail": "online: option<bool>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<bool>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nonline: option<bool>\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "variant",
     "kind": 5,
     "tags": [],
-    "detail": "variant: someVariant\n\nsomeRecord",
-    "documentation": null
+    "detail": "someVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\nvariant: someVariant\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "polyvariant",
     "kind": 5,
     "tags": [],
-    "detail": "polyvariant: somePolyVariant\n\nsomeRecord",
-    "documentation": null
+    "detail": "somePolyVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\npolyvariant: somePolyVariant\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "nested",
     "kind": 5,
     "tags": [],
-    "detail": "nested: option<otherRecord>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<otherRecord>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnested: option<otherRecord>\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 29:28
@@ -78,8 +78,8 @@ Path fnTakingRecord
     "label": "nested",
     "kind": 5,
     "tags": [],
-    "detail": "nested: option<otherRecord>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<otherRecord>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnested: option<otherRecord>\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 32:35
@@ -118,32 +118,32 @@ Path fnTakingRecord
     "label": "offline",
     "kind": 5,
     "tags": [],
-    "detail": "offline: bool\n\nsomeRecord",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\noffline: bool\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "online",
     "kind": 5,
     "tags": [],
-    "detail": "online: option<bool>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<bool>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nonline: option<bool>\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "variant",
     "kind": 5,
     "tags": [],
-    "detail": "variant: someVariant\n\nsomeRecord",
-    "documentation": null
+    "detail": "someVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\nvariant: someVariant\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "polyvariant",
     "kind": 5,
     "tags": [],
-    "detail": "polyvariant: somePolyVariant\n\nsomeRecord",
-    "documentation": null
+    "detail": "somePolyVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\npolyvariant: somePolyVariant\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "nested",
     "kind": 5,
     "tags": [],
-    "detail": "nested: option<otherRecord>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<otherRecord>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnested: option<otherRecord>\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 38:37
@@ -159,26 +159,26 @@ Path fnTakingRecord
     "label": "online",
     "kind": 5,
     "tags": [],
-    "detail": "online: option<bool>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<bool>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nonline: option<bool>\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "variant",
     "kind": 5,
     "tags": [],
-    "detail": "variant: someVariant\n\nsomeRecord",
-    "documentation": null
+    "detail": "someVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\nvariant: someVariant\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "polyvariant",
     "kind": 5,
     "tags": [],
-    "detail": "polyvariant: somePolyVariant\n\nsomeRecord",
-    "documentation": null
+    "detail": "somePolyVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\npolyvariant: somePolyVariant\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }, {
     "label": "nested",
     "kind": 5,
     "tags": [],
-    "detail": "nested: option<otherRecord>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<otherRecord>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnested: option<otherRecord>\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 41:44
@@ -195,7 +195,7 @@ Path fnTakingRecord
     "kind": 12,
     "tags": [],
     "detail": "otherRecord",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"},
     "insertText": "Some(nested)$0",
     "insertTextFormat": 2
   }, {
@@ -203,7 +203,7 @@ Path fnTakingRecord
     "kind": 12,
     "tags": [],
     "detail": "otherRecord",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"},
     "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
@@ -211,13 +211,13 @@ Path fnTakingRecord
     "kind": 12,
     "tags": [],
     "detail": "otherRecord",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"}
   }, {
     "label": "Some({})",
     "kind": 12,
     "tags": [],
     "detail": "otherRecord",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"},
     "insertText": "Some({$0})",
     "insertTextFormat": 2
   }]
@@ -246,14 +246,14 @@ Path fnTakingRecord
     "label": "someField",
     "kind": 5,
     "tags": [],
-    "detail": "someField: int\n\notherRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeField: int\n```\n\n```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"}
   }, {
     "label": "otherField",
     "kind": 5,
     "tags": [],
-    "detail": "otherField: string\n\notherRecord",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\notherField: string\n```\n\n```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 50:45
@@ -269,24 +269,24 @@ Path fnTakingRecord
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two",
     "kind": 4,
     "tags": [],
-    "detail": "Two\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "Two",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Two",
     "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(int, string)\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "Three(int, string)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(int, string)\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
@@ -304,8 +304,8 @@ Path fnTakingRecord
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }]
@@ -324,7 +324,7 @@ Path fnTakingRecord
     "kind": 12,
     "tags": [],
     "detail": "someRecord",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>, variant: someVariant, polyvariant: somePolyVariant, nested: option<otherRecord>}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -615,7 +615,7 @@ Path fnTakingRecordWithOptVariant
     "kind": 12,
     "tags": [],
     "detail": "someVariant",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Some(someVariant)$0",
     "insertTextFormat": 2
   }, {
@@ -623,7 +623,7 @@ Path fnTakingRecordWithOptVariant
     "kind": 12,
     "tags": [],
     "detail": "someVariant",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
@@ -631,29 +631,29 @@ Path fnTakingRecordWithOptVariant
     "kind": 12,
     "tags": [],
     "detail": "someVariant",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two | Three(int, string)\n```"}
   }, {
     "label": "Some(One)",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Some(One)",
     "insertTextFormat": 2
   }, {
     "label": "Some(Two)",
     "kind": 4,
     "tags": [],
-    "detail": "Two\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "Two",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Some(Two)",
     "insertTextFormat": 2
   }, {
     "label": "Some(Three(_, _))",
     "kind": 4,
     "tags": [],
-    "detail": "Three(int, string)\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "Three(int, string)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(int, string)\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Some(Three(${1:_}, ${2:_}))",
     "insertTextFormat": 2
   }]
@@ -738,7 +738,7 @@ Path fnTakingInlineRecord
     "kind": 12,
     "tags": [],
     "detail": "otherRecord",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -757,14 +757,14 @@ Path fnTakingInlineRecord
     "label": "someField",
     "kind": 5,
     "tags": [],
-    "detail": "someField: int\n\notherRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeField: int\n```\n\n```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"}
   }, {
     "label": "otherField",
     "kind": 5,
     "tags": [],
-    "detail": "otherField: string\n\notherRecord",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\notherField: string\n```\n\n```rescript\ntype otherRecord = {someField: int, otherField: string}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 159:20
@@ -950,8 +950,8 @@ Path fff
     "label": "someOptField",
     "kind": 5,
     "tags": [],
-    "detail": "someOptField?: bool\n\ntype recordWithOptionalField = {\n  someField: int,\n  someOptField?: bool,\n}",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeOptField?: bool\n```\n\n```rescript\ntype recordWithOptionalField = {\n  someField: int,\n  someOptField?: bool,\n}\n```"}
   }]
 
 Complete src/CompletionExpressions.res 205:11
@@ -1126,8 +1126,8 @@ Path takesExotic
     "label": "#\"some exotic\"",
     "kind": 4,
     "tags": [],
-    "detail": "#\"some exotic\"\n\n[#\"some exotic\"]",
-    "documentation": null,
+    "detail": "#\"some exotic\"",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#\"some exotic\"\n```\n\n```rescript\n[#\"some exotic\"]\n```"},
     "insertText": "#\"some exotic\"",
     "insertTextFormat": 2
   }]
@@ -1145,24 +1145,24 @@ Path fnTakingPolyVariant
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#one",
     "insertTextFormat": 2
   }, {
     "label": "#three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "#three(someRecord, bool)\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#three(someRecord, bool)\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }, {
     "label": "#two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "#two(bool)\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two(bool)\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#two($0)",
     "insertTextFormat": 2
   }]
@@ -1180,24 +1180,24 @@ Path fnTakingPolyVariant
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "one",
     "insertTextFormat": 2
   }, {
     "label": "#three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "#three(someRecord, bool)\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#three(someRecord, bool)\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }, {
     "label": "#two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "#two(bool)\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two(bool)\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "two($0)",
     "insertTextFormat": 2
   }]
@@ -1215,8 +1215,8 @@ Path fnTakingPolyVariant
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "one",
     "insertTextFormat": 2
   }]
@@ -1234,8 +1234,8 @@ Path fnTakingPolyVariant
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#one",
     "insertTextFormat": 2
   }]
@@ -1419,7 +1419,7 @@ Path someTyp
     "label": "test",
     "kind": 5,
     "tags": [],
-    "detail": "test: bool\n\ntype someTyp = {test: bool}",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntest: bool\n```\n\n```rescript\ntype someTyp = {test: bool}\n```"}
   }]
 

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -176,13 +176,21 @@ Path someFnTakingVariant
     "kind": 9,
     "tags": [],
     "detail": "module Obj",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "Obj",
+      "filePath": "src/CompletionFunctionArguments.res"
+    }
   }, {
     "label": "Objects",
     "kind": 9,
     "tags": [],
     "detail": "module Objects",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "Objects",
+      "filePath": "src/CompletionFunctionArguments.res"
+    }
   }]
 
 Complete src/CompletionFunctionArguments.res 57:33
@@ -208,7 +216,11 @@ Path someFnTakingVariant
     "kind": 9,
     "tags": [],
     "detail": "module Sort",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "Sort",
+      "filePath": "src/CompletionFunctionArguments.res"
+    }
   }]
 
 Complete src/CompletionFunctionArguments.res 60:44
@@ -240,13 +252,21 @@ Path someFnTakingVariant
     "kind": 9,
     "tags": [],
     "detail": "module Obj",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "Obj",
+      "filePath": "src/CompletionFunctionArguments.res"
+    }
   }, {
     "label": "Objects",
     "kind": 9,
     "tags": [],
     "detail": "module Objects",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "Objects",
+      "filePath": "src/CompletionFunctionArguments.res"
+    }
   }]
 
 Complete src/CompletionFunctionArguments.res 63:23

--- a/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
+++ b/analysis/tests/src/expected/CompletionFunctionArguments.res.txt
@@ -125,24 +125,24 @@ Path someFnTakingVariant
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two",
     "kind": 4,
     "tags": [],
-    "detail": "Two\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "Two",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Two",
     "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(int, string)\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "Three(int, string)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(int, string)\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "insertText": "Three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
@@ -160,8 +160,8 @@ Path someFnTakingVariant
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "sortText": "A One",
     "insertText": "One",
     "insertTextFormat": 2
@@ -169,19 +169,19 @@ Path someFnTakingVariant
     "label": "OIncludeMeInCompletions",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module OIncludeMeInCompletions",
     "documentation": null
   }, {
     "label": "Obj",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module Obj",
     "documentation": null
   }, {
     "label": "Objects",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module Objects",
     "documentation": null
   }]
 
@@ -199,7 +199,7 @@ Path someFnTakingVariant
     "kind": 12,
     "tags": [],
     "detail": "someVariant",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "sortText": "A Some(_)",
     "insertText": "Some($0)",
     "insertTextFormat": 2
@@ -207,7 +207,7 @@ Path someFnTakingVariant
     "label": "Sort",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module Sort",
     "documentation": null
   }]
 
@@ -224,8 +224,8 @@ Path someFnTakingVariant
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two | Three(int, string)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two | Three(int, string)\n```"},
     "sortText": "A One",
     "insertText": "One",
     "insertTextFormat": 2
@@ -233,19 +233,19 @@ Path someFnTakingVariant
     "label": "OIncludeMeInCompletions",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module OIncludeMeInCompletions",
     "documentation": null
   }, {
     "label": "Obj",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module Obj",
     "documentation": null
   }, {
     "label": "Objects",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module Objects",
     "documentation": null
   }]
 
@@ -350,20 +350,20 @@ Path fnTakingRecord
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nsomeRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>}\n```"}
   }, {
     "label": "offline",
     "kind": 5,
     "tags": [],
-    "detail": "offline: bool\n\nsomeRecord",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\noffline: bool\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>}\n```"}
   }, {
     "label": "online",
     "kind": 5,
     "tags": [],
-    "detail": "online: option<bool>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<bool>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nonline: option<bool>\n```\n\n```rescript\ntype someRecord = {age: int, offline: bool, online: option<bool>}\n```"}
   }]
 
 Complete src/CompletionFunctionArguments.res 109:29

--- a/analysis/tests/src/expected/CompletionInferValues.res.txt
+++ b/analysis/tests/src/expected/CompletionInferValues.res.txt
@@ -41,14 +41,14 @@ Path getSomeRecord
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 21:53
@@ -69,14 +69,14 @@ Path getSomeRecord
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 24:63
@@ -102,14 +102,14 @@ Path someFnWithCallback
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 27:90
@@ -137,14 +137,14 @@ Path someFnWithCallback
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 30:36
@@ -353,14 +353,14 @@ Path someRecord
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 78:78
@@ -381,14 +381,14 @@ Path someRecordWithNestedStuff
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 82:86
@@ -409,8 +409,8 @@ Path someRecordWithNestedStuff
     "label": "someRecord",
     "kind": 5,
     "tags": [],
-    "detail": "someRecord: someRecord\n\ntype someNestedRecord = {someRecord: someRecord}",
-    "documentation": null
+    "detail": "someRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeRecord: someRecord\n```\n\n```rescript\ntype someNestedRecord = {someRecord: someRecord}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 86:103
@@ -431,14 +431,14 @@ Path someRecordWithNestedStuff
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype someRecord = {name: string, age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 90:81
@@ -652,14 +652,14 @@ Path otherNestedRecord
     "label": "someRecord",
     "kind": 5,
     "tags": [],
-    "detail": "someRecord: someRecord\n\ntype otherNestedRecord = {someRecord: someRecord, someTuple: (someVariant, int, somePolyVariant), optRecord: option<someRecord>}",
-    "documentation": null
+    "detail": "someRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeRecord: someRecord\n```\n\n```rescript\ntype otherNestedRecord = {someRecord: someRecord, someTuple: (someVariant, int, somePolyVariant), optRecord: option<someRecord>}\n```"}
   }, {
     "label": "someTuple",
     "kind": 5,
     "tags": [],
-    "detail": "someTuple: (someVariant, int, somePolyVariant)\n\ntype otherNestedRecord = {someRecord: someRecord, someTuple: (someVariant, int, somePolyVariant), optRecord: option<someRecord>}",
-    "documentation": null
+    "detail": "(someVariant, int, somePolyVariant)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeTuple: (someVariant, int, somePolyVariant)\n```\n\n```rescript\ntype otherNestedRecord = {someRecord: someRecord, someTuple: (someVariant, int, somePolyVariant), optRecord: option<someRecord>}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 122:53
@@ -701,14 +701,14 @@ Path fnWithRecordCallback
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\nsomeRecord",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nsomeRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {name: string, age: int}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 137:30
@@ -849,8 +849,8 @@ Path CompletionSupport2.makeRenderer
     "label": "root",
     "kind": 5,
     "tags": [],
-    "detail": "root: ReactDOM.Client.Root.t\n\ntype config = {root: ReactDOM.Client.Root.t}",
-    "documentation": null
+    "detail": "ReactDOM.Client.Root.t",
+    "documentation": {"kind": "markdown", "value": "```rescript\nroot: ReactDOM.Client.Root.t\n```\n\n```rescript\ntype config = {root: ReactDOM.Client.Root.t}\n```"}
   }]
 
 Complete src/CompletionInferValues.res 162:110

--- a/analysis/tests/src/expected/CompletionJsx.res.txt
+++ b/analysis/tests/src/expected/CompletionJsx.res.txt
@@ -534,16 +534,16 @@ Path MultiPropComp.make
     "label": "Now",
     "kind": 4,
     "tags": [],
-    "detail": "Now\n\ntype time = Now | Later",
-    "documentation": null,
+    "detail": "Now",
+    "documentation": {"kind": "markdown", "value": "```rescript\nNow\n```\n\n```rescript\ntype time = Now | Later\n```"},
     "insertText": "{Now}",
     "insertTextFormat": 2
   }, {
     "label": "Later",
     "kind": 4,
     "tags": [],
-    "detail": "Later\n\ntype time = Now | Later",
-    "documentation": null,
+    "detail": "Later",
+    "documentation": {"kind": "markdown", "value": "```rescript\nLater\n```\n\n```rescript\ntype time = Now | Later\n```"},
     "insertText": "{Later}",
     "insertTextFormat": 2
   }]
@@ -560,16 +560,16 @@ Path MultiPropComp.make
     "label": "Now",
     "kind": 4,
     "tags": [],
-    "detail": "Now\n\ntype time = Now | Later",
-    "documentation": null,
+    "detail": "Now",
+    "documentation": {"kind": "markdown", "value": "```rescript\nNow\n```\n\n```rescript\ntype time = Now | Later\n```"},
     "insertText": "{Now}",
     "insertTextFormat": 2
   }, {
     "label": "Later",
     "kind": 4,
     "tags": [],
-    "detail": "Later\n\ntype time = Now | Later",
-    "documentation": null,
+    "detail": "Later",
+    "documentation": {"kind": "markdown", "value": "```rescript\nLater\n```\n\n```rescript\ntype time = Now | Later\n```"},
     "insertText": "{Later}",
     "insertTextFormat": 2
   }]
@@ -586,16 +586,16 @@ Path MultiPropComp.make
     "label": "Now",
     "kind": 4,
     "tags": [],
-    "detail": "Now\n\ntype time = Now | Later",
-    "documentation": null,
+    "detail": "Now",
+    "documentation": {"kind": "markdown", "value": "```rescript\nNow\n```\n\n```rescript\ntype time = Now | Later\n```"},
     "insertText": "{Now}",
     "insertTextFormat": 2
   }, {
     "label": "Later",
     "kind": 4,
     "tags": [],
-    "detail": "Later\n\ntype time = Now | Later",
-    "documentation": null,
+    "detail": "Later",
+    "documentation": {"kind": "markdown", "value": "```rescript\nLater\n```\n\n```rescript\ntype time = Now | Later\n```"},
     "insertText": "{Later}",
     "insertTextFormat": 2
   }]

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -67,19 +67,31 @@ Path CompletionSupport.TestComponent.make
     "kind": 9,
     "tags": [],
     "detail": "module TableclothMap",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "TableclothMap",
+      "filePath": "src/CompletionJsxProps.res"
+    }
   }, {
     "label": "TypeAtPosCompletion",
     "kind": 9,
     "tags": [],
     "detail": "module TypeAtPosCompletion",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "TypeAtPosCompletion",
+      "filePath": "src/CompletionJsxProps.res"
+    }
   }, {
     "label": "TypeDefinition",
     "kind": 9,
     "tags": [],
     "detail": "module TypeDefinition",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "TypeDefinition",
+      "filePath": "src/CompletionJsxProps.res"
+    }
   }]
 
 Complete src/CompletionJsxProps.res 9:52

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -48,8 +48,8 @@ Path CompletionSupport.TestComponent.make
     "label": "Two",
     "kind": 4,
     "tags": [],
-    "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
-    "documentation": null,
+    "detail": "Two",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo\n```\n\n```rescript\ntype testVariant = One | Two | Three(int)\n```"},
     "sortText": "A Two",
     "insertText": "{Two}",
     "insertTextFormat": 2
@@ -57,8 +57,8 @@ Path CompletionSupport.TestComponent.make
     "label": "Three(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
-    "documentation": null,
+    "detail": "Three(int)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(int)\n```\n\n```rescript\ntype testVariant = One | Two | Three(int)\n```"},
     "sortText": "A Three(_)",
     "insertText": "{Three($0)}",
     "insertTextFormat": 2
@@ -66,19 +66,19 @@ Path CompletionSupport.TestComponent.make
     "label": "TableclothMap",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module TableclothMap",
     "documentation": null
   }, {
     "label": "TypeAtPosCompletion",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module TypeAtPosCompletion",
     "documentation": null
   }, {
     "label": "TypeDefinition",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module TypeDefinition",
     "documentation": null
   }]
 
@@ -94,32 +94,32 @@ Path CompletionSupport.TestComponent.make
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "{#one}",
     "insertTextFormat": 2
   }, {
     "label": "#three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "#three(int, bool)\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#three(int, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#three(int, bool)\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "{#three(${1:_}, ${2:_})}",
     "insertTextFormat": 2
   }, {
     "label": "#two",
     "kind": 4,
     "tags": [],
-    "detail": "#two\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#two",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "{#two}",
     "insertTextFormat": 2
   }, {
     "label": "#two2",
     "kind": 4,
     "tags": [],
-    "detail": "#two2\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#two2",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two2\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "{#two2}",
     "insertTextFormat": 2
   }]
@@ -136,24 +136,24 @@ Path CompletionSupport.TestComponent.make
     "label": "#three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "#three(int, bool)\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#three(int, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#three(int, bool)\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "{three(${1:_}, ${2:_})}",
     "insertTextFormat": 2
   }, {
     "label": "#two",
     "kind": 4,
     "tags": [],
-    "detail": "#two\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#two",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "{two}",
     "insertTextFormat": 2
   }, {
     "label": "#two2",
     "kind": 4,
     "tags": [],
-    "detail": "#two2\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#two2",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two2\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "{two2}",
     "insertTextFormat": 2
   }]
@@ -214,7 +214,7 @@ Path CompletionSupport.TestComponent.make
     "kind": 12,
     "tags": [],
     "detail": "testVariant",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype testVariant = One | Two | Three(int)\n```"},
     "sortText": "A",
     "insertText": "{[$0]}",
     "insertTextFormat": 2
@@ -232,24 +232,24 @@ Path CompletionSupport.TestComponent.make
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype testVariant = One | Two | Three(int)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype testVariant = One | Two | Three(int)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two",
     "kind": 4,
     "tags": [],
-    "detail": "Two\n\ntype testVariant = One | Two | Three(int)",
-    "documentation": null,
+    "detail": "Two",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo\n```\n\n```rescript\ntype testVariant = One | Two | Three(int)\n```"},
     "insertText": "Two",
     "insertTextFormat": 2
   }, {
     "label": "Three(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(int)\n\ntype testVariant = One | Two | Three(int)",
-    "documentation": null,
+    "detail": "Three(int)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(int)\n```\n\n```rescript\ntype testVariant = One | Two | Three(int)\n```"},
     "insertText": "Three($0)",
     "insertTextFormat": 2
   }]
@@ -266,32 +266,32 @@ Path CompletionSupport.TestComponent.make
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "#one",
     "insertTextFormat": 2
   }, {
     "label": "#three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "#three(int, bool)\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#three(int, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#three(int, bool)\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "#three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }, {
     "label": "#two",
     "kind": 4,
     "tags": [],
-    "detail": "#two\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#two",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "#two",
     "insertTextFormat": 2
   }, {
     "label": "#two2",
     "kind": 4,
     "tags": [],
-    "detail": "#two2\n\n[#one | #three(int, bool) | #two | #two2]",
-    "documentation": null,
+    "detail": "#two2",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two2\n```\n\n```rescript\n[#one | #three(int, bool) | #two | #two2]\n```"},
     "insertText": "#two2",
     "insertTextFormat": 2
   }]

--- a/analysis/tests/src/expected/CompletionPattern.res.txt
+++ b/analysis/tests/src/expected/CompletionPattern.res.txt
@@ -100,7 +100,7 @@ Path f
     "kind": 22,
     "tags": [],
     "detail": "someRecord",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -117,26 +117,26 @@ Path f
     "label": "first",
     "kind": 5,
     "tags": [],
-    "detail": "first: int\n\nsomeRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfirst: int\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "second",
     "kind": 5,
     "tags": [],
-    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
-    "documentation": null
+    "detail": "(bool, option<someRecord>)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsecond: (bool, option<someRecord>)\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "optThird",
     "kind": 5,
     "tags": [],
-    "detail": "optThird: option<[#first | #second(someRecord)]>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<[#first | #second(someRecord)]>",
+    "documentation": {"kind": "markdown", "value": "```rescript\noptThird: option<[#first | #second(someRecord)]>\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "nest",
     "kind": 5,
     "tags": [],
-    "detail": "nest: nestedRecord\n\nsomeRecord",
-    "documentation": null
+    "detail": "nestedRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnest: nestedRecord\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }]
 
 Complete src/CompletionPattern.res 52:24
@@ -150,14 +150,14 @@ Path f
     "label": "optThird",
     "kind": 5,
     "tags": [],
-    "detail": "optThird: option<[#first | #second(someRecord)]>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<[#first | #second(someRecord)]>",
+    "documentation": {"kind": "markdown", "value": "```rescript\noptThird: option<[#first | #second(someRecord)]>\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "nest",
     "kind": 5,
     "tags": [],
-    "detail": "nest: nestedRecord\n\nsomeRecord",
-    "documentation": null
+    "detail": "nestedRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnest: nestedRecord\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }]
 
 Complete src/CompletionPattern.res 55:19
@@ -172,8 +172,8 @@ Path f
     "label": "first",
     "kind": 5,
     "tags": [],
-    "detail": "first: int\n\nsomeRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfirst: int\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }]
 
 Complete src/CompletionPattern.res 58:19
@@ -189,8 +189,8 @@ Path z
     "label": "optThird",
     "kind": 5,
     "tags": [],
-    "detail": "optThird: option<[#first | #second(someRecord)]>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<[#first | #second(someRecord)]>",
+    "documentation": {"kind": "markdown", "value": "```rescript\noptThird: option<[#first | #second(someRecord)]>\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }]
 
 Complete src/CompletionPattern.res 61:22
@@ -205,7 +205,7 @@ Path f
     "kind": 22,
     "tags": [],
     "detail": "nestedRecord",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype nestedRecord = {nested: bool}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -223,8 +223,8 @@ Path f
     "label": "nested",
     "kind": 5,
     "tags": [],
-    "detail": "nested: bool\n\nnestedRecord",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnested: bool\n```\n\n```rescript\ntype nestedRecord = {nested: bool}\n```"}
   }]
 
 Complete src/CompletionPattern.res 70:22
@@ -240,8 +240,8 @@ Path nest
     "label": "nested",
     "kind": 5,
     "tags": [],
-    "detail": "nested: bool\n\nnestedRecord",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnested: bool\n```\n\n```rescript\ntype nestedRecord = {nested: bool}\n```"}
   }]
 
 Complete src/CompletionPattern.res 76:8
@@ -255,26 +255,26 @@ Path f
     "label": "first",
     "kind": 5,
     "tags": [],
-    "detail": "first: int\n\nsomeRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfirst: int\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "second",
     "kind": 5,
     "tags": [],
-    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
-    "documentation": null
+    "detail": "(bool, option<someRecord>)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsecond: (bool, option<someRecord>)\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "optThird",
     "kind": 5,
     "tags": [],
-    "detail": "optThird: option<[#first | #second(someRecord)]>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<[#first | #second(someRecord)]>",
+    "documentation": {"kind": "markdown", "value": "```rescript\noptThird: option<[#first | #second(someRecord)]>\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "nest",
     "kind": 5,
     "tags": [],
-    "detail": "nest: nestedRecord\n\nsomeRecord",
-    "documentation": null
+    "detail": "nestedRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnest: nestedRecord\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }]
 
 Complete src/CompletionPattern.res 79:16
@@ -290,8 +290,8 @@ Path f
     "label": "nested",
     "kind": 5,
     "tags": [],
-    "detail": "nested: bool\n\nnestedRecord",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnested: bool\n```\n\n```rescript\ntype nestedRecord = {nested: bool}\n```"}
   }]
 
 Complete src/CompletionPattern.res 87:20
@@ -348,26 +348,26 @@ Path z
     "label": "first",
     "kind": 5,
     "tags": [],
-    "detail": "first: int\n\nsomeRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfirst: int\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "second",
     "kind": 5,
     "tags": [],
-    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
-    "documentation": null
+    "detail": "(bool, option<someRecord>)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsecond: (bool, option<someRecord>)\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "optThird",
     "kind": 5,
     "tags": [],
-    "detail": "optThird: option<[#first | #second(someRecord)]>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<[#first | #second(someRecord)]>",
+    "documentation": {"kind": "markdown", "value": "```rescript\noptThird: option<[#first | #second(someRecord)]>\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "nest",
     "kind": 5,
     "tags": [],
-    "detail": "nest: nestedRecord\n\nsomeRecord",
-    "documentation": null
+    "detail": "nestedRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnest: nestedRecord\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }]
 
 Complete src/CompletionPattern.res 96:27
@@ -439,26 +439,26 @@ Path b
     "label": "first",
     "kind": 5,
     "tags": [],
-    "detail": "first: int\n\nsomeRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nfirst: int\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "second",
     "kind": 5,
     "tags": [],
-    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
-    "documentation": null
+    "detail": "(bool, option<someRecord>)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsecond: (bool, option<someRecord>)\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "optThird",
     "kind": 5,
     "tags": [],
-    "detail": "optThird: option<[#first | #second(someRecord)]>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<[#first | #second(someRecord)]>",
+    "documentation": {"kind": "markdown", "value": "```rescript\noptThird: option<[#first | #second(someRecord)]>\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "nest",
     "kind": 5,
     "tags": [],
-    "detail": "nest: nestedRecord\n\nsomeRecord",
-    "documentation": null
+    "detail": "nestedRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnest: nestedRecord\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }]
 
 Complete src/CompletionPattern.res 112:28
@@ -896,24 +896,24 @@ Path z
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Two(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(someRecord, bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
@@ -1083,24 +1083,24 @@ Path getThing
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Two(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(someRecord, bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
@@ -1119,24 +1119,24 @@ Path res
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Two(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(someRecord, bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
@@ -1155,24 +1155,24 @@ Path res
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#one",
     "insertTextFormat": 2
   }, {
     "label": "#three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "#three(someRecord, bool)\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#three(someRecord, bool)\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }, {
     "label": "#two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "#two(bool)\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two(bool)\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#two(${1:_})",
     "insertTextFormat": 2
   }]
@@ -1191,19 +1191,19 @@ Path r
     "label": "second",
     "kind": 5,
     "tags": [],
-    "detail": "second: (bool, option<someRecord>)\n\nsomeRecord",
-    "documentation": null
+    "detail": "(bool, option<someRecord>)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsecond: (bool, option<someRecord>)\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "optThird",
     "kind": 5,
     "tags": [],
-    "detail": "optThird: option<[#first | #second(someRecord)]>\n\nsomeRecord",
-    "documentation": null
+    "detail": "option<[#first | #second(someRecord)]>",
+    "documentation": {"kind": "markdown", "value": "```rescript\noptThird: option<[#first | #second(someRecord)]>\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }, {
     "label": "nest",
     "kind": 5,
     "tags": [],
-    "detail": "nest: nestedRecord\n\nsomeRecord",
-    "documentation": null
+    "detail": "nestedRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\nnest: nestedRecord\n```\n\n```rescript\ntype someRecord = {first: int, second: (bool, option<someRecord>), optThird: option<[#first | #second(someRecord)]>, nest: nestedRecord}\n```"}
   }]
 

--- a/analysis/tests/src/expected/CompletionPipeSubmodules.res.txt
+++ b/analysis/tests/src/expected/CompletionPipeSubmodules.res.txt
@@ -15,13 +15,13 @@ Path A.B1.
     "kind": 12,
     "tags": [],
     "detail": "b1",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype b1 = B1\n```"}
   }, {
     "label": "A.B1.B1",
     "kind": 4,
     "tags": [],
-    "detail": "B1\n\ntype b1 = B1",
-    "documentation": null
+    "detail": "B1",
+    "documentation": {"kind": "markdown", "value": "```rescript\nB1\n```\n\n```rescript\ntype b1 = B1\n```"}
   }]
 
 Complete src/CompletionPipeSubmodules.res 16:18
@@ -42,13 +42,13 @@ Path A.B1.
     "kind": 12,
     "tags": [],
     "detail": "b1",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype b1 = B1\n```"}
   }, {
     "label": "A.B1.B1",
     "kind": 4,
     "tags": [],
-    "detail": "B1\n\ntype b1 = B1",
-    "documentation": null
+    "detail": "B1",
+    "documentation": {"kind": "markdown", "value": "```rescript\nB1\n```\n\n```rescript\ntype b1 = B1\n```"}
   }]
 
 Complete src/CompletionPipeSubmodules.res 38:20
@@ -69,8 +69,8 @@ Path C.
     "label": "C.C",
     "kind": 4,
     "tags": [],
-    "detail": "C\n\ntype t = C",
-    "documentation": null
+    "detail": "C",
+    "documentation": {"kind": "markdown", "value": "```rescript\nC\n```\n\n```rescript\ntype t = C\n```"}
   }]
 
 Complete src/CompletionPipeSubmodules.res 42:21
@@ -91,7 +91,7 @@ Path D.C2.
     "label": "D.C2.C2",
     "kind": 4,
     "tags": [],
-    "detail": "C2\n\ntype t2 = C2",
-    "documentation": null
+    "detail": "C2",
+    "documentation": {"kind": "markdown", "value": "```rescript\nC2\n```\n\n```rescript\ntype t2 = C2\n```"}
   }]
 

--- a/analysis/tests/src/expected/CompletionResolve.res.txt
+++ b/analysis/tests/src/expected/CompletionResolve.res.txt
@@ -1,0 +1,6 @@
+Completion resolve: Belt_Array
+"\nUtilities for `Array` functions.\n\n### Note about index syntax\n\nCode like `arr[0]` does *not* compile to JavaScript `arr[0]`. Reason transforms\nthe `[]` index syntax into a function: `Array.get(arr, 0)`. By default, this\nuses the default standard library's `Array.get` function, which may raise an\nexception if the index isn't found. If you `open Belt`, it will use the\n`Belt.Array.get` function which returns options instead of raising exceptions. \n[See this for more information](../belt.mdx#array-access-runtime-safety).\n"
+
+Completion resolve: ModuleStuff
+" This is a top level module doc. "
+

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -9,8 +9,8 @@ Path someRecord
     "label": "{}",
     "kind": 12,
     "tags": [],
-    "detail": "type someRecord = {age: int, name: string}",
-    "documentation": null,
+    "detail": "someRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someRecord = {age: int, name: string}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -27,14 +27,14 @@ Path someRecord
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype someRecord = {age: int, name: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype someRecord = {age: int, name: string}\n```"}
   }, {
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype someRecord = {age: int, name: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype someRecord = {age: int, name: string}\n```"}
   }]
 
 Complete src/CompletionTypeAnnotation.res 15:23
@@ -48,16 +48,16 @@ Path someVariant
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "Two($0)",
     "insertTextFormat": 2
   }]
@@ -73,8 +73,8 @@ Path someVariant
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "sortText": "A One",
     "insertText": "One",
     "insertTextFormat": 2
@@ -82,13 +82,13 @@ Path someVariant
     "label": "Obj",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module Obj",
     "documentation": null
   }, {
     "label": "Objects",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module Objects",
     "documentation": null
   }]
 
@@ -103,16 +103,16 @@ Path somePolyVariant
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #two(bool)]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #two(bool)]\n```"},
     "insertText": "#one",
     "insertTextFormat": 2
   }, {
     "label": "#two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "#two(bool)\n\n[#one | #two(bool)]",
-    "documentation": null,
+    "detail": "#two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two(bool)\n```\n\n```rescript\n[#one | #two(bool)]\n```"},
     "insertText": "#two($0)",
     "insertTextFormat": 2
   }]
@@ -128,8 +128,8 @@ Path somePolyVariant
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #two(bool)]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #two(bool)]\n```"},
     "insertText": "one",
     "insertTextFormat": 2
   }]
@@ -216,30 +216,30 @@ Path someVariant
     "label": "None",
     "kind": 12,
     "tags": [],
-    "detail": "type someVariant = One | Two(bool)",
-    "documentation": null
+    "detail": "someVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two(bool)\n```"}
   }, {
     "label": "Some(_)",
     "kind": 12,
     "tags": [],
-    "detail": "type someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "someVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "Some($0)",
     "insertTextFormat": 2
   }, {
     "label": "Some(One)",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "Some(One)",
     "insertTextFormat": 2
   }, {
     "label": "Some(Two(_))",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "Some(Two($0))",
     "insertTextFormat": 2
   }]
@@ -256,16 +256,16 @@ Path someVariant
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "Two($0)",
     "insertTextFormat": 2
   }]
@@ -282,8 +282,8 @@ Path someVariant
     "label": "[]",
     "kind": 12,
     "tags": [],
-    "detail": "type someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "someVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two(bool)\n```"},
     "sortText": "A",
     "insertText": "[$0]",
     "insertTextFormat": 2
@@ -301,16 +301,16 @@ Path someVariant
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "Two($0)",
     "insertTextFormat": 2
   }]
@@ -329,7 +329,7 @@ Path someVariant
     "kind": 12,
     "tags": [],
     "detail": "option<someVariant>",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\noption<someVariant>\n```"},
     "sortText": "A",
     "insertText": "[$0]",
     "insertTextFormat": 2
@@ -348,16 +348,16 @@ Path someVariant
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool)\n```"},
     "insertText": "Two($0)",
     "insertTextFormat": 2
   }]

--- a/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
+++ b/analysis/tests/src/expected/CompletionTypeAnnotation.res.txt
@@ -83,13 +83,21 @@ Path someVariant
     "kind": 9,
     "tags": [],
     "detail": "module Obj",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "Obj",
+      "filePath": "src/CompletionTypeAnnotation.res"
+    }
   }, {
     "label": "Objects",
     "kind": 9,
     "tags": [],
     "detail": "module Objects",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "Objects",
+      "filePath": "src/CompletionTypeAnnotation.res"
+    }
   }]
 
 Complete src/CompletionTypeAnnotation.res 21:27

--- a/analysis/tests/src/expected/Destructuring.res.txt
+++ b/analysis/tests/src/expected/Destructuring.res.txt
@@ -9,8 +9,8 @@ Path x
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nx",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype x = {name: string, age: int}\n```"}
   }]
 
 Complete src/Destructuring.res 7:8
@@ -24,14 +24,14 @@ Path x
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\nx",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype x = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nx",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype x = {name: string, age: int}\n```"}
   }]
 
 Complete src/Destructuring.res 11:13
@@ -48,8 +48,8 @@ Path x
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nx",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype x = {name: string, age: int}\n```"}
   }]
 
 Complete src/Destructuring.res 17:10
@@ -66,14 +66,14 @@ Path x
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\nx",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype x = {name: string, age: int}\n```"}
   }, {
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nx",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype x = {name: string, age: int}\n```"}
   }]
 
 Complete src/Destructuring.res 31:8
@@ -87,13 +87,13 @@ Path x
     "label": "someField",
     "kind": 5,
     "tags": [],
-    "detail": "someField: int\n\nrecordWithOptField",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nsomeField: int\n```\n\n```rescript\ntype recordWithOptField = {someField: int, someOptField: option<bool>}\n```"}
   }, {
     "label": "?someOptField",
     "kind": 5,
     "tags": [],
-    "detail": "?someOptField: option<bool>\n\nrecordWithOptField",
-    "documentation": {"kind": "markdown", "value": "someOptField is an optional field, and needs to be destructured using '?'."}
+    "detail": "option<bool>",
+    "documentation": {"kind": "markdown", "value": "someOptField is an optional field, and needs to be destructured using '?'.\n\n```rescript\n?someOptField: option<bool>\n```\n\n```rescript\ntype recordWithOptField = {someField: int, someOptField: option<bool>}\n```"}
   }]
 

--- a/analysis/tests/src/expected/EnvCompletion.res.txt
+++ b/analysis/tests/src/expected/EnvCompletion.res.txt
@@ -9,16 +9,16 @@ Path res
     "label": "Okay(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Okay('a)\n\ntype someResult<'a, 'b> = Okay('a) | Failure('b)",
-    "documentation": null,
+    "detail": "Okay('a)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOkay('a)\n```\n\n```rescript\ntype someResult<'a, 'b> = Okay('a) | Failure('b)\n```"},
     "insertText": "Okay(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Failure(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Failure('b)\n\ntype someResult<'a, 'b> = Okay('a) | Failure('b)",
-    "documentation": null,
+    "detail": "Failure('b)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nFailure('b)\n```\n\n```rescript\ntype someResult<'a, 'b> = Okay('a) | Failure('b)\n```"},
     "insertText": "Failure(${1:_})",
     "insertTextFormat": 2
   }]
@@ -37,16 +37,16 @@ Path res
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype things = One | Two",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype things = One | Two\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two",
     "kind": 4,
     "tags": [],
-    "detail": "Two\n\ntype things = One | Two",
-    "documentation": null,
+    "detail": "Two",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo\n```\n\n```rescript\ntype things = One | Two\n```"},
     "insertText": "Two",
     "insertTextFormat": 2
   }]
@@ -85,7 +85,7 @@ Path use
     "kind": 22,
     "tags": [],
     "detail": "EnvCompletionOtherFile.response",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype EnvCompletionOtherFile.response = {stuff: theVariant, res: someResult<theVariant, string>}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -103,14 +103,14 @@ Path use
     "label": "stuff",
     "kind": 5,
     "tags": [],
-    "detail": "stuff: theVariant\n\nEnvCompletionOtherFile.response",
-    "documentation": null
+    "detail": "theVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\nstuff: theVariant\n```\n\n```rescript\ntype EnvCompletionOtherFile.response = {stuff: theVariant, res: someResult<theVariant, string>}\n```"}
   }, {
     "label": "res",
     "kind": 5,
     "tags": [],
-    "detail": "res: someResult<theVariant, string>\n\nEnvCompletionOtherFile.response",
-    "documentation": null
+    "detail": "someResult<theVariant, string>",
+    "documentation": {"kind": "markdown", "value": "```rescript\nres: someResult<theVariant, string>\n```\n\n```rescript\ntype EnvCompletionOtherFile.response = {stuff: theVariant, res: someResult<theVariant, string>}\n```"}
   }]
 
 Complete src/EnvCompletion.res 25:27
@@ -125,16 +125,16 @@ Path use
     "label": "First",
     "kind": 4,
     "tags": [],
-    "detail": "First\n\ntype theVariant = First | Second(r1)",
-    "documentation": null,
+    "detail": "First",
+    "documentation": {"kind": "markdown", "value": "```rescript\nFirst\n```\n\n```rescript\ntype theVariant = First | Second(r1)\n```"},
     "insertText": "First",
     "insertTextFormat": 2
   }, {
     "label": "Second(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Second(r1)\n\ntype theVariant = First | Second(r1)",
-    "documentation": null,
+    "detail": "Second(r1)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nSecond(r1)\n```\n\n```rescript\ntype theVariant = First | Second(r1)\n```"},
     "insertText": "Second(${1:_})",
     "insertTextFormat": 2
   }]
@@ -156,7 +156,7 @@ Path use
     "kind": 22,
     "tags": [],
     "detail": "r1",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype r1 = {age: int}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -177,8 +177,8 @@ Path use
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nr1",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype r1 = {age: int}\n```"}
   }]
 
 Complete src/EnvCompletion.res 34:25
@@ -193,16 +193,16 @@ Path use
     "label": "Okay(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Okay('a)\n\ntype someResult<'a, 'b> = Okay('a) | Failure('b)",
-    "documentation": null,
+    "detail": "Okay('a)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOkay('a)\n```\n\n```rescript\ntype someResult<'a, 'b> = Okay('a) | Failure('b)\n```"},
     "insertText": "Okay(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Failure(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Failure('b)\n\ntype someResult<'a, 'b> = Okay('a) | Failure('b)",
-    "documentation": null,
+    "detail": "Failure('b)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nFailure('b)\n```\n\n```rescript\ntype someResult<'a, 'b> = Okay('a) | Failure('b)\n```"},
     "insertText": "Failure(${1:_})",
     "insertTextFormat": 2
   }]
@@ -223,16 +223,16 @@ Path use
     "label": "First",
     "kind": 4,
     "tags": [],
-    "detail": "First\n\ntype theVariant = First | Second(r1)",
-    "documentation": null,
+    "detail": "First",
+    "documentation": {"kind": "markdown", "value": "```rescript\nFirst\n```\n\n```rescript\ntype theVariant = First | Second(r1)\n```"},
     "insertText": "First",
     "insertTextFormat": 2
   }, {
     "label": "Second(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Second(r1)\n\ntype theVariant = First | Second(r1)",
-    "documentation": null,
+    "detail": "Second(r1)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nSecond(r1)\n```\n\n```rescript\ntype theVariant = First | Second(r1)\n```"},
     "insertText": "Second(${1:_})",
     "insertTextFormat": 2
   }]
@@ -256,7 +256,7 @@ Path use
     "kind": 22,
     "tags": [],
     "detail": "r1",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype r1 = {age: int}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -279,8 +279,8 @@ Path use
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\nr1",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype r1 = {age: int}\n```"}
   }]
 
 Complete src/EnvCompletion.res 52:18
@@ -294,8 +294,8 @@ Path res2
     "label": "{}",
     "kind": 22,
     "tags": [],
-    "detail": "EnvCompletionOtherFile.someRecord<things2>",
-    "documentation": null,
+    "detail": "EnvCompletionOtherFile.someRecord",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype EnvCompletionOtherFile.someRecord = {name: string, theThing: 'thing, theVariant: theVariant}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -312,20 +312,20 @@ Path res2
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\nEnvCompletionOtherFile.someRecord<things2>",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype EnvCompletionOtherFile.someRecord = {name: string, theThing: 'thing, theVariant: theVariant}\n```"}
   }, {
     "label": "theThing",
     "kind": 5,
     "tags": [],
-    "detail": "theThing: 'thing\n\nEnvCompletionOtherFile.someRecord<things2>",
-    "documentation": null
+    "detail": "'thing",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntheThing: 'thing\n```\n\n```rescript\ntype EnvCompletionOtherFile.someRecord = {name: string, theThing: 'thing, theVariant: theVariant}\n```"}
   }, {
     "label": "theVariant",
     "kind": 5,
     "tags": [],
-    "detail": "theVariant: theVariant\n\nEnvCompletionOtherFile.someRecord<things2>",
-    "documentation": null
+    "detail": "theVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntheVariant: theVariant\n```\n\n```rescript\ntype EnvCompletionOtherFile.someRecord = {name: string, theThing: 'thing, theVariant: theVariant}\n```"}
   }]
 
 Complete src/EnvCompletion.res 58:29
@@ -339,16 +339,16 @@ Path res2
     "label": "Four",
     "kind": 4,
     "tags": [],
-    "detail": "Four\n\ntype things2 = Four | Five",
-    "documentation": null,
+    "detail": "Four",
+    "documentation": {"kind": "markdown", "value": "```rescript\nFour\n```\n\n```rescript\ntype things2 = Four | Five\n```"},
     "insertText": "Four",
     "insertTextFormat": 2
   }, {
     "label": "Five",
     "kind": 4,
     "tags": [],
-    "detail": "Five\n\ntype things2 = Four | Five",
-    "documentation": null,
+    "detail": "Five",
+    "documentation": {"kind": "markdown", "value": "```rescript\nFive\n```\n\n```rescript\ntype things2 = Four | Five\n```"},
     "insertText": "Five",
     "insertTextFormat": 2
   }]
@@ -364,16 +364,16 @@ Path res2
     "label": "First",
     "kind": 4,
     "tags": [],
-    "detail": "First\n\ntype theVariant = First | Second(r1)",
-    "documentation": null,
+    "detail": "First",
+    "documentation": {"kind": "markdown", "value": "```rescript\nFirst\n```\n\n```rescript\ntype theVariant = First | Second(r1)\n```"},
     "insertText": "First",
     "insertTextFormat": 2
   }, {
     "label": "Second(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Second(r1)\n\ntype theVariant = First | Second(r1)",
-    "documentation": null,
+    "detail": "Second(r1)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nSecond(r1)\n```\n\n```rescript\ntype theVariant = First | Second(r1)\n```"},
     "insertText": "Second(${1:_})",
     "insertTextFormat": 2
   }]

--- a/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -10,7 +10,7 @@ Path withSomeVarian
     "kind": 12,
     "tags": [],
     "detail": "someVariant",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two | Three(option<bool>)\n```"}
   }, {
     "label": "withSomeVariant (exhaustive switch)",
     "kind": 15,

--- a/analysis/tests/src/expected/Hover.res.txt
+++ b/analysis/tests/src/expected/Hover.res.txt
@@ -128,8 +128,8 @@ Path x1
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype bar = {age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype bar = {age: int}\n```"}
   }]
 
 Complete src/Hover.res 173:16
@@ -146,8 +146,8 @@ Path x2
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype bar = {age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype bar = {age: int}\n```"}
   }]
 
 Complete src/Hover.res 182:16
@@ -164,8 +164,8 @@ Path y1
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype bar = {age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype bar = {age: int}\n```"}
   }]
 
 Complete src/Hover.res 185:16
@@ -182,8 +182,8 @@ Path y2
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age: int\n\ntype bar = {age: int}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage: int\n```\n\n```rescript\ntype bar = {age: int}\n```"}
   }]
 
 Hover src/Hover.res 197:4

--- a/analysis/tests/src/expected/Jsx2.res.txt
+++ b/analysis/tests/src/expected/Jsx2.res.txt
@@ -53,19 +53,41 @@ Path M
     "kind": 9,
     "tags": [],
     "detail": "module Map",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "Map",
+      "filePath": "src/Jsx2.res"
+    }
   }, {
     "label": "MapLabels",
     "kind": 9,
     "tags": [],
     "detail": "module MapLabels",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "MapLabels",
+      "filePath": "src/Jsx2.res"
+    }
+  }, {
+    "label": "ModuleStuff",
+    "kind": 9,
+    "tags": [],
+    "detail": "module ModuleStuff",
+    "documentation": null,
+    "data": {
+      "modulePath": "ModuleStuff",
+      "filePath": "src/Jsx2.res"
+    }
   }, {
     "label": "MoreLabels",
     "kind": 9,
     "tags": [],
     "detail": "module MoreLabels",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "MoreLabels",
+      "filePath": "src/Jsx2.res"
+    }
   }]
 
 Complete src/Jsx2.res 22:19
@@ -384,7 +406,11 @@ Path ReactDOMR
     "kind": 9,
     "tags": [],
     "detail": "module ReactDOMRe",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "ReactDOMRe",
+      "filePath": "src/Jsx2.res"
+    }
   }]
 
 Complete src/Jsx2.res 102:21

--- a/analysis/tests/src/expected/Jsx2.res.txt
+++ b/analysis/tests/src/expected/Jsx2.res.txt
@@ -46,25 +46,25 @@ Path M
     "label": "M",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module M",
     "documentation": null
   }, {
     "label": "Map",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module Map",
     "documentation": null
   }, {
     "label": "MapLabels",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module MapLabels",
     "documentation": null
   }, {
     "label": "MoreLabels",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module MoreLabels",
     "documentation": null
   }]
 
@@ -334,7 +334,7 @@ Path WithChildren
     "label": "WithChildren",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module WithChildren",
     "documentation": null
   }]
 
@@ -366,8 +366,8 @@ Path React.e
     "label": "element",
     "kind": 22,
     "tags": [],
-    "detail": "type element = Jsx.element",
-    "documentation": null
+    "detail": "type element",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype element = Jsx.element\n```"}
   }]
 
 Complete src/Jsx2.res 96:20
@@ -383,7 +383,7 @@ Path ReactDOMR
     "label": "ReactDOMRe",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module ReactDOMRe",
     "documentation": null
   }]
 
@@ -430,14 +430,14 @@ Path DefineSomeFields.th
     "label": "thisField",
     "kind": 5,
     "tags": [],
-    "detail": "thisField: int\n\ntype r = {thisField: int, thatField: string}",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nthisField: int\n```\n\n```rescript\ntype r = {thisField: int, thatField: string}\n```"}
   }, {
     "label": "thatField",
     "kind": 5,
     "tags": [],
-    "detail": "thatField: string\n\ntype r = {thisField: int, thatField: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nthatField: string\n```\n\n```rescript\ntype r = {thisField: int, thatField: string}\n```"}
   }]
 
 Complete src/Jsx2.res 122:20
@@ -508,7 +508,7 @@ Path Nested.Co
     "label": "Comp",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module Comp",
     "documentation": null
   }]
 
@@ -524,7 +524,7 @@ Path Nested.
     "label": "Comp",
     "kind": 9,
     "tags": [],
-    "detail": "module",
+    "detail": "module Comp",
     "documentation": null
   }]
 

--- a/analysis/tests/src/expected/Jsx2.resi.txt
+++ b/analysis/tests/src/expected/Jsx2.resi.txt
@@ -18,8 +18,8 @@ Path React.e
     "label": "element",
     "kind": 22,
     "tags": [],
-    "detail": "type element = Jsx.element",
-    "documentation": null
+    "detail": "type element",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype element = Jsx.element\n```"}
   }]
 
 Complete src/Jsx2.resi 10:18
@@ -34,7 +34,7 @@ Path React.e
     "label": "element",
     "kind": 22,
     "tags": [],
-    "detail": "type element = Jsx.element",
-    "documentation": null
+    "detail": "type element",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype element = Jsx.element\n```"}
   }]
 

--- a/analysis/tests/src/expected/RecordCompletion.res.txt
+++ b/analysis/tests/src/expected/RecordCompletion.res.txt
@@ -61,8 +61,8 @@ Path R.
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype t = {name: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype t = {name: string}\n```"}
   }]
 
 Complete src/RecordCompletion.res 22:7
@@ -77,7 +77,7 @@ Path R.
     "label": "name",
     "kind": 5,
     "tags": [],
-    "detail": "name: string\n\ntype t = {name: string}",
-    "documentation": null
+    "detail": "string",
+    "documentation": {"kind": "markdown", "value": "```rescript\nname: string\n```\n\n```rescript\ntype t = {name: string}\n```"}
   }]
 

--- a/analysis/tests/src/expected/RecoveryOnProp.res.txt
+++ b/analysis/tests/src/expected/RecoveryOnProp.res.txt
@@ -19,13 +19,13 @@ Path Res
     "label": "RescriptReactErrorBoundary",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module RescriptReactErrorBoundary",
     "documentation": null
   }, {
     "label": "RescriptReactRouter",
     "kind": 9,
     "tags": [],
-    "detail": "file module",
+    "detail": "module RescriptReactRouter",
     "documentation": null
   }]
 

--- a/analysis/tests/src/expected/RecoveryOnProp.res.txt
+++ b/analysis/tests/src/expected/RecoveryOnProp.res.txt
@@ -20,12 +20,20 @@ Path Res
     "kind": 9,
     "tags": [],
     "detail": "module RescriptReactErrorBoundary",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "RescriptReactErrorBoundary",
+      "filePath": "src/RecoveryOnProp.res"
+    }
   }, {
     "label": "RescriptReactRouter",
     "kind": 9,
     "tags": [],
     "detail": "module RescriptReactRouter",
-    "documentation": null
+    "documentation": null,
+    "data": {
+      "modulePath": "RescriptReactRouter",
+      "filePath": "src/RecoveryOnProp.res"
+    }
   }]
 

--- a/analysis/tests/src/expected/Reprod.res.txt
+++ b/analysis/tests/src/expected/Reprod.res.txt
@@ -12,7 +12,7 @@ Path Query.use
     "kind": 12,
     "tags": [],
     "detail": "input_ByAddress",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype input_ByAddress = {city: string}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -29,24 +29,24 @@ Path record
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Two(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(someRecord, bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
@@ -63,7 +63,7 @@ Path record
     "kind": 22,
     "tags": [],
     "detail": "SchemaAssets.input_ByAddress",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype SchemaAssets.input_ByAddress = {city: string}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2
@@ -83,24 +83,24 @@ Path res
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Two(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(someRecord, bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]
@@ -119,24 +119,24 @@ Path res
     "label": "#one",
     "kind": 4,
     "tags": [],
-    "detail": "#one\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#one",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#one\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#one",
     "insertTextFormat": 2
   }, {
     "label": "#three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "#three(someRecord, bool)\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#three(someRecord, bool)\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }, {
     "label": "#two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "#two(bool)\n\n[#one | #three(someRecord, bool) | #two(bool)]",
-    "documentation": null,
+    "detail": "#two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\n#two(bool)\n```\n\n```rescript\n[#one | #three(someRecord, bool) | #two(bool)]\n```"},
     "insertText": "#two(${1:_})",
     "insertTextFormat": 2
   }]
@@ -156,37 +156,37 @@ Path resOpt
     "kind": 12,
     "tags": [],
     "detail": "someVariant",
-    "documentation": null
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"}
   }, {
     "label": "Some(_)",
     "kind": 12,
     "tags": [],
     "detail": "someVariant",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Some(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Some(One)",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Some(One)",
     "insertTextFormat": 2
   }, {
     "label": "Some(Two(_))",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Some(Two(${1:_}))",
     "insertTextFormat": 2
   }, {
     "label": "Some(Three(_, _))",
     "kind": 4,
     "tags": [],
-    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(someRecord, bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Some(Three(${1:_}, ${2:_}))",
     "insertTextFormat": 2
   }]
@@ -207,24 +207,24 @@ Path resOpt
     "label": "One",
     "kind": 4,
     "tags": [],
-    "detail": "One\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "One",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOne\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "One",
     "insertTextFormat": 2
   }, {
     "label": "Two(_)",
     "kind": 4,
     "tags": [],
-    "detail": "Two(bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Two(bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nTwo(bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Two(${1:_})",
     "insertTextFormat": 2
   }, {
     "label": "Three(_, _)",
     "kind": 4,
     "tags": [],
-    "detail": "Three(someRecord, bool)\n\ntype someVariant = One | Two(bool) | Three(someRecord, bool)",
-    "documentation": null,
+    "detail": "Three(someRecord, bool)",
+    "documentation": {"kind": "markdown", "value": "```rescript\nThree(someRecord, bool)\n```\n\n```rescript\ntype someVariant = One | Two(bool) | Three(someRecord, bool)\n```"},
     "insertText": "Three(${1:_}, ${2:_})",
     "insertTextFormat": 2
   }]

--- a/analysis/tests/src/expected/TypeAtPosCompletion.res.txt
+++ b/analysis/tests/src/expected/TypeAtPosCompletion.res.txt
@@ -8,14 +8,14 @@ ContextPath CTypeAtPos()
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age?: int\n\noptRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage?: int\n```\n\n```rescript\ntype optRecord = {name: string, age: option<int>, online: option<bool>}\n```"}
   }, {
     "label": "online",
     "kind": 5,
     "tags": [],
-    "detail": "online?: bool\n\noptRecord",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\nonline?: bool\n```\n\n```rescript\ntype optRecord = {name: string, age: option<int>, online: option<bool>}\n```"}
   }]
 
 Complete src/TypeAtPosCompletion.res 16:18
@@ -30,14 +30,14 @@ ContextPath CTypeAtPos()
     "label": "age",
     "kind": 5,
     "tags": [],
-    "detail": "age?: int\n\noptRecord",
-    "documentation": null
+    "detail": "int",
+    "documentation": {"kind": "markdown", "value": "```rescript\nage?: int\n```\n\n```rescript\ntype optRecord = {name: string, age: option<int>, online: option<bool>}\n```"}
   }, {
     "label": "online",
     "kind": 5,
     "tags": [],
-    "detail": "online?: bool\n\noptRecord",
-    "documentation": null
+    "detail": "bool",
+    "documentation": {"kind": "markdown", "value": "```rescript\nonline?: bool\n```\n\n```rescript\ntype optRecord = {name: string, age: option<int>, online: option<bool>}\n```"}
   }]
 
 Complete src/TypeAtPosCompletion.res 22:12
@@ -51,7 +51,7 @@ ContextPath CTypeAtPos()
     "kind": 12,
     "tags": [],
     "detail": "optRecord",
-    "documentation": null,
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype optRecord = {name: string, age: option<int>, online: option<bool>}\n```"},
     "sortText": "A",
     "insertText": "{$0}",
     "insertTextFormat": 2


### PR DESCRIPTION
Closes https://github.com/rescript-lang/rescript-vscode/issues/469 and https://github.com/rescript-lang/rescript-vscode/pull/837

This does 2 things:
- Does a major clean up of the details and docs generated for completion items.
- Implements the LSP `completionResolve` request so we can resolve (some) completion item docs async. Then via that implement file module docs resolution. 

This is a big diff test wise, because I've changed quite a few things wrt details and docs. It might not all be perfect yet, but it's going to be much much better than what we have today already, given what mess the details and docs for completion items are today.

Example of file module level docs:
![image](https://github.com/rescript-lang/rescript-vscode/assets/1457626/1db9ed9c-f183-4d75-aa86-1c1fcb694612)
