### PR TITLE
Use `bsc.exe` to figure out rescript version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - Fix: bug where incremental compilation crashes when rewatch is being run in a specific package vs the root of the monorepo. https://github.com/rescript-lang/rescript-vscode/pull/1082
 
+- Fix: Absence of Node.js does not hinder LSP server. https://github.com/rescript-lang/rescript-vscode/pull/1083
+
 ## 1.62.0
 
 #### :nail_care: Polish

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -148,36 +148,31 @@ export let findReScriptVersion = (
     return undefined;
   }
 
-  let rescriptBinary = lookup.findFilePathFromProjectRoot(
-    projectRoot,
-    path.join(c.nodeModulesBinDir, c.rescriptBinName)
-  );
+  const bscExe = findBinary(findPlatformPath(projectRoot), c.bscExeName);
 
-  if (rescriptBinary == null) {
+  if (bscExe == null) {
     return undefined;
   }
 
   try {
-    let version = childProcess.execSync(`${rescriptBinary} -v`);
-    return version.toString().trim();
+    let version = childProcess.execSync(`${bscExe} -v`);
+    return version.toString().replace(/rescript/gi, "").trim();
   } catch (e) {
+    console.error("rescrip binary failed", e);
     return undefined;
   }
 };
 
 export function findReScriptVersionForProjectRoot(projectRootPath:string) : string | undefined {
-  let rescriptBinary = lookup.findFilePathFromProjectRoot(
-    projectRootPath,
-    path.join(c.nodeModulesBinDir, c.rescriptBinName)
-  );
+  const bscExe = findBinary(findPlatformPath(projectRootPath), c.bscExeName);
 
-  if (rescriptBinary == null) {
+  if (bscExe == null) {
     return undefined;
   }
 
   try {
-    let version = childProcess.execSync(`${rescriptBinary} -v`);
-    return version.toString().trim();
+    let version = childProcess.execSync(`${bscExe} -v`);
+    return version.toString().replace(/rescript/gi, "").trim();
   } catch (e) {
     return undefined;
   }


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/1079

I'm also in a little weird position where I use `nvm` on Mac, and somehow node is not always on my path anymore. This worked in the past, but is somehow broken for me, so I took a look in how I can get the LSP server working without depending on Node being present.

Turns out, the only thing I bump into is the initial rescript version call.
That will run `node_modules/.bin/rescript` which in the latest alpha has

```
#!/usr/bin/env node
...
```

For all the other stuff where we shell out to `bsc`, `rescript-editor-analysis`, we target the platform specific executable.

So, in this PR, I'm changing the version check to do the same. `bsc.exe -v` also produces the version we are after, prepended with `ReScript`.