### PR TITLE
Expose runtime cache in dump command

### DIFF
--- a/server/src/find-runtime.ts
+++ b/server/src/find-runtime.ts
@@ -149,21 +149,14 @@ async function findRuntimePath(project: string): Promise<string[]> {
   return rescriptRuntimeDirs.map((runtime) => resolve(runtime));
 }
 
-function findRuntimeCached(): (project: string) => Promise<string[]> {
-  const cache = new Map<string, string[]>();
-  return async (project: string) => {
-    if (cache.has(project)) {
-      return cache.get(project)!;
-    }
-    const runtimes = await findRuntimePath(project);
-    cache.set(project, runtimes);
-    return runtimes;
-  };
-}
-
 /**
  * Find all installed @rescript/runtime directories in the given project path.
  * In a perfect world, there should be exactly one.
- * This function is cached per project path.
+ * Note: This function is not cached here. Caching is handled by the caller
+ * (see getRuntimePathFromWorkspaceRoot in utils.ts).
  */
-export const findRescriptRuntimesInProject = findRuntimeCached();
+export async function findRescriptRuntimesInProject(
+  project: string,
+): Promise<string[]> {
+  return await findRuntimePath(project);
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1510,6 +1510,7 @@ async function onMessage(msg: p.Message) {
           config: config.extensionConfiguration,
           projects,
           workspaceFolders: Array.from(workspaceFolders),
+          runtimePathCache: utils.getRuntimePathCacheSnapshot(),
         };
 
         let response: p.ResponseMessage = {

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -486,6 +486,14 @@ export async function getRuntimePathFromProjectRoot(
   return result;
 }
 
+/**
+ * Returns a snapshot of the runtime path cache as a plain object.
+ * Useful for debugging and state dumps.
+ */
+export function getRuntimePathCacheSnapshot(): Record<string, string | null> {
+  return Object.fromEntries(runtimePathCache);
+}
+
 export const getNamespaceNameFromConfigFile = (
   projDir: p.DocumentUri,
 ): execResult => {


### PR DESCRIPTION
I had something weird the other day, so I want to show what runtimes we found.
Maybe something was up there.