### PR TITLE
Don't filter out module-related type errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### :bug: Bug fix
 
+- Fix: bug where we incorrectly showed a warning notification about something going wrong with incremental type checking, when in fact the compiler was reporting module-related type errors https://github.com/rescript-lang/rescript-vscode/pull/1090
+
 - Fix: bug where we incorrectly showed a warning notification about something going wrong with incremental type checking, when in fact the compiler was reporting multiple definitions of the same type or module name https://github.com/rescript-lang/rescript-vscode/pull/1086
 
 - Fix: incorrect highlighting of `as` inside labelled arguments like `toast` https://github.com/rescript-lang/rescript-vscode/pull/1085

--- a/server/src/incrementalCompilation.ts
+++ b/server/src/incrementalCompilation.ts
@@ -683,7 +683,12 @@ async function compileContents(
                   ) ||
                   // The `Multiple definition of the <kind> name <name>` type error's
                   // message includes the filepath with LOC of the duplicate definition
-                  d.message.includes("Multiple definition of the")
+                  d.message.startsWith("Multiple definition of the") ||
+                  // The signature mismatch, with mismatch and ill typed applicative functor
+                  // type errors all include the filepath with LOC
+                  d.message.startsWith("Signature mismatch") ||
+                  d.message.startsWith("In this `with' constraint") ||
+                  d.message.startsWith("This `with' constraint on")
                 )
               ) {
                 hasIgnoredErrorMessages = true;


### PR DESCRIPTION
The [`Not_included`](https://github.com/rescript-lang/rescript/blob/a87e656c6408f05f2686043cf7015c64b4a52a4e/compiler/ml/typemod.ml#L1817-L1818), [`With_mismatch`](https://github.com/rescript-lang/rescript/blob/a87e656c6408f05f2686043cf7015c64b4a52a4e/compiler/ml/typemod.ml#L1831-L1835) and [`With_makes_applicative_functor_ill_typed`](https://github.com/rescript-lang/rescript/blob/a87e656c6408f05f2686043cf7015c64b4a52a4e/compiler/ml/typemod.ml#L1836-L1840) errors from [`typemod.ml`](https://github.com/rescript-lang/rescript/blob/a87e656c6408f05f2686043cf7015c64b4a52a4e/compiler/ml/typemod.ml) use `Includemod.report_error` to report errors, which includes filepaths in its output.

Like in https://github.com/rescript-lang/rescript-vscode/pull/1086, by checking for the presence of these errors we're ensuring that the user will not incorrectly see a 'something has gone wrong with incremental typechecking' warning notification.  