### PR TITLE
Make JSX completion work for React.component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :nail_care: Polish
 
 - Make sure doc strings are always on top in hovers. https://github.com/rescript-lang/rescript-vscode/pull/956
+- Make JSX completion work for `make` functions of type `React.component<props>`, like what you get when using `React.lazy_`. https://github.com/rescript-lang/rescript-vscode/pull/966
 
 #### :rocket: New Feature
 

--- a/analysis/src/CompletionJsx.ml
+++ b/analysis/src/CompletionJsx.ml
@@ -747,6 +747,17 @@ let getJsxLabels ~componentPath ~findTypeOfValue ~package =
             _ ) ->
         (* JSX V3 *)
         getFieldsV3 tObj
+      | Tconstr (p, [propsType], _) when Path.name p = "React.component" -> (
+        let rec getPropsType (t : Types.type_expr) =
+          match t.desc with
+          | Tlink t1 | Tsubst t1 | Tpoly (t1, []) -> getPropsType t1
+          | Tconstr (path, typeArgs, _) when Path.last path = "props" ->
+            Some (path, typeArgs)
+          | _ -> None
+        in
+        match propsType |> getPropsType with
+        | Some (path, typeArgs) -> getFieldsV4 ~path ~typeArgs
+        | None -> [])
       | Tarrow (Nolabel, {desc = Tconstr (path, typeArgs, _)}, _, _)
         when Path.last path = "props" ->
         (* JSX V4 *)

--- a/analysis/tests/src/CompletableComponent.res
+++ b/analysis/tests/src/CompletableComponent.res
@@ -1,0 +1,10 @@
+type status = On | Off
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+@react.component
+let make = (~status: status, ~name: string) => {
+  ignore(status)
+  ignore(name)
+  React.null
+}

--- a/analysis/tests/src/CompletionJsxProps.res
+++ b/analysis/tests/src/CompletionJsxProps.res
@@ -34,3 +34,13 @@ let tsomeVar = #two
 
 // let _ = <CompletionSupport.TestComponent on={t}
 //                                               ^com
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module CompletableComponentLazy = {
+  let loadComponent = () => Js.import(CompletableComponent.make)
+  let make = React.lazy_(loadComponent)
+}
+
+// let _ = <CompletableComponentLazy status=
+//                                          ^com

--- a/analysis/tests/src/expected/CompletionJsxProps.res.txt
+++ b/analysis/tests/src/expected/CompletionJsxProps.res.txt
@@ -330,3 +330,29 @@ Path CompletionSupport.TestComponent.make
     "documentation": null
   }]
 
+Complete src/CompletionJsxProps.res 44:44
+posCursor:[44:44] posNoWhite:[44:43] Found expr:[44:12->44:44]
+JSX <CompletableComponentLazy:[44:12->44:36] status[44:37->44:43]=...__ghost__[0:-1->0:-1]> _children:None
+Completable: Cexpression CJsxPropValue [CompletableComponentLazy] status
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath CJsxPropValue [CompletableComponentLazy] status
+Path CompletableComponentLazy.make
+[{
+    "label": "On",
+    "kind": 4,
+    "tags": [],
+    "detail": "On",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOn\n```\n\n```rescript\ntype status = On | Off\n```"},
+    "insertText": "{On}",
+    "insertTextFormat": 2
+  }, {
+    "label": "Off",
+    "kind": 4,
+    "tags": [],
+    "detail": "Off",
+    "documentation": {"kind": "markdown", "value": "```rescript\nOff\n```\n\n```rescript\ntype status = On | Off\n```"},
+    "insertText": "{Off}",
+    "insertTextFormat": 2
+  }]
+


### PR DESCRIPTION
This makes JSX completion work when make functions of type `React.component<props>`  are detected, like when using `React.lazy_`.