### PR TITLE
fix: wrap binary path resolution with fileURLToPath

### DIFF
--- a/shared/src/findBinary.ts
+++ b/shared/src/findBinary.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as fsAsync from "fs/promises";
 import * as path from "path";
 import * as semver from "semver";
+import * as url from "url";
 
 export type BinaryName =
   | "bsc.exe"
@@ -115,7 +116,7 @@ export const findBinary = async ({
       "..",
       `@rescript/${target}/bin.js`,
     );
-    const { binPaths } = await import(targetPackagePath);
+    const { binPaths } = await import(url.fileURLToPath(targetPackagePath));
 
     if (binary === "bsc.exe") {
       binaryPath = binPaths.bsc_exe;


### PR DESCRIPTION
The extension was failing to correctly resolve the path on Windows.
```
node:internal/modules/esm/load:188
    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(parsed, schemes);
          ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, node, and electron are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

Adding [fileURLToPath](https://nodejs.org/api/url.html#urlfileurltopathurl-options) uses node's built in way to normalize the file URL so it works across platforms.

> ...as well as ensuring a cross-platform valid absolute path string