### PR TITLE
Fix expr record field completion in existing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix JSX prop special case in end of JSX element. https://github.com/rescript-lang/rescript-vscode/pull/984
 - preserve URI format in canonicalizeUri. https://github.com/rescript-lang/rescript-vscode/pull/990
 - Remove workaround for canonicalize function in tests https://github.com/rescript-lang/rescript-vscode/pull/992
+- Get completions for writing new field names in a record body expressions in more cases. https://github.com/rescript-lang/rescript-vscode/pull/997
 
 #### :nail_care: Polish
 

--- a/analysis/src/CompletionExpressions.ml
+++ b/analysis/src/CompletionExpressions.ml
@@ -84,6 +84,10 @@ let rec traverseExpr (exp : Parsetree.expression) ~exprPath ~pos
         (* An expression hole means for example `{someField: <com>}`. We want to complete for the type of `someField`.  *)
         someIfHasCursor
           ("", [Completable.NFollowRecordField {fieldName = fname}] @ exprPath)
+      | Pexp_ident {txt = Lident txt} when fname = txt ->
+        (* This is a heuristic for catching writing field names. ReScript has punning for record fields, but the AST doesn't,
+           so punning is represented as the record field name and identifier being the same: {someField}. *)
+        someIfHasCursor (txt, [Completable.NRecordBody {seenFields}] @ exprPath)
       | Pexp_ident {txt = Lident txt} ->
         (* A var means `{someField: s}` or similar. Complete for identifiers or values. *)
         someIfHasCursor (txt, exprPath)

--- a/analysis/src/CompletionExpressions.ml
+++ b/analysis/src/CompletionExpressions.ml
@@ -98,12 +98,21 @@ let rec traverseExpr (exp : Parsetree.expression) ~exprPath ~pos
                ([Completable.NFollowRecordField {fieldName = fname}] @ exprPath)
       )
     | None, None -> (
+      if Debug.verbose () then (
+        Printf.printf "[traverse_expr] No field with cursor and no expr hole.\n";
+
+        match firstCharBeforeCursorNoWhite with
+        | None -> ()
+        | Some c ->
+          Printf.printf "[traverse_expr] firstCharBeforeCursorNoWhite: %c.\n" c);
+
       (* Figure out if we're completing for a new field.
          If the cursor is inside of the record body, but no field has the cursor,
          and there's no pattern hole. Check the first char to the left of the cursor,
-         ignoring white space. If that's a comma, we assume you're completing for a new field. *)
+         ignoring white space. If that's a comma or {, we assume you're completing for a new field,
+         since you're either between 2 fields (comma to the left) or at the start of the record ({). *)
       match firstCharBeforeCursorNoWhite with
-      | Some ',' ->
+      | Some (',' | '{') ->
         someIfHasCursor ("", [Completable.NRecordBody {seenFields}] @ exprPath)
       | _ -> None))
   | Pexp_construct

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -379,8 +379,7 @@ let hook = (config: config) => {
 }
 
 let {name} = hook({
-  //
-  // ^com
+  //                  ^com
   // ope
   //    ^com
   includeName: true,

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -362,3 +362,25 @@ let someTyp: someTyp = {test: true}
 
 // switch someTyp. { | _ => () }
 //                ^com
+
+type config = {
+  includeName: bool,
+  operator?: [#"and" | #or],
+  showMore: bool,
+}
+
+type hookReturn = {name: string}
+
+let hook = (config: config) => {
+  ignore(config)
+  {
+    name: "tester",
+  }
+}
+
+let {name} = hook({
+  // ope
+  //    ^com
+  includeName: true,
+  showMore: true,
+})

--- a/analysis/tests/src/CompletionExpressions.res
+++ b/analysis/tests/src/CompletionExpressions.res
@@ -379,6 +379,8 @@ let hook = (config: config) => {
 }
 
 let {name} = hook({
+  //
+  // ^com
   // ope
   //    ^com
   includeName: true,

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1423,9 +1423,9 @@ Path someTyp
     "documentation": {"kind": "markdown", "value": "```rescript\ntest: bool\n```\n\n```rescript\ntype someTyp = {test: bool}\n```"}
   }]
 
-Complete src/CompletionExpressions.res 381:5
-posCursor:[381:5] posNoWhite:[381:-2] Found expr:[380:13->387:2]
-Pexp_apply ...[380:13->380:17] (...[380:18->387:1])
+Complete src/CompletionExpressions.res 380:22
+posCursor:[380:22] posNoWhite:[380:18] Found expr:[380:13->386:2]
+Pexp_apply ...[380:13->380:17] (...[380:18->386:1])
 Completable: Cexpression CArgument Value[hook]($0)->recordBody
 Raw opens: 1 CompletionSupport.place holder
 Package opens Pervasives.JsxModules.place holder
@@ -1441,9 +1441,9 @@ Path hook
     "documentation": {"kind": "markdown", "value": "```rescript\noperator?: [#\"and\" | #or]\n```\n\n```rescript\ntype config = {includeName: bool, operator: option<[#\"and\" | #or]>, showMore: bool}\n```"}
   }]
 
-Complete src/CompletionExpressions.res 383:8
-posCursor:[383:8] posNoWhite:[383:7] Found expr:[380:13->387:2]
-Pexp_apply ...[380:13->380:17] (...[380:18->387:1])
+Complete src/CompletionExpressions.res 382:8
+posCursor:[382:8] posNoWhite:[382:7] Found expr:[380:13->386:2]
+Pexp_apply ...[380:13->380:17] (...[380:18->386:1])
 Completable: Cexpression CArgument Value[hook]($0)=ope->recordBody
 Raw opens: 1 CompletionSupport.place holder
 Package opens Pervasives.JsxModules.place holder

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1423,9 +1423,27 @@ Path someTyp
     "documentation": {"kind": "markdown", "value": "```rescript\ntest: bool\n```\n\n```rescript\ntype someTyp = {test: bool}\n```"}
   }]
 
