### PR TITLE
Find per-platform binaries for v12.0.0-alpha.13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## master
 
+#### :rocket: New Feature
+
+- Find `bsc.exe` and `rescript-code-editor-analysis.exe` from platform-specific packages used by ReScript `v12.0.0-alpha.13`+.https://github.com/rescript-lang/rescript-vscode/pull/1092
+
 #### :bug: Bug fix
 
 - Fix: bug where we incorrectly showed a warning notification about something going wrong with incremental type checking, when in fact the compiler was reporting module-related type errors https://github.com/rescript-lang/rescript-vscode/pull/1090

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -739,6 +739,16 @@ let findPlatformPath = (projectRootPath: p.DocumentUri | null) => {
 
   let platformPath = path.join(rescriptDir, c.platformDir);
 
+  // Binaries have been split into optional platform-specific dependencies
+  // since v12.0.0-alpha.13
+  if (!fs.existsSync(platformPath)) {
+    platformPath = path.join(
+      rescriptDir,
+      "..",
+      `@rescript/${process.platform}-${process.arch}/bin`
+    )
+  }
+
   // Workaround for darwinarm64 which has no folder yet in ReScript <= 9.1.4
   if (
     process.platform == "darwin" &&


### PR DESCRIPTION
https://github.com/rescript-lang/rescript/pull/7395 split binaries into optional platform-specific dependencies (e.g. `@rescript/linux-x64`).

I've updated `utils.findPlatformPath` (used by `utils.findBscExeBinary` and `utils.findEditorAnalysisBinary`) to look for these platform-specific dependencies if `node_modules/rescript/{platform}` doesn't exist.