### PR TITLE
Emit %todo istead of failwith when appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ SHELL = /bin/bash
 
 build:
 	dune build
-	cp _build/install/default/bin/rescript-editor-analysis rescript-editor-analysis.exe
-	cp _build/install/default/bin/rescript-tools rescript-tools.exe
+	cp -f _build/install/default/bin/rescript-editor-analysis analysis/rescript-editor-analysis.exe
+	cp -f _build/install/default/bin/rescript-editor-analysis rescript-editor-analysis.exe
+	cp -f _build/install/default/bin/rescript-tools rescript-tools.exe
 
 test:
 	make -C analysis test

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -338,6 +338,17 @@ let test ~path =
           | "db-" -> Log.verbose := false
           | "dv+" -> Debug.debugLevel := Verbose
           | "dv-" -> Debug.debugLevel := Off
+          | "ve+" -> (
+            let version = String.sub rest 3 (String.length rest - 3) in
+            let version = String.trim version in
+            if Debug.verbose () then
+              Printf.printf "Setting version: %s\n" version;
+            match String.split_on_char '.' version with
+            | [majorRaw; minorRaw] ->
+              let version = (int_of_string majorRaw, int_of_string minorRaw) in
+              Packages.overrideRescriptVersion := Some version
+            | _ -> ())
+          | "ve-" -> Packages.overrideRescriptVersion := None
           | "def" ->
             print_endline
               ("Definition " ^ path ^ " " ^ string_of_int line ^ ":"

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -1033,6 +1033,7 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
       if expr.pexp_loc |> Loc.hasPos ~pos:posNoWhite && !result = None then (
         setFound ();
         match expr.pexp_desc with
+        | Pexp_extension ({txt}, _) -> setResult (CextensionNode txt)
         | Pexp_constant _ -> setResult Cnone
         | Pexp_ident lid ->
           let lidPath = flattenLidCheckDot lid in

--- a/analysis/src/Packages.ml
+++ b/analysis/src/Packages.ml
@@ -11,21 +11,26 @@ let makePathsForModule ~projectFilesAndPaths ~dependenciesFilesAndPaths =
          Hashtbl.replace pathsForModule modName paths);
   pathsForModule
 
+let overrideRescriptVersion = ref None
+
 let getReScriptVersion () =
-  (* TODO: Include patch stuff when needed *)
-  let defaultVersion = (11, 0) in
-  try
-    let value = Sys.getenv "RESCRIPT_VERSION" in
-    let version =
-      match value |> String.split_on_char '.' with
-      | major :: minor :: _rest -> (
-        match (int_of_string_opt major, int_of_string_opt minor) with
-        | Some major, Some minor -> (major, minor)
-        | _ -> defaultVersion)
-      | _ -> defaultVersion
-    in
-    version
-  with Not_found -> defaultVersion
+  match !overrideRescriptVersion with
+  | Some overrideRescriptVersion -> overrideRescriptVersion
+  | None -> (
+    (* TODO: Include patch stuff when needed *)
+    let defaultVersion = (11, 0) in
+    try
+      let value = Sys.getenv "RESCRIPT_VERSION" in
+      let version =
+        match value |> String.split_on_char '.' with
+        | major :: minor :: _rest -> (
+          match (int_of_string_opt major, int_of_string_opt minor) with
+          | Some major, Some minor -> (major, minor)
+          | _ -> defaultVersion)
+        | _ -> defaultVersion
+      in
+      version
+    with Not_found -> defaultVersion)
 
 let newBsPackage ~rootPath =
   let rescriptJson = Filename.concat rootPath "rescript.json" in

--- a/analysis/src/SharedTypes.ml
+++ b/analysis/src/SharedTypes.ml
@@ -642,6 +642,7 @@ module Completable = struct
   type t =
     | Cdecorator of string  (** e.g. @module *)
     | CdecoratorPayload of decoratorPayload
+    | CextensionNode of string  (** e.g. %todo *)
     | CnamedArg of contextPath * string * string list
         (** e.g. (..., "label", ["l1", "l2"]) for ...(...~l1...~l2...~label...) *)
     | Cnone  (** e.g. don't complete inside strings *)
@@ -723,6 +724,7 @@ module Completable = struct
   let toString = function
     | Cpath cp -> "Cpath " ^ contextPathToString cp
     | Cdecorator s -> "Cdecorator(" ^ str s ^ ")"
+    | CextensionNode s -> "CextensionNode(" ^ str s ^ ")"
     | CdecoratorPayload (Module s) -> "CdecoratorPayload(module=" ^ s ^ ")"
     | CdecoratorPayload (ModuleWithImportAttributes _) ->
       "CdecoratorPayload(moduleWithImportAttributes)"

--- a/analysis/tests/src/CompletionAttributes.res
+++ b/analysis/tests/src/CompletionAttributes.res
@@ -34,3 +34,6 @@
 // @module({from: }) external doStuff: t = "default"
 //               ^com
 
+// let dd = %t
+//            ^com
+

--- a/analysis/tests/src/ExhaustiveSwitch.res
+++ b/analysis/tests/src/ExhaustiveSwitch.res
@@ -36,3 +36,8 @@ let vvv = Some(x->getV)
 
 // vvv
 //  ^xfm
+
+// ^ve+ 11.1
+// switch withSomeVarian
+//                      ^com
+// ^ve-

--- a/analysis/tests/src/expected/CompletionAttributes.res.txt
+++ b/analysis/tests/src/expected/CompletionAttributes.res.txt
@@ -266,3 +266,25 @@ Resolved opens 1 pervasives
     "documentation": null
   }]
 
+Complete src/CompletionAttributes.res 36:14
+posCursor:[36:14] posNoWhite:[36:13] Found expr:[36:12->36:14]
+Completable: CextensionNode(t)
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+[{
+    "label": "todo",
+    "kind": 4,
+    "tags": [],
+    "detail": "`%todo` is used to tell the compiler that some code still needs to be implemented.",
+    "documentation": null,
+    "insertText": "todo"
+  }, {
+    "label": "todo (with payload)",
+    "kind": 4,
+    "tags": [],
+    "detail": "`%todo` is used to tell the compiler that some code still needs to be implemented. With a payload.",
+    "documentation": null,
+    "insertText": "todo(\"${0:TODO}\")",
+    "insertTextFormat": 2
+  }]
+

--- a/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -149,3 +149,29 @@ newText:
    | Some(Three(_)) => failwith("TODO")
    }
 
+
+Complete src/ExhaustiveSwitch.res 40:24
+XXX Not found!
+Completable: CexhaustiveSwitch Value[withSomeVarian]
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[withSomeVarian]
+Path withSomeVarian
+[{
+    "label": "withSomeVariant",
+    "kind": 12,
+    "tags": [],
+    "detail": "someVariant",
+    "documentation": {"kind": "markdown", "value": "```rescript\ntype someVariant = One | Two | Three(option<bool>)\n```"}
+  }, {
+    "label": "withSomeVariant (exhaustive switch)",
+    "kind": 15,
+    "tags": [],
+    "detail": "insert exhaustive switch for value",
+    "documentation": null,
+    "filterText": "withSomeVariant",
+    "insertText": "withSomeVariant {\n   | One => ${1:%todo}\n   | Two => ${2:%todo}\n   | Three(_) => ${3:%todo}\n   }",
+    "insertTextFormat": 2
+  }]
+
+


### PR DESCRIPTION
This adds two things:
1. Complete the new `%todo` extension point.
2. Emit `%todo` instead of `failwith("TODO")` when on ReScript >= v11.1.