### PR TITLE
Enable incremental typechecking by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :rocket: New Feature
+
+- Enable incremental typechecking by default. https://github.com/rescript-lang/rescript-vscode/pull/1047
+
 ## 1.58.0
 
 #### :bug: Bug fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :rocket: New Feature
 
-- Enable incremental typechecking by default. https://github.com/rescript-lang/rescript-vscode/pull/1047
+- Enable incremental typechecking and project config cache by default. https://github.com/rescript-lang/rescript-vscode/pull/1047
 
 ## 1.58.0
 

--- a/package.json
+++ b/package.json
@@ -179,8 +179,8 @@
         },
         "rescript.settings.incrementalTypechecking.enable": {
           "type": "boolean",
-          "default": false,
-          "description": "(beta/experimental) Enable incremental type checking."
+          "default": true,
+          "description": "Enable incremental type checking."
         },
         "rescript.settings.incrementalTypechecking.acrossFiles": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
           "default": true,
           "description": "Enable signature help for variant constructor payloads."
         },
-        "rescript.settings.incrementalTypechecking.enabled": {
+        "rescript.settings.incrementalTypechecking.enable": {
           "type": "boolean",
           "default": false,
           "description": "(beta/experimental) Enable incremental type checking."

--- a/package.json
+++ b/package.json
@@ -192,10 +192,10 @@
           "default": false,
           "description": "(debug) Enable debug logging (ends up in the extension output)."
         },
-        "rescript.settings.cache.projectConfig.enabled": {
+        "rescript.settings.cache.projectConfig.enable": {
           "type": "boolean",
-          "default": false,
-          "description": "(beta/experimental) Enable project config caching. Can speed up latency dramatically."
+          "default": true,
+          "description": "Enable project config caching. Can speed up latency dramatically."
         },
         "rescript.settings.binaryPath": {
           "type": [

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -17,7 +17,7 @@ export interface extensionConfiguration {
     forConstructorPayloads?: boolean;
   };
   incrementalTypechecking?: {
-    enabled?: boolean;
+    enable?: boolean;
     acrossFiles?: boolean;
     debugLogging?: boolean;
   };
@@ -46,7 +46,7 @@ let config: { extensionConfiguration: extensionConfiguration } = {
       forConstructorPayloads: true,
     },
     incrementalTypechecking: {
-      enabled: false,
+      enable: true,
       acrossFiles: false,
       debugLogging: false,
     },

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -23,7 +23,7 @@ export interface extensionConfiguration {
   };
   cache?: {
     projectConfig?: {
-      enabled?: boolean;
+      enable?: boolean;
     };
   };
 }
@@ -52,7 +52,7 @@ let config: { extensionConfiguration: extensionConfiguration } = {
     },
     cache: {
       projectConfig: {
-        enabled: false,
+        enable: true,
       },
     },
   },

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -218,9 +218,7 @@ let compilerLogsWatcher = chokidar
   })
   .on("all", (_e, changedPath) => {
     if (changedPath.includes("build.ninja")) {
-      if (
-        config.extensionConfiguration.cache?.projectConfig?.enabled === true
-      ) {
+      if (config.extensionConfiguration.cache?.projectConfig?.enable === true) {
         let projectRoot = utils.findProjectRootOfFile(changedPath);
         if (projectRoot != null) {
           syncProjectConfigCache(projectRoot);
@@ -284,9 +282,7 @@ let openedFile = (fileUri: string, fileContent: string) => {
       compilerLogsWatcher.add(
         path.join(projectRootPath, c.compilerLogPartialPath)
       );
-      if (
-        config.extensionConfiguration.cache?.projectConfig?.enabled === true
-      ) {
+      if (config.extensionConfiguration.cache?.projectConfig?.enable === true) {
         compilerLogsWatcher.add(
           path.join(projectRootPath, c.buildNinjaPartialPath)
         );

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -174,7 +174,7 @@ let deleteProjectDiagnostics = (projectRootPath: string) => {
     });
 
     projectsFiles.delete(projectRootPath);
-    if (config.extensionConfiguration.incrementalTypechecking?.enabled) {
+    if (config.extensionConfiguration.incrementalTypechecking?.enable) {
       ic.removeIncrementalFileFolder(projectRootPath);
     }
   }
@@ -259,7 +259,7 @@ let openedFile = (fileUri: string, fileContent: string) => {
   if (projectRootPath != null) {
     let projectRootState = projectsFiles.get(projectRootPath);
     if (projectRootState == null) {
-      if (config.extensionConfiguration.incrementalTypechecking?.enabled) {
+      if (config.extensionConfiguration.incrementalTypechecking?.enable) {
         ic.recreateIncrementalFileFolder(projectRootPath);
       }
       const namespaceName =
@@ -354,7 +354,7 @@ let openedFile = (fileUri: string, fileContent: string) => {
 let closedFile = (fileUri: string) => {
   let filePath = fileURLToPath(fileUri);
 
-  if (config.extensionConfiguration.incrementalTypechecking?.enabled) {
+  if (config.extensionConfiguration.incrementalTypechecking?.enable) {
     ic.handleClosedFile(filePath);
   }
 
@@ -388,7 +388,7 @@ let updateOpenedFile = (fileUri: string, fileContent: string) => {
   let filePath = fileURLToPath(fileUri);
   assert(stupidFileContentCache.has(filePath));
   stupidFileContentCache.set(filePath, fileContent);
-  if (config.extensionConfiguration.incrementalTypechecking?.enabled) {
+  if (config.extensionConfiguration.incrementalTypechecking?.enable) {
     ic.handleUpdateOpenedFile(filePath, fileContent, send, () => {
       if (config.extensionConfiguration.codeLens) {
         sendCodeLensRefresh();
@@ -862,7 +862,7 @@ function format(msg: p.RequestMessage): Array<p.Message> {
 }
 
 let updateDiagnosticSyntax = (fileUri: string, fileContent: string) => {
-  if (config.extensionConfiguration.incrementalTypechecking?.enabled) {
+  if (config.extensionConfiguration.incrementalTypechecking?.enable) {
     // The incremental typechecking already sends syntax diagnostics.
     return;
   }

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -224,7 +224,7 @@ export let runAnalysisAfterSanityCheck = (
       ...process.env,
       RESCRIPT_VERSION: rescriptVersion,
       RESCRIPT_INCREMENTAL_TYPECHECKING:
-        config.extensionConfiguration.incrementalTypechecking?.enabled === true
+        config.extensionConfiguration.incrementalTypechecking?.enable === true
           ? "true"
           : undefined,
       RESCRIPT_PROJECT_CONFIG_CACHE:

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -228,7 +228,7 @@ export let runAnalysisAfterSanityCheck = (
           ? "true"
           : undefined,
       RESCRIPT_PROJECT_CONFIG_CACHE:
-        config.extensionConfiguration.cache?.projectConfig?.enabled === true
+        config.extensionConfiguration.cache?.projectConfig?.enable === true
           ? "true"
           : undefined,
     },


### PR DESCRIPTION
Enables incremental typechecking by default by changing the name of the prop (so old configs are invalidated) and setting a new default.

I'm sure there are more things we could do with incremental typechecking to make it a better experience, but at this point it's such a magnitudes better experience even with the small issues it might have. Enabling by default will make the experience better for everyone by default, and if issues surface we can fix them.

This also enables the `projectConfig` cache options, that dramatically reduce latency in certain scenarios.