### PR TITLE
Revert "add system requirements section for linux to tools readme"

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,11 +1,5 @@
 # ReScript Tools
 
-## System Requirements
-
-### Linux
-
-The `musl` package needs to be installed to be able to run the binary.
-
 ## Install
 
 ```sh


### PR DESCRIPTION
Reverts rescript-lang/rescript-vscode#1007 because it's obsolete due to #1013 .
releated to #1006