### PR TITLE
Code action: Extract module to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Statically linked Linux binaries
 - Emit `%todo` instead of `failwith("TODO")` when we can (ReScript >= v11.1). https://github.com/rescript-lang/rescript-vscode/pull/981
 - Complete `%todo`. https://github.com/rescript-lang/rescript-vscode/pull/981
+- Add code action for extracting a locally defined module into its own file. https://github.com/rescript-lang/rescript-vscode/pull/983
 
 ## 1.50.0
 

--- a/analysis/src/CodeActions.ml
+++ b/analysis/src/CodeActions.ml
@@ -13,6 +13,15 @@ let make ~title ~kind ~uri ~newText ~range =
     edit =
       {
         documentChanges =
-          [{textDocument = {version = None; uri}; edits = [{newText; range}]}];
+          [
+            TextDocumentEdit
+              {
+                Protocol.textDocument = {version = None; uri};
+                edits = [{newText; range}];
+              };
+          ];
       };
   }
+
+let makeWithDocumentChanges ~title ~kind ~documentChanges =
+  {Protocol.title; codeActionKind = kind; edit = {documentChanges}}

--- a/analysis/src/Codemod.ml
+++ b/analysis/src/Codemod.ml
@@ -6,7 +6,7 @@ let rec collectPatterns p =
   | _ -> [p]
 
 let transform ~path ~pos ~debug ~typ ~hint =
-  let structure, printExpr, _ = Xform.parseImplementation ~filename:path in
+  let structure, printExpr, _, _ = Xform.parseImplementation ~filename:path in
   match typ with
   | AddMissingCases -> (
     let source = "let " ^ hint ^ " = ()" in

--- a/analysis/src/Commands.ml
+++ b/analysis/src/Commands.ml
@@ -447,15 +447,23 @@ let test ~path =
             |> List.iter (fun {Protocol.title; edit = {documentChanges}} ->
                    Printf.printf "Hit: %s\n" title;
                    documentChanges
-                   |> List.iter (fun {Protocol.edits} ->
-                          edits
-                          |> List.iter (fun {Protocol.range; newText} ->
-                                 let indent =
-                                   String.make range.start.character ' '
-                                 in
-                                 Printf.printf "%s\nnewText:\n%s<--here\n%s%s\n"
-                                   (Protocol.stringifyRange range)
-                                   indent indent newText)))
+                   |> List.iter (fun dc ->
+                          match dc with
+                          | Protocol.TextDocumentEdit tde ->
+                            Printf.printf "\nTextDocumentEdit: %s\n"
+                              tde.textDocument.uri;
+
+                            tde.edits
+                            |> List.iter (fun {Protocol.range; newText} ->
+                                   let indent =
+                                     String.make range.start.character ' '
+                                   in
+                                   Printf.printf
+                                     "%s\nnewText:\n%s<--here\n%s%s\n"
+                                     (Protocol.stringifyRange range)
+                                     indent indent newText)
+                          | CreateFile cf ->
+                            Printf.printf "\nCreateFile: %s\n" cf.uri))
           | "c-a" ->
             let hint = String.sub rest 3 (String.length rest - 3) in
             print_endline

