### PR TITLE
Fix extension crash triggered by incremental compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Take namespace into account for incremental cleanup. https://github.com/rescript-lang/rescript-vscode/pull/1164
 - Potential race condition in incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/1167
+- Fix extension crash triggered by incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/1169
 
 #### :nail_care: Polish
 

--- a/server/src/incrementalCompilation.ts
+++ b/server/src/incrementalCompilation.ts
@@ -712,7 +712,12 @@ async function compileContents(
         entry.project.bscBinaryLocation,
         callArgs,
         { cwd, signal },
-      );
+      ).catch((error) => {
+        if (error.stderr) {
+          return { stderr: error.stderr };
+        }
+        throw error;
+      });
 
       getLogger().log(
         `Recompiled ${entry.file.sourceFileName} in ${

--- a/server/src/incrementalCompilation.ts
+++ b/server/src/incrementalCompilation.ts
@@ -13,7 +13,6 @@ import { fileCodeActions } from "./codeActions";
 import { projectsFiles } from "./projectFiles";
 import { getRewatchBscArgs, RewatchCompilerArgs } from "./bsc-args/rewatch";
 import { BsbCompilerArgs, getBsbBscArgs } from "./bsc-args/bsb";
-import { getCurrentCompilerDiagnosticsForFile } from "./server";
 import { NormalizedPath } from "./utils";
 import { getLogger } from "./logger";
 


### PR DESCRIPTION
This PR fixes an extension crash triggered by syntax errors in the current file when incremental compilation is enabled.

## Background

https://github.com/rescript-lang/rescript-vscode/pull/1167 updated `compileContents` to use a promisify'd version of `child_process.execFile`. 

[As mentioned in the execFile docs, it returns a rejected promise on non-zero exit codes](https://nodejs.org/docs/latest/api/child_process.html#child_processexecfilefile-args-options-callback):

> If this method is invoked as its util.promisify()ed version, it returns a Promise for an Object with stdout and stderr properties. The returned ChildProcess instance is attached to the Promise as a child property. **In case of an error (including any error resulting in an exit code other than 0), a rejected promise is returned, with the same error object given in the callback, but with two additional properties stdout and stderr.**

However, `compileContents` assumes that `execFile` returns a resolved promise on non-zero exits: 

https://github.com/rescript-lang/rescript-vscode/blob/adf96f7bedeb2cb8e9f997b0945ad947790eca64/server/src/incrementalCompilation.ts#L711-L715

and so ends up rethrowing this error (line 766):

https://github.com/rescript-lang/rescript-vscode/blob/adf96f7bedeb2cb8e9f997b0945ad947790eca64/server/src/incrementalCompilation.ts#L757-L767

In turn, this makes the extension crash.

## Fix

I added a `.catch` to check if `error.stderr` is non-empty, and if so return that. Otherwise, we throw the error so that we don't accidentally swallow e.g. ENOENT errors.