### PR TITLE
fix: update globs to work on windows with WSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Take namespace into account for incremental cleanup. https://github.com/rescript-lang/rescript-vscode/pull/1164
 - Potential race condition in incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/1167
 - Fix extension crash triggered by incremental compilation. https://github.com/rescript-lang/rescript-vscode/pull/1169
+- Fix file watchers on Windows when using WSL. https://github.com/rescript-lang/rescript-vscode/pull/1178
 
 #### :nail_care: Polish
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1528,20 +1528,27 @@ async function onMessage(msg: p.Message) {
             // Only watch the root compiler log for each workspace folder.
             // In monorepos, `**/lib/bs/.compiler.log` matches every package and dependency,
             // causing a burst of events per save.
-            globPattern: path.join(projectRootPath, c.compilerLogPartialPath),
+            globPattern: {
+              baseUri: utils.pathToURI(projectRootPath),
+              pattern: c.compilerLogPartialPath,
+            },
             kind: p.WatchKind.Change | p.WatchKind.Create | p.WatchKind.Delete,
           },
           {
-            globPattern: path.join(
-              projectRootPath,
-              "**",
-              c.buildNinjaPartialPath,
-            ),
+            // Watch ninja output
+            globPattern: {
+              baseUri: utils.pathToURI(projectRootPath),
+              pattern: path.join("**", c.buildNinjaPartialPath),
+            },
             kind: p.WatchKind.Change | p.WatchKind.Create | p.WatchKind.Delete,
           },
           {
-            globPattern: `${path.join(projectRootPath, "**", c.compilerDirPartialPath)}/**/*.{cmt,cmi}`,
-            kind: p.WatchKind.Change | p.WatchKind.Delete,
+            // Watch build artifacts
+            globPattern: {
+              baseUri: utils.pathToURI(projectRootPath),
+              pattern: path.join(c.compilerDirPartialPath, "**/*.{cmi,cmt}"),
+            },
+            kind: p.WatchKind.Change | p.WatchKind.Create | p.WatchKind.Delete,
           },
         ],
       );


### PR DESCRIPTION
This was mostly trial and error to figure out, but eventually I got it working.

Paths for WSL resolve differently so the simple glob pattern wasn't working.

Instead of setting `globPattern` as a string I changed them to define `baseUri` and `pattern` as separate values.

This only works when you have `incrementalTypechecking` enabled, but I like that anyway. We might want to document that for windows users.

## Before
https://github.com/user-attachments/assets/db9c1be6-10ca-4549-a43b-0ca9fd687b84

## After
https://github.com/user-attachments/assets/c92b8e83-6c7c-4df5-a68f-009f0be7378a

