### PR TITLE
Clarify label for code action for extracting a local module

### DIFF
--- a/analysis/src/Xform.ml
+++ b/analysis/src/Xform.ml
@@ -173,7 +173,10 @@ module ModuleToFile = struct
         in
         changed :=
           Some
-            (CodeActions.makeWithDocumentChanges ~title:"Extract module as file"
+            (CodeActions.makeWithDocumentChanges
+               ~title:
+                 (Printf.sprintf "Extract local module \"%s\" to file \"%s\""
+                    moduleName (moduleName ^ ".res"))
                ~kind:RefactorRewrite
                ~documentChanges:
                  [

--- a/analysis/tests/not_compiled/expected/DocTemplate.res.txt
+++ b/analysis/tests/not_compiled/expected/DocTemplate.res.txt
@@ -69,7 +69,7 @@ module T = {
   let b = 1
   //  ^xfm
 }
-Hit: Extract module as file
+Hit: Extract local module "T" to file "T.res"
 
 CreateFile: T.res
 
@@ -100,7 +100,7 @@ newText:
   
   */
   let b = 1
-Hit: Extract module as file
+Hit: Extract local module "T" to file "T.res"
 
 CreateFile: T.res
 

--- a/analysis/tests/src/expected/Xform.res.txt
+++ b/analysis/tests/src/expected/Xform.res.txt
@@ -168,7 +168,7 @@ newText:
     }
 
 Xform src/Xform.res 72:5
-Hit: Extract module as file
+Hit: Extract local module "ExtractableModule" to file "ExtractableModule.res"
 
 CreateFile: ExtractableModule.res
 


### PR DESCRIPTION
I don't believe this needs a changelog, we haven't released the original functionality yet.