### PR TITLE
Fix/monorepo root compilerlog watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 #### :bug: Bug fix
 
-- Fix Code Analyzer binary lookup for ReScript v12+ projects.
+- Fix Code Analyzer cwd/binary lookup in monorepos (run from workspace root).
+- Fix monorepo build detection by only watching the workspace root `.compiler.log`.
+- Fix Start Build for ReScript v12+ projects by preferring `rescript.exe`.
 - Take namespace into account for incremental cleanup. https://github.com/rescript-lang/rescript-vscode/pull/1164
 - Potential race condition in incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/1167
 - Fix extension crash triggered by incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/1169

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -13,14 +13,12 @@ export { pasteAsRescriptJson } from "./commands/paste_as_rescript_json";
 export { pasteAsRescriptJsx } from "./commands/paste_as_rescript_jsx";
 
 export const codeAnalysisWithReanalyze = (
-  targetDir: string | null,
   diagnosticsCollection: DiagnosticCollection,
   diagnosticsResultCodeActions: DiagnosticsResultCodeActionsMap,
   outputChannel: OutputChannel,
   codeAnalysisRunningStatusBarItem: StatusBarItem,
 ) => {
   runCodeAnalysisWithReanalyze(
-    targetDir,
     diagnosticsCollection,
     diagnosticsResultCodeActions,
     outputChannel,

--- a/client/src/commands/code_analysis.ts
+++ b/client/src/commands/code_analysis.ts
@@ -213,9 +213,14 @@ export const runCodeAnalysisWithReanalyze = (
   let currentDocument = window.activeTextEditor.document;
   let cwd = targetDir ?? path.dirname(currentDocument.uri.fsPath);
 
+  // Resolve the project root from `cwd` (which is the workspace root when code analysis is started),
+  // rather than from the currently-open file (which may be in a subpackage).
   let projectRootPath: NormalizedPath | null = findProjectRootOfFileInDir(
-    currentDocument.uri.fsPath,
+    path.join(cwd, "bsconfig.json"),
   );
+  if (projectRootPath == null) {
+    projectRootPath = findProjectRootOfFileInDir(currentDocument.uri.fsPath);
+  }
 
   // Try v12+ path first: @rescript/{platform}-{arch}/bin/rescript-tools.exe
   // Then fall back to legacy paths via getBinaryPath

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -155,7 +155,6 @@ export function activate(context: ExtensionContext) {
             client.onNotification("rescript/compilationFinished", () => {
               if (inCodeAnalysisState.active === true) {
                 customCommands.codeAnalysisWithReanalyze(
-                  inCodeAnalysisState.activatedFromDirectory,
                   diagnosticsCollection,
                   diagnosticsResultCodeActions,
                   outputChannel,
@@ -308,8 +307,7 @@ export function activate(context: ExtensionContext) {
 
   let inCodeAnalysisState: {
     active: boolean;
-    activatedFromDirectory: string | null;
-  } = { active: false, activatedFromDirectory: null };
+  } = { active: false };
 
   // This code actions provider yields the code actions potentially extracted
   // from the code analysis to the editor.
@@ -442,19 +440,12 @@ export function activate(context: ExtensionContext) {
 
     inCodeAnalysisState.active = true;
 
-    // Run reanalyze from the workspace root (so monorepos consistently analyze the root project),
-    // instead of from whatever file happened to be active when analysis was started.
-    const wsFolder = workspace.getWorkspaceFolder(currentDocument.uri);
-    inCodeAnalysisState.activatedFromDirectory =
-      wsFolder?.uri.fsPath ?? path.dirname(currentDocument.uri.fsPath);
-
     codeAnalysisRunningStatusBarItem.command =
       "rescript-vscode.stop_code_analysis";
     codeAnalysisRunningStatusBarItem.show();
     statusBarItem.setToStopText(codeAnalysisRunningStatusBarItem);
 
     customCommands.codeAnalysisWithReanalyze(
-      inCodeAnalysisState.activatedFromDirectory,
       diagnosticsCollection,
       diagnosticsResultCodeActions,
       outputChannel,
@@ -464,7 +455,6 @@ export function activate(context: ExtensionContext) {
 
   commands.registerCommand("rescript-vscode.stop_code_analysis", () => {
     inCodeAnalysisState.active = false;
-    inCodeAnalysisState.activatedFromDirectory = null;
 
     diagnosticsCollection.clear();
     diagnosticsResultCodeActions.clear();

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -442,12 +442,11 @@ export function activate(context: ExtensionContext) {
 
     inCodeAnalysisState.active = true;
 
-    // Pointing reanalyze to the dir of the current file path is fine, because
-    // reanalyze will walk upwards looking for a bsconfig.json in order to find
-    // the correct project root.
-    inCodeAnalysisState.activatedFromDirectory = path.dirname(
-      currentDocument.uri.fsPath,
-    );
+    // Run reanalyze from the workspace root (so monorepos consistently analyze the root project),
+    // instead of from whatever file happened to be active when analysis was started.
+    const wsFolder = workspace.getWorkspaceFolder(currentDocument.uri);
+    inCodeAnalysisState.activatedFromDirectory =
+      wsFolder?.uri.fsPath ?? path.dirname(currentDocument.uri.fsPath);
 
     codeAnalysisRunningStatusBarItem.command =
       "rescript-vscode.stop_code_analysis";

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -2,6 +2,11 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { DocumentUri } from "vscode-languageclient";
+import { findBinary, type BinaryName } from "../../shared/src/findBinary";
+import {
+  findProjectRootOfFileInDir as findProjectRootOfFileInDirShared,
+  normalizePath as normalizePathShared,
+} from "../../shared/src/projectRoots";
 
 /*
  * Much of the code in here is duplicated from the server code.
@@ -27,7 +32,7 @@ export type NormalizedPath = string & { __brand: "NormalizedPath" };
  */
 export function normalizePath(filePath: string | null): NormalizedPath | null {
   // `path.normalize` ensures we can assume string is now NormalizedPath
-  return filePath != null ? (path.normalize(filePath) as NormalizedPath) : null;
+  return normalizePathShared(filePath) as NormalizedPath | null;
 }
 
 type binaryName = "rescript-editor-analysis.exe" | "rescript-tools.exe";
@@ -83,25 +88,7 @@ export const createFileInTempDir = (prefix = "", extension = "") => {
 export let findProjectRootOfFileInDir = (
   source: string,
 ): NormalizedPath | null => {
-  const normalizedSource = normalizePath(source);
-  if (normalizedSource == null) {
-    return null;
-  }
-  const dir = normalizePath(path.dirname(normalizedSource));
-  if (dir == null) {
-    return null;
-  }
-  if (
-    fs.existsSync(path.join(dir, "rescript.json")) ||
-    fs.existsSync(path.join(dir, "bsconfig.json"))
-  ) {
-    return dir;
-  } else {
-    if (dir === normalizedSource) {
-      // reached top
-      return null;
-    } else {
-      return findProjectRootOfFileInDir(dir);
-    }
-  }
+  return normalizePath(findProjectRootOfFileInDirShared(source));
 };
+
+export { findBinary, BinaryName };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -118,28 +118,16 @@ let findRescriptBinary = async (
 ): Promise<utils.NormalizedPath | null> => {
   if (
     config.extensionConfiguration.binaryPath != null &&
-    (fs.existsSync(
-      path.join(config.extensionConfiguration.binaryPath, "rescript.exe"),
-    ) ||
-      fs.existsSync(
-        path.join(config.extensionConfiguration.binaryPath, "rescript"),
-      ))
+    fs.existsSync(
+      path.join(config.extensionConfiguration.binaryPath, "rescript"),
+    )
   ) {
     return utils.normalizePath(
-      fs.existsSync(
-        path.join(config.extensionConfiguration.binaryPath, "rescript.exe"),
-      )
-        ? path.join(config.extensionConfiguration.binaryPath, "rescript.exe")
-        : path.join(config.extensionConfiguration.binaryPath, "rescript"),
+      path.join(config.extensionConfiguration.binaryPath, "rescript"),
     );
   }
 
-  // Prefer the native rescript.exe (v12+) for spawning `build -w`.
-  // Fall back to the legacy/JS wrapper `rescript` path if needed.
-  return (
-    (await utils.findRescriptExeBinary(projectRootPath)) ??
-    (await utils.findRescriptBinary(projectRootPath))
-  );
+  return utils.findRescriptBinary(projectRootPath);
 };
 
 let createInterfaceRequest = new v.RequestType<

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -7,9 +7,9 @@
     "sourceMap": true,
     "strict": true,
     "outDir": "out",
-    "rootDir": "src",
+    "rootDirs": ["src", "../shared/src"],
     "esModuleInterop": true
   },
-  "include": ["src"],
+  "include": ["src", "../shared/src"],
   "exclude": ["node_modules"]
 }

--- a/shared/src/findBinary.ts
+++ b/shared/src/findBinary.ts
@@ -1,0 +1,133 @@
+import * as fs from "fs";
+import * as fsAsync from "fs/promises";
+import * as path from "path";
+import * as semver from "semver";
+
+export type BinaryName =
+  | "bsc.exe"
+  | "rescript-editor-analysis.exe"
+  | "rescript-tools.exe"
+  | "rescript"
+  | "rewatch.exe"
+  | "rescript.exe";
+
+type FindBinaryOptions = {
+  projectRootPath: string | null;
+  binary: BinaryName;
+  platformPath?: string | null;
+};
+
+const compilerInfoPartialPath = path.join("lib", "bs", "compiler-info.json");
+const platformDir =
+  process.arch === "arm64" ? process.platform + process.arch : process.platform;
+
+const normalizePath = (filePath: string | null): string | null => {
+  return filePath != null ? path.normalize(filePath) : null;
+};
+
+const findFilePathFromProjectRoot = (
+  directory: string | null,
+  filePartialPath: string,
+): string | null => {
+  if (directory == null) {
+    return null;
+  }
+
+  const filePath = path.join(directory, filePartialPath);
+  if (fs.existsSync(filePath)) {
+    return normalizePath(filePath);
+  }
+
+  const parentDirStr = path.dirname(directory);
+  if (parentDirStr === directory) {
+    return null;
+  }
+
+  return findFilePathFromProjectRoot(
+    normalizePath(parentDirStr),
+    filePartialPath,
+  );
+};
+
+export const findBinary = async ({
+  projectRootPath,
+  binary,
+  platformPath,
+}: FindBinaryOptions): Promise<string | null> => {
+  if (platformPath != null) {
+    const result = path.join(platformPath, binary);
+    return normalizePath(result);
+  }
+
+  if (projectRootPath !== null) {
+    try {
+      const compilerInfo = path.resolve(
+        projectRootPath,
+        compilerInfoPartialPath,
+      );
+      const contents = await fsAsync.readFile(compilerInfo, "utf8");
+      const compileInfo = JSON.parse(contents);
+      if (compileInfo && compileInfo.bsc_path) {
+        const bscPath = compileInfo.bsc_path;
+        if (binary === "bsc.exe") {
+          return normalizePath(bscPath);
+        } else {
+          const binaryPath = path.join(path.dirname(bscPath), binary);
+          return normalizePath(binaryPath);
+        }
+      }
+    } catch {}
+  }
+
+  const rescriptDir = findFilePathFromProjectRoot(
+    projectRootPath,
+    path.join("node_modules", "rescript"),
+  );
+  if (rescriptDir == null) {
+    return null;
+  }
+
+  let rescriptVersion = null;
+  let rescriptJSWrapperPath = null;
+  try {
+    const rescriptPackageJSONPath = path.join(rescriptDir, "package.json");
+    const rescriptPackageJSON = JSON.parse(
+      await fsAsync.readFile(rescriptPackageJSONPath, "utf-8"),
+    );
+    rescriptVersion = rescriptPackageJSON.version;
+    rescriptJSWrapperPath = rescriptPackageJSON.bin.rescript;
+  } catch {
+    return null;
+  }
+
+  let binaryPath: string | null = null;
+  if (binary === "rescript") {
+    binaryPath = path.join(rescriptDir, rescriptJSWrapperPath);
+  } else if (semver.gte(rescriptVersion, "12.0.0-alpha.13")) {
+    const target = `${process.platform}-${process.arch}`;
+    const targetPackagePath = path.join(
+      fs.realpathSync(rescriptDir),
+      "..",
+      `@rescript/${target}/bin.js`,
+    );
+    const { binPaths } = await import(targetPackagePath);
+
+    if (binary === "bsc.exe") {
+      binaryPath = binPaths.bsc_exe;
+    } else if (binary === "rescript-editor-analysis.exe") {
+      binaryPath = binPaths.rescript_editor_analysis_exe;
+    } else if (binary === "rewatch.exe") {
+      binaryPath = binPaths.rewatch_exe;
+    } else if (binary === "rescript.exe") {
+      binaryPath = binPaths.rescript_exe;
+    }
+  } else {
+    binaryPath = path.join(rescriptDir, platformDir, binary);
+  }
+
+  if (binaryPath != null && fs.existsSync(binaryPath)) {
+    return normalizePath(binaryPath);
+  }
+
+  return null;
+};

--- a/shared/src/projectRoots.ts
+++ b/shared/src/projectRoots.ts
@@ -1,0 +1,40 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export const normalizePath = (filePath: string | null): string | null => {
+  return filePath != null ? path.normalize(filePath) : null;
+};
+
+export const findProjectRootOfFileInDir = (source: string): string | null => {
+  const normalizedSource = normalizePath(source);
+  if (normalizedSource == null) {
+    return null;
+  }
+
+  const dir = normalizePath(path.dirname(normalizedSource));
+  if (dir == null) {
+    return null;
+  }
+
+  if (
+    fs.existsSync(path.join(dir, "rescript.json")) ||
+    fs.existsSync(path.join(dir, "bsconfig.json"))
+  ) {
+    return dir;
+  }
+
+  if (dir === normalizedSource) {
+    return null;
+  }
+
+  return findProjectRootOfFileInDir(dir);
+};
+
+export const findProjectRootOfFile = (source: string): string | null => {
+  const normalizedSource = normalizePath(source);
+  if (normalizedSource == null) {
+    return null;
+  }
+
+  return findProjectRootOfFileInDir(normalizedSource);
+};

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -4,9 +4,9 @@
     "target": "es2019",
     "lib": ["ES2019"],
     "outDir": "out",
-    "rootDirs": ["src", "../shared/src"],
+    "rootDir": "src",
     "sourceMap": true
   },
-  "include": ["src", "../shared/src"],
+  "include": ["src"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "./server"
+    },
+    {
+      "path": "./shared"
     }
   ]
 }


### PR DESCRIPTION
Fix monorepo build detection: watch only root .compiler.log; run reanalyze from root

- move logic for finding binaries to be shared between server and client
- Server: restrict .compiler.log watching to ROOT/lib/bs/.compiler.log per workspace folder to avoid event floods from packages/** and node_modules/**.
- Client: Start Code Analysis now uses shared logic to locate the binary, and starts the analysis from outside "node_modules" where the binary is
