### PR TITLE
Remove builtin formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :nail_care: Polish
 
-- Remove the built-in formatter since it has been causing more harm than done good.
+- Remove the built-in formatter since it has been causing more harm than done good. https://github.com/rescript-lang/rescript-vscode/pull/1073
 
 #### :rocket: New Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :nail_care: Polish
+
+- Remove the built-in formatter since it has been causing more harm than done good.
+
 #### :rocket: New Feature
 
 - Add support for "dot completion everywhere". In addition to record fields, dots will now complete for object fields, and pipe completions applicable to the type the dot is on. You can also configure where the editor draws extra pipe completions from via the `@editor.completeFrom` attribute. https://github.com/rescript-lang/rescript-vscode/pull/1054

--- a/package.json
+++ b/package.json
@@ -136,12 +136,6 @@
       "type": "object",
       "title": "ReScript",
       "properties": {
-        "rescript.settings.allowBuiltInFormatter": {
-          "scope": "language-overridable",
-          "type": "boolean",
-          "default": false,
-          "description": "Whether you want to allow the extension to format your code using its built in formatter when it cannot find a ReScript compiler version in your current project to use for formatting."
-        },
         "rescript.settings.askToStartBuild": {
           "scope": "language-overridable",
           "type": "boolean",

--- a/server/config.md
+++ b/server/config.md
@@ -7,12 +7,6 @@ These configurations are sent to the server on [initialization](https://microsof
 ```typescript
 interface config {
   /**
-  * Format code using builtin formatter from server
-  * @default false
-  */
-  allowBuiltInFormatter: boolean;
-
-  /**
   * Whether you want the extension to prompt for autostarting a ReScript build if a project is opened with no build running
   * @default true
   */

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -3,7 +3,6 @@ import { Message } from "vscode-languageserver-protocol";
 export type send = (msg: Message) => void;
 
 export interface extensionConfiguration {
-  allowBuiltInFormatter?: boolean;
   askToStartBuild?: boolean;
   inlayHints?: {
     enable?: boolean;
@@ -32,7 +31,6 @@ export interface extensionConfiguration {
 // initialized, and the current config is received from the client.
 let config: { extensionConfiguration: extensionConfiguration } = {
   extensionConfiguration: {
-    allowBuiltInFormatter: false,
     askToStartBuild: true,
     inlayHints: {
       enable: false,

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -100,17 +100,12 @@ type execResult =
       error: string;
     };
 
-type formatCodeResult =
-  | execResult
-  | {
-      kind: "blocked-using-built-in-formatter";
-    };
+type formatCodeResult = execResult;
 
 export let formatCode = (
   bscPath: p.DocumentUri | null,
   filePath: string,
-  code: string,
-  allowBuiltInFormatter: boolean
+  code: string
 ): formatCodeResult => {
   let extension = path.extname(filePath);
   let formatTempFileFullPath = createFileInTempDir(extension);
@@ -132,29 +127,7 @@ export let formatCode = (
         result: result.toString(),
       };
     } else {
-      if (!allowBuiltInFormatter) {
-        return {
-          kind: "blocked-using-built-in-formatter",
-        };
-      }
-
-      let result = runAnalysisAfterSanityCheck(
-        formatTempFileFullPath,
-        ["format", formatTempFileFullPath],
-        false
-      );
-
-      // The formatter returning an empty string means it couldn't format the
-      // sources, probably because of errors. In that case, we bail from
-      // formatting by returning the unformatted content.
-      if (result === "") {
-        result = code;
-      }
-
-      return {
-        kind: "success",
-        result,
-      };
+      throw new Error("Could not find ReScript compiler for project.");
     }
   } catch (e) {
     return {


### PR DESCRIPTION
This removes the builtin formatter, since it has been doing more harm than good. 

One very concrete example is that code can be formatted differently if the ReScript compiler is installed vs not installed (different ReScript formatter version). But also things like https://github.com/rescript-lang/rescript-vscode/issues/1071.

Closes https://github.com/rescript-lang/rescript-vscode/issues/1071.