--- a/analysis/src/Protocol.ml
+++ b/analysis/src/Protocol.ml
@@ -242,8 +242,8 @@ let stringifyTextDocumentEdit tde =
 let stringifyCreateFile cf =
   stringifyObject
     [
-      ("kind", Some "create");
-      ("uri", Some cf.uri);
+      ("kind", Some (wrapInQuotes "create"));
+      ("uri", Some (wrapInQuotes cf.uri));
       ( "options",
         match cf.options with
         | None -> None

--- a/analysis/tests/not_compiled/expected/DocTemplate.res.txt
+++ b/analysis/tests/not_compiled/expected/DocTemplate.res.txt
@@ -1,6 +1,8 @@
 Xform not_compiled/DocTemplate.res 3:3
 can't find module DocTemplate
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.res
 {"start": {"line": 3, "character": 0}, "end": {"line": 5, "character": 9}}
 newText:
 <--here
@@ -14,6 +16,8 @@ and e = C
 Xform not_compiled/DocTemplate.res 6:15
 can't find module DocTemplate
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.res
 {"start": {"line": 6, "character": 0}, "end": {"line": 6, "character": 33}}
 newText:
 <--here
@@ -26,6 +30,8 @@ type name = Name(string)
 Xform not_compiled/DocTemplate.res 8:4
 can't find module DocTemplate
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.res
 {"start": {"line": 8, "character": 0}, "end": {"line": 8, "character": 9}}
 newText:
 <--here
@@ -37,6 +43,8 @@ let a = 1
 Xform not_compiled/DocTemplate.res 10:4
 can't find module DocTemplate
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.res
 {"start": {"line": 10, "character": 0}, "end": {"line": 10, "character": 20}}
 newText:
 <--here
@@ -48,6 +56,8 @@ let inc = x => x + 1
 Xform not_compiled/DocTemplate.res 12:7
 can't find module DocTemplate
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.res
 {"start": {"line": 12, "character": 0}, "end": {"line": 16, "character": 1}}
 newText:
 <--here
@@ -59,10 +69,30 @@ module T = {
   let b = 1
   //  ^xfm
 }
+Hit: Extract module as file
+
+CreateFile: T.res
+
+TextDocumentEdit: T.res
+{"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
+newText:
+<--here
+//   ^xfm
+let b = 1
+//  ^xfm
+
+
+TextDocumentEdit: not_compiled/DocTemplate.res
+{"start": {"line": 12, "character": 0}, "end": {"line": 16, "character": 1}}
+newText:
+<--here
+
 
 Xform not_compiled/DocTemplate.res 14:6
 can't find module DocTemplate
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.res
 {"start": {"line": 14, "character": 2}, "end": {"line": 14, "character": 11}}
 newText:
   <--here
@@ -70,10 +100,30 @@ newText:
   
   */
   let b = 1
+Hit: Extract module as file
+
+CreateFile: T.res
+
+TextDocumentEdit: T.res
+{"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
+newText:
+<--here
+//   ^xfm
+let b = 1
+//  ^xfm
+
+
+TextDocumentEdit: not_compiled/DocTemplate.res
+{"start": {"line": 12, "character": 0}, "end": {"line": 16, "character": 1}}
+newText:
+<--here
+
 
 Xform not_compiled/DocTemplate.res 18:2
 can't find module DocTemplate
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.res
 {"start": {"line": 17, "character": 0}, "end": {"line": 18, "character": 46}}
 newText:
 <--here

--- a/analysis/tests/not_compiled/expected/DocTemplate.resi.txt
+++ b/analysis/tests/not_compiled/expected/DocTemplate.resi.txt
@@ -1,5 +1,7 @@
 Xform not_compiled/DocTemplate.resi 3:3
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.resi
 {"start": {"line": 3, "character": 0}, "end": {"line": 5, "character": 9}}
 newText:
 <--here
@@ -12,6 +14,8 @@ and e = C
 
 Xform not_compiled/DocTemplate.resi 6:15
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.resi
 {"start": {"line": 6, "character": 0}, "end": {"line": 6, "character": 33}}
 newText:
 <--here
@@ -23,6 +27,8 @@ type name = Name(string)
 
 Xform not_compiled/DocTemplate.resi 8:4
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.resi
 {"start": {"line": 8, "character": 0}, "end": {"line": 8, "character": 10}}
 newText:
 <--here
@@ -33,6 +39,8 @@ let a: int
 
 Xform not_compiled/DocTemplate.resi 10:4
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.resi
 {"start": {"line": 10, "character": 0}, "end": {"line": 10, "character": 19}}
 newText:
 <--here
@@ -43,6 +51,8 @@ let inc: int => int
 
 Xform not_compiled/DocTemplate.resi 12:7
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.resi
 {"start": {"line": 12, "character": 0}, "end": {"line": 16, "character": 1}}
 newText:
 <--here
@@ -57,6 +67,8 @@ module T: {
 
 Xform not_compiled/DocTemplate.resi 14:6
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.resi
 {"start": {"line": 14, "character": 2}, "end": {"line": 14, "character": 12}}
 newText:
   <--here
@@ -67,6 +79,8 @@ newText:
 
 Xform not_compiled/DocTemplate.resi 18:2
 Hit: Add Documentation template
+
+TextDocumentEdit: DocTemplate.resi
 {"start": {"line": 17, "character": 0}, "end": {"line": 18, "character": 46}}
 newText:
 <--here

--- a/analysis/tests/src/Xform.res
+++ b/analysis/tests/src/Xform.res
@@ -65,3 +65,9 @@ let bar = () => {
   }
   @res.partial Inner.foo(1)
 }
+
+module ExtractableModule = {
+  type t = int
+  let doStuff = a => a + 1
+  // ^xfm
+}

--- a/analysis/tests/src/Xform.res
+++ b/analysis/tests/src/Xform.res
@@ -67,7 +67,9 @@ let bar = () => {
 }
 
 module ExtractableModule = {
+  /** Doc comment. */
   type t = int
+  // A comment here
   let doStuff = a => a + 1
   // ^xfm
 }

--- a/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
+++ b/analysis/tests/src/expected/ExhaustiveSwitch.res.txt
@@ -119,6 +119,8 @@ Path getV
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 1 pervasives
 Hit: Exhaustive switch
+
+TextDocumentEdit: ExhaustiveSwitch.res
 {"start": {"line": 33, "character": 3}, "end": {"line": 33, "character": 10}}
 newText:
    <--here
@@ -138,6 +140,8 @@ Path vvv
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 1 pervasives
 Hit: Exhaustive switch
+
+TextDocumentEdit: ExhaustiveSwitch.res
 {"start": {"line": 36, "character": 3}, "end": {"line": 36, "character": 6}}
 newText:
    <--here

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -8,6 +8,8 @@ Path kind
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 1 pervasives
 Hit: Replace with switch
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 6, "character": 0}, "end": {"line": 11, "character": 1}}
 newText:
 <--here
@@ -20,6 +22,8 @@ switch kind {
 
 Xform src/Xform.res 13:15
 Hit: Replace with switch
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 13, "character": 0}, "end": {"line": 13, "character": 79}}
 newText:
 <--here
@@ -30,11 +34,15 @@ switch kind {
 
 Xform src/Xform.res 16:5
 Hit: Add type annotation
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 16, "character": 8}, "end": {"line": 16, "character": 8}}
 newText:
         <--here
         : string
 Hit: Add Documentation template
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 16, "character": 0}, "end": {"line": 16, "character": 18}}
 newText:
 <--here
