### PR TITLE
Remove workaround for canonicalize function in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Fix highlighting of other languages being affected by rescript-vscode. https://github.com/rescript-lang/rescript-vscode/pull/973
 - Use canonicalized URIs/paths for jump to definition. https://github.com/rescript-lang/rescript-vscode/pull/982
 - Fix JSX prop special case in end of JSX element. https://github.com/rescript-lang/rescript-vscode/pull/984
+- preserve URI format in canonicalizeUri. https://github.com/rescript-lang/rescript-vscode/pull/990
+- Remove workaround for canonicalize function in tests https://github.com/rescript-lang/rescript-vscode/pull/992
 
 #### :nail_care: Polish
 

--- a/analysis/bin/main.ml
+++ b/analysis/bin/main.ml
@@ -191,9 +191,7 @@ let main () =
       (Json.escape (CreateInterface.command ~path ~cmiFile))
   | [_; "format"; path] ->
     Printf.printf "\"%s\"" (Json.escape (Commands.format ~path))
-  | [_; "test"; path] ->
-    Cfg.isTestMode := true;
-    Commands.test ~path
+  | [_; "test"; path] -> Commands.test ~path
   | args when List.mem "-h" args || List.mem "--help" args -> prerr_endline help
   | _ ->
     prerr_endline help;

--- a/analysis/src/Cfg.ml
+++ b/analysis/src/Cfg.ml
@@ -1,5 +1,3 @@
 let debugFollowCtxPath = ref false
 
 let isDocGenFromCompiler = ref false
-
-let isTestMode = ref false

--- a/analysis/src/Files.ml
+++ b/analysis/src/Files.ml
@@ -104,7 +104,5 @@ let classifySourceFile path =
   else Other
 
 let canonicalizeUri uri =
-  if Cfg.isTestMode.contents then uri |> Uri.toString
-  else
-    let path = Uri.toPath uri in
-    path |> Unix.realpath |> Uri.fromPath |> Uri.toString
+  let path = Uri.toPath uri in
+  path |> Unix.realpath |> Uri.fromPath |> Uri.toString


### PR DESCRIPTION
With the fix from #990 tests run now fine without the workaround