### PR TITLE
preserve URI format in `canonicalizeUri`

### DIFF
--- a/analysis/src/Files.ml
+++ b/analysis/src/Files.ml
@@ -107,4 +107,4 @@ let canonicalizeUri uri =
   if Cfg.isTestMode.contents then uri |> Uri.toString
   else
     let path = Uri.toPath uri in
-    path |> Unix.realpath
+    path |> Unix.realpath |> Uri.fromPath |> Uri.toString


### PR DESCRIPTION
This PR addresses a bug in the `canonicalizeUri` function that was causing issues with the `go to definition` feature in Neovim.
