### PR TITLE
Update compiler args for beta 2

### DIFF
--- a/server/src/incrementalCompilation.ts
+++ b/server/src/incrementalCompilation.ts
@@ -331,10 +331,8 @@ function getBscArgs(
           }
         }
         
-        const rewatchArguments = semver.satisfies(project.rescriptVersion, ">12.0.0-alpha.14", { includePrerelease: true }) ? [
+        const rewatchArguments = semver.satisfies(project.rescriptVersion, ">=12.0.0-beta.2", { includePrerelease: true }) ? [
           "compiler-args",
-           "--rescript-version",
-          project.rescriptVersion,
           entry.file.sourceFilePath,
         ] : [
               "--rescript-version",
@@ -342,9 +340,11 @@ function getBscArgs(
               "--compiler-args",
               entry.file.sourceFilePath,
             ];
+        const bscExe = await utils.findBscExeBinary(entry.project.workspaceRootPath);
+        const env = bscExe != null ? { RESCRIPT_BSC_EXE: bscExe } : undefined;
         const compilerArgs = JSON.parse(
           cp
-            .execFileSync(rewatchPath, rewatchArguments)
+            .execFileSync(rewatchPath, rewatchArguments, { env })
             .toString()
             .trim()
         ) as RewatchCompilerArgs;


### PR DESCRIPTION
Deals with the change in https://github.com/rescript-lang/rescript/pull/7627/files#diff-1874d1cb9bb9f2d79e86c69636b1a43a67796fae03b818799cd31200cf1b5f84L185-L186

I don't think it is super useful to keep this working for alpha 14 or beta 1.