-Complete src/CompletionExpressions.res 381:8
-posCursor:[381:8] posNoWhite:[381:7] Found expr:[380:13->385:2]
-Pexp_apply ...[380:13->380:17] (...[380:18->385:1])
+Complete src/CompletionExpressions.res 381:5
+posCursor:[381:5] posNoWhite:[381:-2] Found expr:[380:13->387:2]
+Pexp_apply ...[380:13->380:17] (...[380:18->387:1])
+Completable: Cexpression CArgument Value[hook]($0)->recordBody
+Raw opens: 1 CompletionSupport.place holder
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 2 pervasives CompletionSupport.res
+ContextPath CArgument Value[hook]($0)
+ContextPath Value[hook]
+Path hook
+[{
+    "label": "operator",
+    "kind": 5,
+    "tags": [],
+    "detail": "[#\"and\" | #or]",
+    "documentation": {"kind": "markdown", "value": "```rescript\noperator?: [#\"and\" | #or]\n```\n\n```rescript\ntype config = {includeName: bool, operator: option<[#\"and\" | #or]>, showMore: bool}\n```"}
+  }]
+
+Complete src/CompletionExpressions.res 383:8
+posCursor:[383:8] posNoWhite:[383:7] Found expr:[380:13->387:2]
+Pexp_apply ...[380:13->380:17] (...[380:18->387:1])
 Completable: Cexpression CArgument Value[hook]($0)=ope->recordBody
 Raw opens: 1 CompletionSupport.place holder
 Package opens Pervasives.JsxModules.place holder

--- a/analysis/tests/src/expected/CompletionExpressions.res.txt
+++ b/analysis/tests/src/expected/CompletionExpressions.res.txt
@@ -1423,3 +1423,21 @@ Path someTyp
     "documentation": {"kind": "markdown", "value": "```rescript\ntest: bool\n```\n\n```rescript\ntype someTyp = {test: bool}\n```"}
   }]
 
+Complete src/CompletionExpressions.res 381:8
+posCursor:[381:8] posNoWhite:[381:7] Found expr:[380:13->385:2]
+Pexp_apply ...[380:13->380:17] (...[380:18->385:1])
+Completable: Cexpression CArgument Value[hook]($0)=ope->recordBody
+Raw opens: 1 CompletionSupport.place holder
+Package opens Pervasives.JsxModules.place holder
+Resolved opens 2 pervasives CompletionSupport.res
+ContextPath CArgument Value[hook]($0)
+ContextPath Value[hook]
+Path hook
+[{
+    "label": "operator",
+    "kind": 5,
+    "tags": [],
+    "detail": "[#\"and\" | #or]",
+    "documentation": {"kind": "markdown", "value": "```rescript\noperator?: [#\"and\" | #or]\n```\n\n```rescript\ntype config = {includeName: bool, operator: option<[#\"and\" | #or]>, showMore: bool}\n```"}
+  }]
+


### PR DESCRIPTION
This fixes 2 cases that were broken when completing record fields in expressions:
- Starting to write out a new field name was mistakenly picked up as writing an ident for a field value, because of punning.
- The heuristic for whether you're intending to write a new record field picked up between fields (commas) but not at the start of the record body (`{`).