### PR TITLE
Remove  not-existing #storage include in TextMate

### DIFF
--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -538,7 +538,6 @@
     }
   },
   "patterns": [
-    { "include": "#storage" },
     { "include": "#ffi-single" },
     { "include": "#ffi" },
     { "include": "#constant" },


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/967