### PR TITLE
Show existing compiler warnings and errors on file open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 #### :bug: Bug fix
 
+- Fix: show existing compiler errors and warnings on file open. https://github.com/rescript-lang/rescript-vscode/pull/1103
+
 - Fix: bug where we incorrectly showed a warning notification about something going wrong with incremental type checking, when in fact the compiler was reporting module-related type errors https://github.com/rescript-lang/rescript-vscode/pull/1090
 
 - Fix: bug where we incorrectly showed a warning notification about something going wrong with incremental type checking, when in fact the compiler was reporting multiple definitions of the same type or module name https://github.com/rescript-lang/rescript-vscode/pull/1086

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1088,6 +1088,7 @@ async function onMessage(msg: p.Message) {
     } else if (msg.method === DidOpenTextDocumentNotification.method) {
       let params = msg.params as p.DidOpenTextDocumentParams;
       await openedFile(params.textDocument.uri, params.textDocument.text);
+      await sendUpdatedDiagnostics();
       await updateDiagnosticSyntax(params.textDocument.uri, params.textDocument.text);
     } else if (msg.method === DidChangeTextDocumentNotification.method) {
       let params = msg.params as p.DidChangeTextDocumentParams;


### PR DESCRIPTION
Currently, opening a ReScript file in VS Code does not show existing compiler warnings and errors until a file change triggers `onWorkspaceDidChangeWatchedFiles`, which in turn calls `sendUpdatedDiagnostics`.

This fix calls `sendUpdatedDiagnostics` on file open, ensuring that users will see existing warnings & errors immediately.