### PR TITLE
Code action: Expand catch all variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Emit `%todo` instead of `failwith("TODO")` when we can (ReScript >= v11.1). https://github.com/rescript-lang/rescript-vscode/pull/981
 - Complete `%todo`. https://github.com/rescript-lang/rescript-vscode/pull/981
 - Add code action for extracting a locally defined module into its own file. https://github.com/rescript-lang/rescript-vscode/pull/983
+- Add code action for expanding catch-all patterns. https://github.com/rescript-lang/rescript-vscode/pull/987
 
 ## 1.50.0
 

--- a/analysis/src/CompletionFrontEnd.ml
+++ b/analysis/src/CompletionFrontEnd.ml
@@ -1005,7 +1005,9 @@ let completionWithParser1 ~currentFile ~debug ~offset ~path ~posCursor
     typedCompletionExpr expr;
     match expr.pexp_desc with
     | Pexp_match (expr, cases)
-      when cases <> [] && locHasCursor expr.pexp_loc = false ->
+      when cases <> []
+           && locHasCursor expr.pexp_loc = false
+           && Option.is_none findThisExprLoc ->
       if Debug.verbose () then
         print_endline "[completionFrontend] Checking each case";
       let ctxPath = exprToContextPath expr in

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -532,7 +532,7 @@ module ExpandCatchAllForVariants = struct
               "Some("
               ^ (missingConstructors
                 |> List.map (fun (name, hasArgs) ->
-                       name ^ if hasArgs then "" else "(_)")
+                       name ^ if hasArgs then "(_)" else "")
                 |> String.concat " | ")
               ^ ")"
             in

--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -430,7 +430,30 @@ module ExpandCatchAllForVariants = struct
           in
           codeActions := codeAction :: !codeActions
         else ()
-      (*| Some (Tpolyvariant {constructors}) -> ()*)
+      | Some (Tpolyvariant {constructors}) ->
+        let missingConstructors =
+          constructors
+          |> List.filter (fun (c : SharedTypes.polyVariantConstructor) ->
+                 currentConstructorNames |> List.mem c.name = false)
+        in
+        if List.length missingConstructors > 0 then
+          let newText =
+            missingConstructors
+            |> List.map (fun (c : SharedTypes.polyVariantConstructor) ->
+                   Res_printer.polyVarIdentToString c.name
+                   ^
+                   match c.args with
+                   | [] -> ""
+                   | _ -> "(_)")
+            |> String.concat " | "
+          in
+          let range = rangeOfLoc catchAllCase.pc_lhs.ppat_loc in
+          let codeAction =
+            CodeActions.make ~title:"Expand catch-all" ~kind:RefactorRewrite
+              ~uri:path ~newText ~range
+          in
+          codeActions := codeAction :: !codeActions
+        else ()
       | _ -> ())
 end
 

--- a/analysis/tests/src/Xform.res
+++ b/analysis/tests/src/Xform.res
@@ -1,8 +1,8 @@
-type kind = First | Second | Third
+type kind = First | Second | Third | Fourth(int)
 type r = {name: string, age: int}
 
-let ret = _ => assert false
-let kind = assert false
+let ret = _ => assert(false)
+let kind = assert(false)
 
 if kind == First {
   // ^xfm
@@ -63,7 +63,7 @@ let bar = () => {
       }
     //^xfm
   }
