### PR TITLE
Handle non-printable control characters when escaping JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 - Fix: Absence of Node.js does not hinder LSP server. https://github.com/rescript-lang/rescript-vscode/pull/1083
 
+- Fix: JSON from `rescript-code-editor-analysis` was not always escaped properly, which prevented code actions from being available in certain situations https://github.com/rescript-lang/rescript-vscode/pull/1089
+
 ## 1.62.0
 
 #### :nail_care: Polish

--- a/analysis/vendor/json/Json.ml
+++ b/analysis/vendor/json/Json.ml
@@ -141,7 +141,10 @@ let escape text =
       | '\b' -> Buffer.add_string buf "\\b"
       | '\r' -> Buffer.add_string buf "\\r"
       | '\t' -> Buffer.add_string buf "\\t"
-      | c -> Buffer.add_char buf c);
+      | c ->
+        let code = Char.code c in
+        if code < 0x20 then Printf.bprintf buf "\\u%04x" code
+        else Buffer.add_char buf c);
       loop (i + 1))
   in
   loop 0;


### PR DESCRIPTION
This is a backport of https://github.com/rescript-lang/rescript/pull/7435

More details about this fix can be found in that PR's description.