### PR TITLE
Tools: Print module structure with signature to module path

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+### :bug: Bug Fix
+
+- Print module structure with signature to module path. https://github.com/rescript-lang/rescript-vscode/pull/1018
+
 ## 0.6.3
 
 #### :bug: Bug Fix

--- a/tools/src/tools.ml
+++ b/tools/src/tools.ml
@@ -469,6 +469,12 @@ let extractDocs ~entryPointFile ~debug =
                             (extractDocsForModule
                                ~modulePath:(interface.name :: modulePath)
                                interface))
+                     | Module {type_ = Constraint (Structure m, Ident _)} ->
+                       (* module M: T = {  }. Print M *)
+                       Some
+                         (Module
+                            (extractDocsForModule
+                               ~modulePath:(m.name :: modulePath) m))
                      | _ -> None);
           }
         in

--- a/tools/tests/src/expected/DocExtractionRes.res.json
+++ b/tools/tests/src/expected/DocExtractionRes.res.json
@@ -306,5 +306,41 @@
         "col": 3
       }
     }]
+  }, 
+  {
+    "id": "DocExtractionRes.M",
+    "name": "M",
+    "kind": "module",
+    "docstrings": ["implementation of Example module type"],
+    "source": {
+      "filepath": "src/DocExtractionRes.res",
+      "line": 1,
+      "col": 1
+    },
+    "items": [
+    {
+      "id": "DocExtractionRes.M.t",
+      "kind": "type",
+      "name": "t",
+      "signature": "type t = int",
+      "docstrings": ["main type"],
+      "source": {
+        "filepath": "src/DocExtractionRes.res",
+        "line": 123,
+        "col": 3
+      }
+    }, 
+    {
+      "id": "DocExtractionRes.M.f",
+      "kind": "value",
+      "name": "f",
+      "signature": "let f: int => int",
+      "docstrings": ["identity function"],
+      "source": {
+        "filepath": "src/DocExtractionRes.res",
+        "line": 128,
+        "col": 7
+      }
+    }]
   }]
 }


### PR DESCRIPTION
The example added in #925 don't print the module `M` structure

```rescript
module type Example = {
  /***
  this is an example module type 
  */

  /**
  main type of this module 
  */
  type t

  /**
  function from t to t
  */
  let f: t => t
}

module M: Example = {
  /***
  implementation of Example module type
  */

  /**
  main type 
  */
  type t = int

  /**
  identity function
  */
  let f = (x: int) => x
}
```

```
./node_modules/.bin/rescript-tools doc src/Demo.res
```

```json
{
  "name": "Demo",
  "docstrings": [],
  "source": {
    "filepath": "src/Demo.res",
    "line": 1,
    "col": 1
  },
  "items": [
  {
    "id": "Demo.Example",
    "name": "Example",
    "kind": "moduleType",
    "docstrings": [],
    "source": {
      "filepath": "src/Demo.res",
      "line": 1,
      "col": 13
    },
    "items": [
    {
      "id": "Demo.Example.t",
      "kind": "type",
      "name": "t",
      "signature": "type t",
      "docstrings": ["main type of this module"],
      "source": {
        "filepath": "src/Demo.res",
        "line": 9,
        "col": 3
      }
    }, 
    {
      "id": "Demo.Example.f",
      "kind": "value",
      "name": "f",
      "signature": "let f: t => t",
      "docstrings": ["function from t to t"],
      "source": {
        "filepath": "src/Demo.res",
        "line": 11,
        "col": 3
      }
    }]
  }]
}
```