### PR TITLE
Use fs api to check if string is a directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :bug: Bug fix
+
+- Fix: bug where incremental analysis does not work when the project folder contains a dot. https://github.com/rescript-lang/rescript-vscode/pull/1080
+
 ## 1.62.0
 
 #### :nail_care: Polish

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -268,7 +268,7 @@ let openedFile = (fileUri: string, fileContent: string) => {
         filesDiagnostics: {},
         namespaceName:
           namespaceName.kind === "success" ? namespaceName.result : null,
-        rescriptVersion: utils.findReScriptVersion(projectRootPath),
+        rescriptVersion: utils.findReScriptVersionForProjectRoot(projectRootPath),
         bsbWatcherByEditor: null,
         bscBinaryLocation: utils.findBscExeBinary(projectRootPath),
         editorAnalysisLocation: utils.findEditorAnalysisBinary(projectRootPath),

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -67,8 +67,7 @@ export let findProjectRootOfFile = (
   if (foundRootFromProjectFiles != null) {
     return foundRootFromProjectFiles;
   } else {
-    const dirStat = fs.statSync(source);
-    const isDir = dirStat.isDirectory();
+    const isDir = path.extname(source) === "";
     return findProjectRootOfFileInDir(
       isDir && !allowDir ? path.join(source, "dummy.res") : source
     );
@@ -165,6 +164,24 @@ export let findReScriptVersion = (
     return undefined;
   }
 };
+
+export function findReScriptVersionForProjectRoot(projectRootPath:string) : string | undefined {
+  let rescriptBinary = lookup.findFilePathFromProjectRoot(
+    projectRootPath,
+    path.join(c.nodeModulesBinDir, c.rescriptBinName)
+  );
+
+  if (rescriptBinary == null) {
+    return undefined;
+  }
+
+  try {
+    let version = childProcess.execSync(`${rescriptBinary} -v`);
+    return version.toString().trim();
+  } catch (e) {
+    return undefined;
+  }
+}
 
 // This is the path for the _builtin_ legacy analysis, that works for versions 11 and below.
 let builtinBinaryPath: string | null = null;

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -67,7 +67,8 @@ export let findProjectRootOfFile = (
   if (foundRootFromProjectFiles != null) {
     return foundRootFromProjectFiles;
   } else {
-    const isDir = path.extname(source) === "";
+    const dirStat = fs.statSync(source);
+    const isDir = dirStat.isDirectory();
     return findProjectRootOfFileInDir(
       isDir && !allowDir ? path.join(source, "dummy.res") : source
     );


### PR DESCRIPTION
I found out why the incremental build wasn't working yesterday.
Turns out I have a dot in my project folder name, this was mistaken for a file.
That file is not part of the project, thus the rescript version could not be found for the root.