### PR TITLE
Allow `esmodule` as a "module" option when compiling path

### DIFF
--- a/server/src/buildSchema.ts
+++ b/server/src/buildSchema.ts
@@ -15,6 +15,7 @@ export enum ModuleFormat {
   Commonjs = "commonjs",
   Es6 = "es6",
   Es6Global = "es6-global",
+  Esmodule = "esmodule",
 }
 
 export interface ModuleFormatObject {

--- a/server/src/lookup.ts
+++ b/server/src/lookup.ts
@@ -7,6 +7,7 @@ import * as c from "./constants";
 
 const getCompiledFolderName = (moduleFormat: ModuleFormat): string => {
   switch (moduleFormat) {
+    case "esmodule":
     case "es6":
       return "es6";
     case "es6-global":


### PR DESCRIPTION
Updates `ModuleFormat` to understand latest `rescript.json` `"module:" "esmodule"` config. This allows a user to use the `ReScript: Open the compiled JS file for this implementation file` option without it default looking for `/lib/js/src` instead of `/lib/es6/src`.