### PR TITLE
Add status bar compilation status item

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,11 @@
           ],
           "default": null,
           "description": "Path to the directory where platform-specific ReScript binaries are. You can use it if you haven't or don't want to use the installed ReScript from node_modules in your project."
+        },
+        "rescript.settings.compileStatus.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show compile status in the status bar (compiling/errors/warnings/success)."
         }
       }
     },


### PR DESCRIPTION
This adds a status bar item that tracks compilation status - ok, compiling, errors, warnings. It's behind a setting, although I did default to make it turned on.

Let me know what you think! Some images:

<img width="213" height="91" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/aab741ff-280e-4178-ad8f-56593cb7c173" />
Compiling

<img width="354" height="142" alt="Chronicler V ReScript Ok" src="https://github.com/user-attachments/assets/b29a14c2-7d99-4975-abfe-80ea4f9aee8a" />
Ok

<img width="346" height="94" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/f1a48bf0-11d3-4721-823a-8ad5ed2a31a8" />
Warnings

<img width="399" height="125" alt="Chronicler" src="https://github.com/user-attachments/assets/8b16b7cd-9eed-46ed-ad83-0fff9b385a51" />
Failed