-  @res.partial Inner.foo(1)
+  Inner.foo(1, ...)
 }
 
 module ExtractableModule = {
@@ -72,4 +72,12 @@ module ExtractableModule = {
   // A comment here
   let doStuff = a => a + 1
   // ^xfm
+}
+
+let variant = First
+
+let _x = switch variant {
+| First => "first"
+| _ => "other"
+//  ^xfm
 }

--- a/analysis/tests/src/Xform.res
+++ b/analysis/tests/src/Xform.res
@@ -89,3 +89,20 @@ let _y = switch polyvariant {
 | _ => "other"
 //  ^xfm
 }
+
+let variantOpt = Some(variant)
+
+let _x = switch variantOpt {
+| Some(First) => "first"
+| _ => "other"
+//  ^xfm
+}
+
+let polyvariantOpt = Some(polyvariant)
+
+let _x = switch polyvariantOpt {
+| Some(#first) => "first"
+| None => "nothing"
+| _ => "other"
+//  ^xfm
+}

--- a/analysis/tests/src/Xform.res
+++ b/analysis/tests/src/Xform.res
@@ -81,3 +81,11 @@ let _x = switch variant {
 | _ => "other"
 //  ^xfm
 }
+
+let polyvariant: [#first | #second | #"illegal identifier" | #third(int)] = #first
+
+let _y = switch polyvariant {
+| #first => "first"
+| _ => "other"
+//  ^xfm
+}

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -189,3 +189,20 @@ newText:
 <--here
 
 
+Xform src/Xform.res 80:4
+posCursor:[78:16] posNoWhite:[78:14] Found expr:[78:9->82:1]
+Completable: Cpath Value[variant]
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[variant]
+Path variant
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+Hit: Expand catch-all
+
+TextDocumentEdit: Xform.res
+{"start": {"line": 80, "character": 2}, "end": {"line": 80, "character": 3}}
+newText:
+  <--here
+  Second | Third | Fourth(_)
+

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -238,7 +238,7 @@ TextDocumentEdit: Xform.res
 {"start": {"line": 96, "character": 2}, "end": {"line": 96, "character": 3}}
 newText:
   <--here
-  Some(Second(_) | Third(_) | Fourth) | None
+  Some(Second | Third | Fourth(_)) | None
 
 Xform src/Xform.res 105:4
 posCursor:[102:16] posNoWhite:[102:14] Found expr:[102:9->107:1]
@@ -255,5 +255,5 @@ TextDocumentEdit: Xform.res
 {"start": {"line": 105, "character": 2}, "end": {"line": 105, "character": 3}}
 newText:
   <--here
-  Some(#"illegal identifier"(_) | #second(_) | #third)
+  Some(#"illegal identifier" | #second | #third(_))
 

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -223,3 +223,37 @@ newText:
   <--here
   #second | #"illegal identifier" | #third(_)
 
+Xform src/Xform.res 96:4
+posCursor:[94:16] posNoWhite:[94:14] Found expr:[94:9->98:1]
+Completable: Cpath Value[variantOpt]
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[variantOpt]
+Path variantOpt
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+Hit: Expand catch-all
+
+TextDocumentEdit: Xform.res
+{"start": {"line": 96, "character": 2}, "end": {"line": 96, "character": 3}}
+newText:
+  <--here
+  Some(Second(_) | Third(_) | Fourth) | None
+
+Xform src/Xform.res 105:4
+posCursor:[102:16] posNoWhite:[102:14] Found expr:[102:9->107:1]
+Completable: Cpath Value[polyvariantOpt]
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[polyvariantOpt]
+Path polyvariantOpt
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+Hit: Expand catch-all
+
+TextDocumentEdit: Xform.res
+{"start": {"line": 105, "character": 2}, "end": {"line": 105, "character": 3}}
+newText:
+  <--here
+  Some(#"illegal identifier"(_) | #second(_) | #third)
+

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -206,3 +206,20 @@ newText:
   <--here
   Second | Third | Fourth(_)
 
+Xform src/Xform.res 88:4
+posCursor:[86:16] posNoWhite:[86:14] Found expr:[86:9->90:1]
+Completable: Cpath Value[polyvariant]
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+ContextPath Value[polyvariant]
+Path polyvariant
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 1 pervasives
+Hit: Expand catch-all
+
+TextDocumentEdit: Xform.res
+{"start": {"line": 88, "character": 2}, "end": {"line": 88, "character": 3}}
+newText:
+  <--here
+  #second | #"illegal identifier" | #third(_)
+


### PR DESCRIPTION
![code-action-expand-catch-all](https://github.com/rescript-lang/rescript-vscode/assets/1457626/4e58d3c6-22ed-4c6e-85cc-a163b1273eaa)

Code action for expanding catch-all patterns. Useful when you want to go from a catch all to get exhaustive matching when you add new variant members, for example.

Works on:
- Variant
- Polyvariant
- Option of variant
- Option of polyvariant

Those are the ones I thought made sense to support without this snowballing in complexity.