### PR TITLE
fix broken link on npmjs.org

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
   "engines": {
     "node": "*"
   },
-  "homepage": "https://github.com/rescript-lang/rescript-vscode/server/README.md",
+  "homepage": "https://github.com/rescript-lang/rescript-vscode/blob/master/server/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/rescript-lang/rescript-vscode",


### PR DESCRIPTION
Presently, this package links to a 404 - Not Found error. This commit fixes the link.