### PR TITLE
Add command to dump LSP server state

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -9,6 +9,7 @@ export { createInterface } from "./commands/create_interface";
 export { openCompiled } from "./commands/open_compiled";
 export { switchImplIntf } from "./commands/switch_impl_intf";
 export { dumpDebug, dumpDebugRetrigger } from "./commands/dump_debug";
+export { dumpServerState } from "./commands/dump_server_state";
 
 export const codeAnalysisWithReanalyze = (
   targetDir: string | null,

--- a/client/src/commands/dump_server_state.ts
+++ b/client/src/commands/dump_server_state.ts
@@ -1,0 +1,38 @@
+import {
+  ExtensionContext,
+  StatusBarItem,
+  Uri,
+  ViewColumn,
+  window,
+} from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import * as fs from "fs";
+import { createFileInTempDir } from "../utils";
+
+export async function dumpServerState(
+  client: LanguageClient,
+  _context?: ExtensionContext,
+  _statusBarItem?: StatusBarItem,
+) {
+  try {
+    const result = await client.sendRequest("rescript/dumpServerState");
+    const outputFile = createFileInTempDir("server_state", ".json");
+
+    // Pretty-print JSON with stable ordering where possible
+    const replacer = (_key: string, value: any) => {
+      if (value instanceof Map) return Object.fromEntries(value);
+      if (value instanceof Set) return Array.from(value);
+      return value;
+    };
+
+    const json = JSON.stringify(result, replacer, 2);
+    fs.writeFileSync(outputFile, json, { encoding: "utf-8" });
+
+    await window.showTextDocument(Uri.parse(outputFile), {
+      viewColumn: ViewColumn.Beside,
+      preview: false,
+    });
+  } catch (e) {
+    window.showErrorMessage(`Failed to dump server state: ${String(e)}`);
+  }
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -371,6 +371,10 @@ export function activate(context: ExtensionContext) {
     customCommands.dumpDebug(context, debugDumpStatusBarItem);
   });
 
+  commands.registerCommand("rescript-vscode.dump-server-state", () => {
+    customCommands.dumpServerState(client, context, debugDumpStatusBarItem);
+  });
+
   commands.registerCommand("rescript-vscode.showProblems", async () => {
     try {
       await commands.executeCommand("workbench.actions.view.problems");

--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
       {
         "command": "rescript-vscode.debug-dump-start",
         "title": "DEBUG ReScript: Dump analysis info"
+      },
+      {
+        "command": "rescript-vscode.dump-server-state",
+        "title": "DEBUG ReScript: Dump LSP Server State"
       }
     ],
     "keybindings": [


### PR DESCRIPTION
<img width="1411" height="836" alt="image" src="https://github.com/user-attachments/assets/cb20ff6f-73d0-4100-972a-c06d68f9bb7a" />

Adds another dump command to ask the LSP server to get all the project state.
This could be useful for troubleshooting future issue around runtime/bsc.exe detection.