### PR TITLE
Find other binaries via compiler-info.json

### DIFF
--- a/server/src/incrementalCompilation.ts
+++ b/server/src/incrementalCompilation.ts
@@ -14,6 +14,7 @@ import { fileCodeActions } from "./codeActions";
 import { projectsFiles } from "./projectFiles";
 import { getRewatchBscArgs, RewatchCompilerArgs } from "./bsc-args/rewatch";
 import { BsbCompilerArgs, getBsbBscArgs } from "./bsc-args/bsb";
+import { workspaceFolders } from "./server";
 
 export function debug() {
   return (
@@ -262,6 +263,12 @@ function triggerIncrementalCompilationOfFile(
     }
 
     const projectRewatchLockfiles = [
+      ...Array.from(workspaceFolders).map((w) =>
+        path.resolve(w, c.rewatchLockPartialPath),
+      ),
+      ...Array.from(workspaceFolders).map((w) =>
+        path.resolve(w, c.rescriptLockPartialPath),
+      ),
       path.resolve(projectRootPath, c.rewatchLockPartialPath),
       path.resolve(projectRootPath, c.rescriptLockPartialPath),
     ];

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -31,7 +31,7 @@ import { projectsFiles } from "./projectFiles";
 
 // Absolute paths to all the workspace folders
 // Configured during the initialize request
-const workspaceFolders = new Set<string>();
+export const workspaceFolders = new Set<string>();
 
 // This holds client capabilities specific to our extension, and not necessarily
 // related to the LS protocol. It's for enabling/disabling features that might

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -92,7 +92,7 @@ let findBinary = async (
     return path.join(config.extensionConfiguration.platformPath, binary);
   }
 
-  if (projectRootPath !== null && binary === "bsc.exe") {
+  if (projectRootPath !== null) {
     try {
       const compilerInfo = path.resolve(
         projectRootPath,
@@ -101,7 +101,13 @@ let findBinary = async (
       const contents = await fsAsync.readFile(compilerInfo, "utf8");
       const compileInfo = JSON.parse(contents);
       if (compileInfo && compileInfo.bsc_path) {
-        return compileInfo.bsc_path;
+        const bsc_path = compileInfo.bsc_path;
+        if (binary === "bsc.exe") {
+          return bsc_path;
+        } else {
+          const binary_path = path.join(path.dirname(bsc_path), binary);
+          return binary_path;
+        }
       }
     } catch {}
   }


### PR DESCRIPTION
See sample in https://github.com/rescript-lang/end-to-end/pull/1

Adds some fixes for #1106 

package `a` has a `compiler-info.json` of:

```json
{
  "version": "12.0.0-beta.13",
  "bsc_path": "/Users/nojaf/Projects/rescript-end-to-end/repos/pnpm/monorepo/node_modules/.pnpm/@rescript+darwin-arm64@12.0.0-beta.13/node_modules/@rescript/darwin-arm64/bin/bsc.exe",
  "bsc_hash": "1263ce9a1dad7e30b855a8221d361b1147c2c1541a3f2600d09e954deb989ae6",
  "rescript_config_hash": "68d9b6cfd83ac38869b2afe037b4fcbbbb9faa016302a2f26d45a1e7875e1479",
  "runtime_path": "/Users/nojaf/Projects/rescript-end-to-end/repos/pnpm/monorepo/node_modules/.pnpm/@rescript+runtime@12.0.0-beta.13/node_modules/@rescript/runtime",
  "generated_at": "1759387416473"
}
```