### PR TITLE
Restore semver package in top-level package.json to fix bump-version.js workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.62.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.2"
+      },
       "devDependencies": {
         "@types/node": "^14.14.41",
         "@types/semver": "^7.7.0",
@@ -445,6 +448,18 @@
         "@esbuild/win32-x64": "0.20.1"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -670,6 +685,11 @@
         "@esbuild/win32-ia32": "0.20.1",
         "@esbuild/win32-x64": "0.20.1"
       }
+    },
+    "semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
     },
     "typescript": {
       "version": "5.8.3",

--- a/package.json
+++ b/package.json
@@ -259,5 +259,8 @@
     "@types/vscode": "1.68.0",
     "esbuild": "^0.20.1",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "semver": "^7.7.2"
   }
 }


### PR DESCRIPTION
In https://github.com/rescript-lang/rescript-vscode/pull/1093 I added `semver` to `server/package.json` but in doing so accidentally removed it from the top-level `package.json`.

This broke the `package` job in the GitHub actions workflow: https://github.com/rescript-lang/rescript-vscode/actions/runs/15137696086/job/42554026987