### PR TITLE
Build with OCaml 5.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,23 @@ jobs:
 
     - name: Use OCaml
       uses: ocaml/setup-ocaml@v2
+      if: matrix.os != 'windows-latest'
       with:
-        ocaml-compiler: 4.14.x
+        ocaml-compiler: 5.1.1
+        opam-pin: false
+        opam-depext: false
+
+    - name: Use OCaml (Windows)
+      uses: ocaml/setup-ocaml@v2
+      if: matrix.os == 'windows-latest'
+      with:
+        ocaml-compiler: ocaml-variants.5.1.1+options,ocaml-option-mingw
+        opam-pin: false
+        opam-depext: false
+        opam-repositories: |
+          windows-5.0: https://github.com/dra27/opam-repository.git#windows-5.0
+          sunset: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+          default: https://github.com/ocaml/opam-repository.git
 
     - name: Use Node.js
       uses: actions/setup-node@v4

--- a/analysis/vendor/res_syntax/jsx_v4.ml
+++ b/analysis/vendor/res_syntax/jsx_v4.ml
@@ -1,4 +1,4 @@
-open Ast_helper
+open! Ast_helper
 open Ast_mapper
 open Asttypes
 open Parsetree


### PR DESCRIPTION
Build with OCaml 5.1.1, like on the master branch of the rescript-compiler repo.

So that we can also use the same matching version of the docker container for the static Linux build which I'll add in a separate PR.