### PR TITLE
Reduce language server latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :nail_care: Polish
+
+- Reduce latency of language server by caching a few project config related things. https://github.com/rescript-lang/rescript-vscode/pull/1003
+
 #### :bug: Bug Fix
 
 - Fix edge case in switch expr completion. https://github.com/rescript-lang/rescript-vscode/pull/1002

--- a/server/src/projectFiles.ts
+++ b/server/src/projectFiles.ts
@@ -10,6 +10,8 @@ interface projectFiles {
   filesWithDiagnostics: Set<string>;
   filesDiagnostics: filesDiagnostics;
   rescriptVersion: string | undefined;
+  bscBinaryLocation: string | null;
+  namespaceName: string | null;
 
   bsbWatcherByEditor: null | cp.ChildProcess;
 

--- a/server/src/projectFiles.ts
+++ b/server/src/projectFiles.ts
@@ -1,0 +1,25 @@
+import * as cp from "node:child_process";
+import * as p from "vscode-languageserver-protocol";
+
+export type filesDiagnostics = {
+  [key: string]: p.Diagnostic[];
+};
+
+interface projectFiles {
+  openFiles: Set<string>;
+  filesWithDiagnostics: Set<string>;
+  filesDiagnostics: filesDiagnostics;
+  rescriptVersion: string | undefined;
+
+  bsbWatcherByEditor: null | cp.ChildProcess;
+
+  // This keeps track of whether we've prompted the user to start a build
+  // automatically, if there's no build currently running for the project. We
+  // only want to prompt the user about this once, or it becomes
+  // annoying.
+  // The type `never` means that we won't show the prompt if the project is inside node_modules
+  hasPromptedToStartBuild: boolean | "never";
+}
+
+export let projectsFiles: Map<string, projectFiles> = // project root path
+  new Map();

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -22,12 +22,11 @@ import * as c from "./constants";
 import * as chokidar from "chokidar";
 import { assert } from "console";
 import { fileURLToPath } from "url";
-import * as cp from "node:child_process";
 import { WorkspaceEdit } from "vscode-languageserver";
-import { filesDiagnostics } from "./utils";
 import { onErrorReported } from "./errorReporter";
 import * as ic from "./incrementalCompilation";
 import config, { extensionConfiguration } from "./config";
+import { projectsFiles } from "./projectFiles";
 
 // This holds client capabilities specific to our extension, and not necessarily
 // related to the LS protocol. It's for enabling/disabling features that might
@@ -49,23 +48,7 @@ let serverSentRequestIdCounter = 0;
 // https://microsoft.github.io/language-server-protocol/specification#exit
 let shutdownRequestAlreadyReceived = false;
 let stupidFileContentCache: Map<string, string> = new Map();
-let projectsFiles: Map<
-  string, // project root path
-  {
-    openFiles: Set<string>;
-    filesWithDiagnostics: Set<string>;
-    filesDiagnostics: filesDiagnostics;
 
-    bsbWatcherByEditor: null | cp.ChildProcess;
-
-    // This keeps track of whether we've prompted the user to start a build
-    // automatically, if there's no build currently running for the project. We
-    // only want to prompt the user about this once, or it becomes
-    // annoying.
-    // The type `never` means that we won't show the prompt if the project is inside node_modules
-    hasPromptedToStartBuild: boolean | "never";
-  }
-> = new Map();
 // ^ caching AND states AND distributed system. Why does LSP has to be stupid like this
 
 // This keeps track of code actions extracted from diagnostics.
@@ -279,6 +262,7 @@ let openedFile = (fileUri: string, fileContent: string) => {
         openFiles: new Set(),
         filesWithDiagnostics: new Set(),
         filesDiagnostics: {},
+        rescriptVersion: utils.findReScriptVersion(projectRootPath),
         bsbWatcherByEditor: null,
         hasPromptedToStartBuild: /(\/|\\)node_modules(\/|\\)/.test(
           projectRootPath

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -258,12 +258,18 @@ let openedFile = (fileUri: string, fileContent: string) => {
       if (config.extensionConfiguration.incrementalTypechecking?.enabled) {
         ic.recreateIncrementalFileFolder(projectRootPath);
       }
+      const namespaceName =
+        utils.getNamespaceNameFromConfigFile(projectRootPath);
+
       projectRootState = {
         openFiles: new Set(),
         filesWithDiagnostics: new Set(),
         filesDiagnostics: {},
+        namespaceName:
+          namespaceName.kind === "success" ? namespaceName.result : null,
         rescriptVersion: utils.findReScriptVersion(projectRootPath),
         bsbWatcherByEditor: null,
+        bscBinaryLocation: utils.findBscExeBinary(projectRootPath),
         hasPromptedToStartBuild: /(\/|\\)node_modules(\/|\\)/.test(
           projectRootPath
         )
@@ -795,7 +801,9 @@ function format(msg: p.RequestMessage): Array<p.Message> {
     let code = getOpenedFileContent(params.textDocument.uri);
 
     let projectRootPath = utils.findProjectRootOfFile(filePath);
-    let bscExeBinaryPath = utils.findBscExeBinary(projectRootPath);
+    let project =
+      projectRootPath != null ? projectsFiles.get(projectRootPath) : null;
+    let bscExeBinaryPath = project?.bscBinaryLocation ?? null;
 
     let formattedResult = utils.formatCode(
       bscExeBinaryPath,

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -58,15 +58,19 @@ export let findProjectRootOfFile = (
       if (
         foundRootFromProjectFiles == null ||
         rootPath.length > foundRootFromProjectFiles.length
-      )
+      ) {
         foundRootFromProjectFiles = rootPath;
+      }
     }
   }
 
   if (foundRootFromProjectFiles != null) {
     return foundRootFromProjectFiles;
   } else {
-    return findProjectRootOfFileInDir(source);
+    const isDir = path.extname(source) === "";
+    return findProjectRootOfFileInDir(
+      isDir ? path.join(source, "dummy.res") : source
+    );
   }
 };
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -14,6 +14,7 @@ import * as c from "./constants";
 import * as lookup from "./lookup";
 import { reportError } from "./errorReporter";
 import config from "./config";
+import { filesDiagnostics, projectsFiles } from "./projectFiles";
 
 let tempFilePrefix = "rescript_format_file_" + process.pid + "_";
 let tempFileId = 0;
@@ -24,9 +25,7 @@ export let createFileInTempDir = (extension = "") => {
   return path.join(os.tmpdir(), tempFileName);
 };
 
-// TODO: races here?
-// TODO: this doesn't handle file:/// scheme
-export let findProjectRootOfFile = (
+let findProjectRootOfFileInDir = (
   source: p.DocumentUri
 ): null | p.DocumentUri => {
   let dir = path.dirname(source);
@@ -40,8 +39,34 @@ export let findProjectRootOfFile = (
       // reached top
       return null;
     } else {
-      return findProjectRootOfFile(dir);
+      return findProjectRootOfFileInDir(dir);
     }
+  }
+};
+
+// TODO: races here?
+// TODO: this doesn't handle file:/// scheme
+export let findProjectRootOfFile = (
+  source: p.DocumentUri
+): null | p.DocumentUri => {
+  // First look in project files
+  let foundRootFromProjectFiles: string | null = null;
+
+  for (const rootPath of projectsFiles.keys()) {
+    if (source.startsWith(rootPath)) {
+      // Prefer the longest path (most nested)
+      if (
+        foundRootFromProjectFiles == null ||
+        rootPath.length > foundRootFromProjectFiles.length
+      )
+        foundRootFromProjectFiles = rootPath;
+    }
+  }
+
+  if (foundRootFromProjectFiles != null) {
+    return foundRootFromProjectFiles;
+  } else {
+    return findProjectRootOfFileInDir(source);
   }
 };
 
@@ -138,7 +163,9 @@ export let formatCode = (
   }
 };
 
-let findReScriptVersion = (filePath: p.DocumentUri): string | undefined => {
+export let findReScriptVersion = (
+  filePath: p.DocumentUri
+): string | undefined => {
   let projectRoot = findProjectRootOfFile(filePath);
   if (projectRoot == null) {
     return undefined;
@@ -161,17 +188,20 @@ let findReScriptVersion = (filePath: p.DocumentUri): string | undefined => {
   }
 };
 
+let binaryPath: string | null = null;
+if (fs.existsSync(c.analysisDevPath)) {
+  binaryPath = c.analysisDevPath;
+} else if (fs.existsSync(c.analysisProdPath)) {
+  binaryPath = c.analysisProdPath;
+} else {
+}
+
 export let runAnalysisAfterSanityCheck = (
   filePath: p.DocumentUri,
   args: Array<any>,
   projectRequired = false
 ) => {
-  let binaryPath;
-  if (fs.existsSync(c.analysisDevPath)) {
-    binaryPath = c.analysisDevPath;
-  } else if (fs.existsSync(c.analysisProdPath)) {
-    binaryPath = c.analysisProdPath;
-  } else {
+  if (binaryPath == null) {
     return null;
   }
 
@@ -179,7 +209,10 @@ export let runAnalysisAfterSanityCheck = (
   if (projectRootPath == null && projectRequired) {
     return null;
   }
-  let rescriptVersion = findReScriptVersion(filePath);
+  let rescriptVersion =
+    projectsFiles.get(projectRootPath ?? "")?.rescriptVersion ??
+    findReScriptVersion(filePath);
+
   let options: childProcess.ExecFileSyncOptions = {
     cwd: projectRootPath || undefined,
     maxBuffer: Infinity,
@@ -449,9 +482,6 @@ let parseFileAndRange = (fileAndRange: string) => {
 };
 
 // main parsing logic
-export type filesDiagnostics = {
-  [key: string]: p.Diagnostic[];
-};
 type parsedCompilerLogResult = {
   done: boolean;
   result: filesDiagnostics;


### PR DESCRIPTION
This reduces latency in the language server by caching a few project config related things, so that we most often don't need to do any potentially expensive lookups before we call the analysis, or invoke incremental typechecking.

Known issues with this approach: We need to recompute the ReScript version if it changes. I however don't believe we're watching anything already that can help us figure out when to recompute it. Will need to think a bit about how to do that. It's not a big problem though, because changing the ReScript version in a project does not happen often. And a restart of the language server (or closing all project files) will fix it.