### PR TITLE
Require whitespace before `as` in `to`/`downto` labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### :bug: Bug fix
 
+- Fix: incorrect highlighting of `as` inside labelled arguments like `toast` https://github.com/rescript-lang/rescript-vscode/pull/1085
+
 - Fix: bug where incremental analysis does not work when the project folder contains a dot. https://github.com/rescript-lang/rescript-vscode/pull/1080
 
 - Fix: bug where incremental compilation crashes when rewatch is being run in a specific package vs the root of the monorepo. https://github.com/rescript-lang/rescript-vscode/pull/1082

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -21,7 +21,7 @@
           }
         },
         {
-          "match": "(to|downto)\\s*(as)",
+          "match": "(to|downto)\\s+(as)",
           "captures": {
             "1": {
               "name": "variable"

--- a/grammars/rescript.tmLanguage.json
+++ b/grammars/rescript.tmLanguage.json
@@ -10,7 +10,7 @@
     "RE_TO_DOWNTO_AS_LABELS": {
       "patterns": [
         {
-          "match": "(to|downto)\\s*(=)",
+          "match": "~(to|downto)\\s*(=)",
           "captures": {
             "1": {
               "name": "variable"
@@ -21,7 +21,7 @@
           }
         },
         {
-          "match": "(to|downto)\\s+(as)",
+          "match": "~(to|downto)\\s+(as)",
           "captures": {
             "1": {
               "name": "variable"


### PR DESCRIPTION
The grammar rule `RE_TO_DOWNTO_AS_LABELS` contains two patterns for ensuring that labelled arguments with names `to` and `downto` are highlighted as variables and not keywords.

The second pattern, `(to|downto)\s*(as)`, is supposed to match cases like `(~to as to2) => ...`, but was also matching e.g. `~toast`.

I've fixed this by changing `\s*` to `\s+`.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/db853fc3-90a7-4ebe-a3ae-319522d6a960) | ![image](https://github.com/user-attachments/assets/18279901-adfa-4e84-899c-cf99de1ab0fe) |