@@ -45,6 +53,8 @@ let name = "hello"
 
 Xform src/Xform.res 19:5
 Hit: Add Documentation template
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 19, "character": 0}, "end": {"line": 19, "character": 23}}
 newText:
 <--here
@@ -55,6 +65,8 @@ let annotated: int = 34
 
 Xform src/Xform.res 26:10
 Hit: Add type annotation
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 26, "character": 10}, "end": {"line": 26, "character": 11}}
 newText:
           <--here
@@ -62,6 +74,8 @@ newText:
 
 Xform src/Xform.res 30:9
 Hit: Add braces to function
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 26, "character": 0}, "end": {"line": 32, "character": 3}}
 newText:
 <--here
@@ -76,6 +90,8 @@ let foo = x => {
 
 Xform src/Xform.res 34:21
 Hit: Add type annotation
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 34, "character": 24}, "end": {"line": 34, "character": 24}}
 newText:
                         <--here
@@ -83,6 +99,8 @@ newText:
 
 Xform src/Xform.res 38:5
 Hit: Add Documentation template
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 37, "character": 0}, "end": {"line": 38, "character": 40}}
 newText:
 <--here
@@ -94,6 +112,8 @@ let make = (~name) => React.string(name)
 
 Xform src/Xform.res 41:9
 Hit: Add type annotation
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 41, "character": 11}, "end": {"line": 41, "character": 11}}
 newText:
            <--here
@@ -110,6 +130,8 @@ Path name
 Package opens Pervasives.JsxModules.place holder
 Resolved opens 1 pervasives
 Hit: Add braces to function
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 48, "character": 0}, "end": {"line": 48, "character": 25}}
 newText:
 <--here
@@ -119,6 +141,8 @@ let noBraces = () => {
 
 Xform src/Xform.res 52:34
 Hit: Add braces to function
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 51, "character": 0}, "end": {"line": 54, "character": 1}}
 newText:
 <--here
@@ -131,6 +155,8 @@ let nested = () => {
 
 Xform src/Xform.res 62:6
 Hit: Add braces to function
+
+TextDocumentEdit: Xform.res
 {"start": {"line": 58, "character": 4}, "end": {"line": 62, "character": 7}}
 newText:
     <--here
@@ -140,4 +166,24 @@ newText:
       | #stuff => 4
       }
     }
+
+Xform src/Xform.res 70:5
+Hit: Extract module as file
+
+CreateFile: ExtractableModule.res
+
+TextDocumentEdit: ExtractableModule.res
+{"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
+newText:
+<--here
+type t = int
+let doStuff = a => a + 1
+// ^xfm
+
+
+TextDocumentEdit: src/Xform.res
+{"start": {"line": 68, "character": 0}, "end": {"line": 72, "character": 1}}
+newText:
+<--here
+
 

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -167,7 +167,7 @@ newText:
       }
     }
 
-Xform src/Xform.res 70:5
+Xform src/Xform.res 72:5
 Hit: Extract module as file
 
 CreateFile: ExtractableModule.res
@@ -176,13 +176,15 @@ TextDocumentEdit: ExtractableModule.res
 {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}}
 newText:
 <--here
+/** Doc comment. */
 type t = int
+// A comment here
 let doStuff = a => a + 1
 // ^xfm
 
 
 TextDocumentEdit: src/Xform.res
-{"start": {"line": 68, "character": 0}, "end": {"line": 72, "character": 1}}
+{"start": {"line": 68, "character": 0}, "end": {"line": 74, "character": 1}}
 newText:
 <--here
 


### PR DESCRIPTION
Adds a code action to extract a module to a separate file.

1. Put your cursor on/inside of a defined module.
2. Choose "Extract module as file"
3. The locally defined module is now removed from the current file, and extracted into a separate "<moduleName>.res" next to the current file.