### PR TITLE
perf(language-server): memoize possibly heavy IO utils

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^3.5.1",
+				"memize": "^2.1.0",
 				"vscode-jsonrpc": "^8.0.1",
 				"vscode-languageserver": "^8.0.1",
 				"vscode-languageserver-protocol": "^3.17.1"
@@ -144,6 +145,11 @@
 			"engines": {
 				"node": ">=0.12.0"
 			}
+		},
+		"node_modules/memize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
+			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -305,6 +311,11 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+		},
+		"memize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
+			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
 		},
 		"normalize-path": {
 			"version": "3.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -31,6 +31,7 @@
 	},
 	"dependencies": {
 		"chokidar": "^3.5.1",
+		"memize": "^2.1.0",
 		"vscode-jsonrpc": "^8.0.1",
 		"vscode-languageserver": "^8.0.1",
 		"vscode-languageserver-protocol": "^3.17.1"

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -74,17 +74,6 @@ let codeActionsFromDiagnostics: codeActions.filesCodeActions = {};
 // will be properly defined later depending on the mode (stdio/node-rpc)
 let send: (msg: p.Message) => void = (_) => {};
 
-let findRescriptBinary = (projectRootPath: p.DocumentUri | null) =>
-  config.extensionConfiguration.binaryPath == null
-    ? lookup.findFilePathFromProjectRoot(
-        projectRootPath,
-        path.join(c.nodeModulesBinDir, c.rescriptBinName)
-      )
-    : utils.findBinary(
-        config.extensionConfiguration.binaryPath,
-        c.rescriptBinName
-      );
-
 let createInterfaceRequest = new v.RequestType<
   p.TextDocumentIdentifier,
   p.TextDocumentIdentifier,
@@ -271,7 +260,7 @@ let openedFile = (fileUri: string, fileContent: string) => {
       // TODO: sometime stale .bsb.lock dangling. bsb -w knows .bsb.lock is
       // stale. Use that logic
       // TODO: close watcher when lang-server shuts down
-      if (findRescriptBinary(projectRootPath) != null) {
+      if (utils.findRescriptBinary(projectRootPath) != null) {
         let payload: clientSentBuildAction = {
           title: c.startBuildAction,
           projectRootPath: projectRootPath,
@@ -1295,7 +1284,7 @@ function onMessage(msg: p.Message) {
       // TODO: close watcher when lang-server shuts down. However, by Node's
       // default, these subprocesses are automatically killed when this
       // language-server process exits
-      let rescriptBinaryPath = findRescriptBinary(projectRootPath);
+      let rescriptBinaryPath = utils.findRescriptBinary(projectRootPath);
       if (rescriptBinaryPath != null) {
         let bsbProcess = utils.runBuildWatcherUsingValidBuildPath(
           rescriptBinaryPath,


### PR DESCRIPTION
This could fixes the LSP latency issue

I noticed that caused by mainly spawning multiple `rescript -v` processes on every single requests, but it could be extreamly slow if there is some process monitor (e.g. antivirus) on the environment.

Ideally, we would create a context object with the LSP server lifespan, but I added simple memoization to make fix easier.