### PR TITLE
fix: Code Analyzer binary lookup for ReScript v12+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### :bug: Bug fix
 
+- Fix Code Analyzer binary lookup for ReScript v12+ projects.
 - Take namespace into account for incremental cleanup. https://github.com/rescript-lang/rescript-vscode/pull/1164
 - Potential race condition in incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/1167
 - Fix extension crash triggered by incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/1169


### PR DESCRIPTION
For v12+, rescript-tools.exe is at @rescript/{platform}-{arch}/bin/. Try this path first, then fall back to legacy paths.