### PR TITLE
Revert "CI: Reuse changelog entries for release notes"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,17 +300,13 @@ jobs:
         name: "Latest master"
         files: rescript-vscode-latest-master.vsix
 
-    - name: Generate release notes from changelog
-        if: startsWith(github.ref, 'refs/tags/')
-        run: sed -e "/^## ${{ steps.tag_name.outputs.tag }}/,/^## / ! d" CHANGELOG.md | head -n -2 > RELEASE.md
-
     - name: Publish release version to GitHub
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v2
       with:
         token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: false
-        body_path: RELEASE.md
+        generate_release_notes: true
         name: ${{ steps.tag_name.outputs.tag }}
         files: rescript-vscode-${{ steps.tag_name.outputs.tag }}.vsix
 


### PR DESCRIPTION
This reverts commit 873342bf5436d510ba60513abce5d1eefd5e8343.

Because it apparently broke PR builds without any error.