### PR TITLE
rescript-tools: do not override flags for static linking

### DIFF
--- a/tools/bin/dune
+++ b/tools/bin/dune
@@ -11,4 +11,4 @@
  (name main)
  (libraries tools)
  (flags
-  (-w "+6+26+27+32+33+39")))
+  (:standard -w "+6+26+27+32+33+39")))


### PR DESCRIPTION
Fixes #1006.