### PR TITLE
Detect quoted path from ninja on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug fix
 
 - Protect against trying to read non-existant `.compiler.log`. https://github.com/rescript-lang/rescript-vscode/pull/1116
+- Detected quoted paths in bsb arguments on Windows. https://github.com/rescript-lang/rescript-vscode/pull/1120
 
 #### :rocket: New Feature
 


### PR DESCRIPTION
I believe this fixes https://github.com/rescript-lang/rescript-vscode/issues/1056 on Windows.
