### PR TITLE
Fix local compilation when in a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Fix: bug where incremental analysis does not work when the project folder contains a dot. https://github.com/rescript-lang/rescript-vscode/pull/1080
 
+- Fix: bug where incremental compilation crashes when rewatch is being run in a specific package vs the root of the monorepo. https://github.com/rescript-lang/rescript-vscode/pull/1082
+
 ## 1.62.0
 
 #### :nail_care: Polish

--- a/server/src/incrementalCompilation.ts
+++ b/server/src/incrementalCompilation.ts
@@ -397,10 +397,9 @@ function triggerIncrementalCompilationOfFile(
     );
 
     let foundRewatchLockfileInProjectRoot = false;
-    try {
-      fs.statSync(projectRewatchLockfile);
+    if (fs.existsSync(projectRewatchLockfile)) {
       foundRewatchLockfileInProjectRoot = true;
-    } catch {}
+    }
 
     // if we find a rewatch.lock in the project root, it's a compilation of a local package
     // in the workspace.

--- a/server/src/incrementalCompilation.ts
+++ b/server/src/incrementalCompilation.ts
@@ -390,9 +390,24 @@ function triggerIncrementalCompilationOfFile(
       if (debug()) console.log("Did not find open project for " + filePath);
       return;
     }
-    const workspaceRootPath = projectRootPath
-      ? utils.findProjectRootOfFile(projectRootPath, true)
-      : null;
+
+    const projectRewatchLockfile = path.resolve(
+      projectRootPath,
+      c.rewatchLockPartialPath
+    );
+
+    let foundRewatchLockfileInProjectRoot = false;
+    try {
+      fs.statSync(projectRewatchLockfile);
+      foundRewatchLockfileInProjectRoot = true;
+    } catch {}
+
+    // if we find a rewatch.lock in the project root, it's a compilation of a local package
+    // in the workspace.
+    const workspaceRootPath =
+      projectRootPath && !foundRewatchLockfileInProjectRoot
+        ? utils.findProjectRootOfFile(projectRootPath, true)
+        : null;
 
     const bscBinaryLocation = project.bscBinaryLocation;
     if (bscBinaryLocation == null) {


### PR DESCRIPTION
If you compile a package inside a workspace, that package needs to be considered the root instead of the whole workspace when using rewatch.