### PR TITLE
Use canonicalized URIs/paths for jump to definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug Fix
 
 - Fix highlighting of other languages being affected by rescript-vscode. https://github.com/rescript-lang/rescript-vscode/pull/973
+- Use canonicalized URIs/paths for jump to definition. https://github.com/rescript-lang/rescript-vscode/pull/982
 
 #### :nail_care: Polish
 

--- a/analysis/bin/main.ml
+++ b/analysis/bin/main.ml
@@ -191,7 +191,9 @@ let main () =
       (Json.escape (CreateInterface.command ~path ~cmiFile))
   | [_; "format"; path] ->
     Printf.printf "\"%s\"" (Json.escape (Commands.format ~path))
-  | [_; "test"; path] -> Commands.test ~path
+  | [_; "test"; path] ->
+    Cfg.isTestMode := true;
+    Commands.test ~path
   | args when List.mem "-h" args || List.mem "--help" args -> prerr_endline help
   | _ ->
     prerr_endline help;

--- a/analysis/src/Cfg.ml
+++ b/analysis/src/Cfg.ml
@@ -1,3 +1,5 @@
 let debugFollowCtxPath = ref false
 
 let isDocGenFromCompiler = ref false
+
+let isTestMode = ref false

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -144,7 +144,10 @@ let definition ~path ~pos ~debug =
           if skipLoc then None
           else
             Some
-              {Protocol.uri = Uri.toString uri; range = Utils.cmtLocToRange loc}
+              {
+                Protocol.uri = Files.canonicalizeUri uri;
+                range = Utils.cmtLocToRange loc;
+              }
         | Some _ -> None))
   in
   print_endline
@@ -164,7 +167,10 @@ let typeDefinition ~path ~pos ~debug =
         | None -> None
         | Some (uri, loc) ->
           Some
-            {Protocol.uri = Uri.toString uri; range = Utils.cmtLocToRange loc}))
+            {
+              Protocol.uri = Files.canonicalizeUri uri;
+              range = Utils.cmtLocToRange loc;
+            }))
   in
   print_endline
     (match maybeLocation with

--- a/analysis/src/Files.ml
+++ b/analysis/src/Files.ml
@@ -20,7 +20,7 @@ let relpath base path =
     let baselen = String.length base in
     let rest = String.sub path baselen (String.length path - baselen) in
     (if rest <> "" && rest.[0] = Filename.dir_sep.[0] then sliceToEnd rest 1
-    else rest)
+     else rest)
     |> removeExtraDots
   else
     let rec loop bp pp =
@@ -102,3 +102,9 @@ let classifySourceFile path =
   if Filename.check_suffix path ".res" && exists path then Res
   else if Filename.check_suffix path ".resi" && exists path then Resi
   else Other
+
+let canonicalizeUri uri =
+  if Cfg.isTestMode.contents then uri |> Uri.toString
+  else
+    let path = Uri.toPath uri in
+    path |> Unix.realpath


### PR DESCRIPTION
This fixes the issue when you have an internal package in a monorepo and you click on a module from it in another package, you end up at `node_modules/@yourNamespace/yourPackageName`. Now it uses the real path and not the symlink anymore, so end up at the correct location.