### PR TITLE
Set GITHUB_OUTPUT instead of GITHUB_ENV in bump-version script

### DIFF
--- a/.github/workflows/bump-version.js
+++ b/.github/workflows/bump-version.js
@@ -49,6 +49,6 @@ if (!semver.valid(newVersion)) {
 }
 
 fs.appendFileSync(
-  process.env.GITHUB_ENV,
+  process.env.GITHUB_OUTPUT,
   `new_version=${newVersion}${os.EOL}`
 );


### PR DESCRIPTION
At least that is also how GitHub's own set output action does it, so it's worth a try.
https://github.com/actions/toolkit/blob/main/packages/core/src/core.ts#L193